### PR TITLE
Implement filtering by activity for external devices - SL #4523

### DIFF
--- a/src/jarabe/journal/model.py
+++ b/src/jarabe/journal/model.py
@@ -39,6 +39,8 @@ from sugar3 import dispatch
 from sugar3 import mime
 from sugar3 import util
 
+import jarabe.model.bundleregistry
+
 
 DS_DBUS_SERVICE = 'org.laptop.sugar.DataStore'
 DS_DBUS_INTERFACE = 'org.laptop.sugar.DataStore'
@@ -263,6 +265,11 @@ class InplaceResultSet(BaseResultSet):
             self._date_end = None
 
         self._mime_types = query.get('mime_type', [])
+
+        if 'activity' in query:
+            registry = jarabe.model.bundleregistry.get_registry()
+            bundle = registry.get_bundle(query['activity'])
+            self._mime_types = bundle.get_mime_types()
 
         self._sort = query.get('order_by', ['+timestamp'])[0]
 

--- a/src/jarabe/model/shell.py
+++ b/src/jarabe/model/shell.py
@@ -30,7 +30,7 @@ from sugar3 import dispatch
 from sugar3.graphics.xocolor import XoColor
 from gi.repository import SugarExt
 
-from jarabe.model.bundleregistry import get_registry
+from jarabe.model import bundleregistry
 
 _SERVICE_NAME = 'org.laptop.Activity'
 _SERVICE_PATH = '/org/laptop/Activity'
@@ -533,7 +533,7 @@ class ShellModel(GObject.GObject):
 
             service_name = SugarExt.wm_get_bundle_id(xid)
             if service_name:
-                registry = get_registry()
+                registry = bundleregistry.get_registry()
                 activity_info = registry.get_bundle(service_name)
             else:
                 activity_info = None
@@ -629,7 +629,7 @@ class ShellModel(GObject.GObject):
         self._activities.remove(home_activity)
 
     def notify_launch(self, activity_id, service_name):
-        registry = get_registry()
+        registry = bundleregistry.get_registry()
         activity_info = registry.get_bundle(service_name)
         if not activity_info:
             raise ValueError("Activity service name '%s'"


### PR DESCRIPTION
The class InplaceResultSet ignored the 'activity' filter.
This patch need change a import in shell.py to avoid
a circular import error.

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
