### PR TITLE
Use customize xo icon

### DIFF
--- a/src/jarabe/desktop/transitionbox.py
+++ b/src/jarabe/desktop/transitionbox.py
@@ -19,6 +19,7 @@ from gi.repository import GObject
 from sugar3.graphics import style
 from sugar3.graphics import animator
 from sugar3.graphics.icon import Icon
+from sugar3.graphics.xoicon import get_name as XoIcon
 
 from jarabe.model.buddy import get_owner_instance
 from jarabe.desktop.viewcontainer import ViewContainer
@@ -50,7 +51,7 @@ class TransitionBox(ViewContainer):
 
         # Round off icon size to an even number to ensure that the icon
         owner = get_owner_instance()
-        self._owner_icon = Icon(icon_name='computer-xo',
+        self._owner_icon = Icon(icon_name=XoIcon(),
                                 xo_color=owner.get_color(),
                                 pixel_size=style.XLARGE_ICON_SIZE & ~1)
         ViewContainer.__init__(self, layout, self._owner_icon)

--- a/src/jarabe/frame/friendstray.py
+++ b/src/jarabe/frame/friendstray.py
@@ -17,6 +17,7 @@
 import logging
 
 from sugar3.graphics.tray import VTray, TrayIcon
+from sugar3.graphics.xoicon import get_name as XoIcon
 
 from jarabe.view.buddymenu import BuddyMenu
 from jarabe.frame.frameinvoker import FrameWidgetInvoker
@@ -27,7 +28,7 @@ from jarabe.model import neighborhood
 
 class FriendIcon(TrayIcon):
     def __init__(self, buddy):
-        TrayIcon.__init__(self, icon_name='computer-xo',
+        TrayIcon.__init__(self, icon_name=XoIcon(),
                           xo_color=buddy.get_color())
 
         self._buddy = buddy

--- a/src/jarabe/journal/expandedentry.py
+++ b/src/jarabe/journal/expandedentry.py
@@ -30,6 +30,7 @@ import json
 
 from sugar3.graphics import style
 from sugar3.graphics.xocolor import XoColor
+from sugar3.graphics.xoicon import get_name as XoIcon
 from sugar3.graphics.icon import CanvasIcon, get_icon_file_name
 from sugar3.graphics.icon import Icon, CellRendererIcon
 from sugar3.graphics.alert import Alert
@@ -57,7 +58,7 @@ class BuddyList(Gtk.Alignment):
         hbox = Gtk.HBox()
         for buddy in buddies:
             nick_, color = buddy
-            icon = CanvasIcon(icon_name='computer-xo',
+            icon = CanvasIcon(icon_name=XoIcon(),
                               xo_color=XoColor(color),
                               pixel_size=style.STANDARD_ICON_SIZE)
             icon.set_palette(BuddyPalette(buddy))
@@ -106,7 +107,7 @@ class CommentsView(Gtk.TreeView):
             for comment in self._comments:
                 self._add_row(comment.get(self.FROM, ''),
                               comment.get(self.MESSAGE, ''),
-                              comment.get(self.ICON, 'computer-xo'),
+                              comment.get(self.ICON, XoIcon()),
                               comment.get(self.ICON_COLOR, '#FFFFFF,#000000'))
 
     def _get_selected_row(self):

--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -28,6 +28,7 @@ from gi.repository import Pango
 from sugar3.graphics import style
 from sugar3.graphics.icon import Icon, CellRendererIcon
 from sugar3.graphics.xocolor import XoColor
+from sugar3.graphics.xoicon import get_name as XoIcon
 from sugar3 import util
 
 from jarabe.journal.listmodel import ListModel
@@ -711,7 +712,7 @@ class CellRendererBuddy(CellRendererIcon):
             self.props.icon_name = None
         else:
             nick_, xo_color = buddy
-            self.props.icon_name = 'computer-xo'
+            self.props.icon_name = XoIcon()
             self.props.xo_color = xo_color
 
     buddy = GObject.property(type=object, setter=set_buddy)

--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -30,6 +30,7 @@ from sugar3.graphics.palette import Palette
 from sugar3.graphics.menuitem import MenuItem
 from sugar3.graphics.icon import Icon
 from sugar3.graphics.xocolor import XoColor
+from sugar3.graphics.xoicon import get_name as XoIcon
 from sugar3.graphics.alert import Alert
 from sugar3 import mime
 
@@ -347,7 +348,7 @@ class FriendsMenu(Gtk.Menu):
             for friend in friends_model:
                 if friend.is_present():
                     menu_item = MenuItem(text_label=friend.get_nick(),
-                                         icon_name='computer-xo',
+                                         icon_name=XoIcon(),
                                          xo_color=friend.get_color())
                     menu_item.connect('activate', self.__item_activate_cb,
                                       friend)
@@ -409,7 +410,7 @@ class BuddyPalette(Palette):
         self._buddy = buddy
 
         nick, colors = buddy
-        buddy_icon = Icon(icon_name='computer-xo',
+        buddy_icon = Icon(icon_name=XoIcon(),
                           icon_size=style.STANDARD_ICON_SIZE,
                           xo_color=XoColor(colors))
 

--- a/src/jarabe/view/buddyicon.py
+++ b/src/jarabe/view/buddyicon.py
@@ -16,6 +16,7 @@
 
 from sugar3.graphics import style
 from sugar3.graphics.icon import CanvasIcon
+from sugar3.graphics.xoicon import get_name as XoIcon
 
 from jarabe.view.buddymenu import BuddyMenu
 from jarabe.util.normalize import normalize_string
@@ -26,7 +27,7 @@ _FILTERED_ALPHA = 0.33
 
 class BuddyIcon(CanvasIcon):
     def __init__(self, buddy, pixel_size=style.STANDARD_ICON_SIZE):
-        CanvasIcon.__init__(self, icon_name='computer-xo',
+        CanvasIcon.__init__(self, icon_name=XoIcon(),
                             pixel_size=pixel_size)
 
         self._filtered = False

--- a/src/jarabe/view/buddymenu.py
+++ b/src/jarabe/view/buddymenu.py
@@ -26,6 +26,7 @@ import dbus
 from sugar3.graphics.palette import Palette
 from sugar3.graphics.palettemenu import PaletteMenuItem
 from sugar3.graphics.icon import Icon
+from sugar3.graphics.xoicon import get_name as XoIcon
 
 from jarabe.model import shell
 from jarabe.model import friends
@@ -38,7 +39,7 @@ class BuddyMenu(Palette):
     def __init__(self, buddy):
         self._buddy = buddy
 
-        buddy_icon = Icon(icon_name='computer-xo',
+        buddy_icon = Icon(icon_name=XoIcon(),
                           xo_color=buddy.get_color(),
                           icon_size=Gtk.IconSize.LARGE_TOOLBAR)
         nick = buddy.get_nick()

--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -34,6 +34,7 @@ from gi.repository import GConf
 from sugar3.graphics import style
 from sugar3.graphics.icon import Icon
 from sugar3.graphics.xocolor import XoColor
+from sugar3.graphics.xoicon import get_name as XoIcon
 from sugar3.graphics.menuitem import MenuItem
 from sugar3.graphics.toolbutton import ToolButton
 from sugar3.graphics.radiotoolbutton import RadioToolButton
@@ -388,7 +389,7 @@ class Toolbar(Gtk.Toolbar):
 
         if sugar_toolkit_path is not None:
             sugar_button = RadioToolButton()
-            icon = Icon(icon_name='computer-xo',
+            icon = Icon(icon_name=XoIcon(),
                         icon_size=Gtk.IconSize.LARGE_TOOLBAR,
                         fill_color=style.COLOR_TRANSPARENT.get_svg(),
                         stroke_color=style.COLOR_WHITE.get_svg())


### PR DESCRIPTION
This patch uses xoicon.py to select the custom xoicon as per [1].

[1] http://wiki.sugarlabs.org/go/Features/Icon_Change

(submitted on behalf of Ignacio Rodriguez)
