### PR TITLE
Use customize xo icon

### DIFF
--- a/src/jarabe/Makefile.am
+++ b/src/jarabe/Makefile.am
@@ -14,7 +14,8 @@ sugar_PYTHON =		\
 	__init__.py	\
 	main.py \
 	apisocket.py \
-	testrunner.py
+	testrunner.py	\
+	xoicon.py
 
 nodist_sugar_PYTHON = config.py
 

--- a/src/jarabe/desktop/transitionbox.py
+++ b/src/jarabe/desktop/transitionbox.py
@@ -20,6 +20,7 @@ from sugar3.graphics import style
 from sugar3.graphics import animator
 from sugar3.graphics.icon import Icon
 
+from jarabe.xoicon import get_name as XoIcon
 from jarabe.model.buddy import get_owner_instance
 from jarabe.desktop.viewcontainer import ViewContainer
 from jarabe.desktop.favoriteslayout import SpreadLayout
@@ -50,7 +51,7 @@ class TransitionBox(ViewContainer):
 
         # Round off icon size to an even number to ensure that the icon
         owner = get_owner_instance()
-        self._owner_icon = Icon(icon_name='computer-xo',
+        self._owner_icon = Icon(icon_name=XoIcon(),
                                 xo_color=owner.get_color(),
                                 pixel_size=style.XLARGE_ICON_SIZE & ~1)
         ViewContainer.__init__(self, layout, self._owner_icon)

--- a/src/jarabe/frame/friendstray.py
+++ b/src/jarabe/frame/friendstray.py
@@ -18,6 +18,7 @@ import logging
 
 from sugar3.graphics.tray import VTray, TrayIcon
 
+from jarabe.xoicon import get_name as XoIcon
 from jarabe.view.buddymenu import BuddyMenu
 from jarabe.frame.frameinvoker import FrameWidgetInvoker
 from jarabe.model import shell
@@ -27,7 +28,7 @@ from jarabe.model import neighborhood
 
 class FriendIcon(TrayIcon):
     def __init__(self, buddy):
-        TrayIcon.__init__(self, icon_name='computer-xo',
+        TrayIcon.__init__(self, icon_name=XoIcon(),
                           xo_color=buddy.get_color())
 
         self._buddy = buddy

--- a/src/jarabe/journal/expandedentry.py
+++ b/src/jarabe/journal/expandedentry.py
@@ -35,6 +35,7 @@ from sugar3.graphics.icon import Icon, CellRendererIcon
 from sugar3.graphics.alert import Alert
 from sugar3.util import format_size
 
+from jarabe.xoicon import get_name as XoIcon
 from jarabe.journal.keepicon import KeepIcon
 from jarabe.journal.palettes import ObjectPalette, BuddyPalette
 from jarabe.journal import misc
@@ -57,7 +58,7 @@ class BuddyList(Gtk.Alignment):
         hbox = Gtk.HBox()
         for buddy in buddies:
             nick_, color = buddy
-            icon = CanvasIcon(icon_name='computer-xo',
+            icon = CanvasIcon(icon_name=XoIcon(),
                               xo_color=XoColor(color),
                               pixel_size=style.STANDARD_ICON_SIZE)
             icon.set_palette(BuddyPalette(buddy))
@@ -106,7 +107,7 @@ class CommentsView(Gtk.TreeView):
             for comment in self._comments:
                 self._add_row(comment.get(self.FROM, ''),
                               comment.get(self.MESSAGE, ''),
-                              comment.get(self.ICON, 'computer-xo'),
+                              comment.get(self.ICON, XoIcon()),
                               comment.get(self.ICON_COLOR, '#FFFFFF,#000000'))
 
     def _get_selected_row(self):

--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -30,6 +30,7 @@ from sugar3.graphics.icon import Icon, CellRendererIcon
 from sugar3.graphics.xocolor import XoColor
 from sugar3 import util
 
+from jarabe.xoicon import get_name as XoIcon
 from jarabe.journal.listmodel import ListModel
 from jarabe.journal.palettes import ObjectPalette, BuddyPalette
 from jarabe.journal import model
@@ -711,7 +712,7 @@ class CellRendererBuddy(CellRendererIcon):
             self.props.icon_name = None
         else:
             nick_, xo_color = buddy
-            self.props.icon_name = 'computer-xo'
+            self.props.icon_name = XoIcon()
             self.props.xo_color = xo_color
 
     buddy = GObject.property(type=object, setter=set_buddy)

--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -33,6 +33,7 @@ from sugar3.graphics.xocolor import XoColor
 from sugar3.graphics.alert import Alert
 from sugar3 import mime
 
+from jarabe.xoicon import get_name as XoIcon
 from jarabe.model import friends
 from jarabe.model import filetransfer
 from jarabe.model import mimeregistry
@@ -347,7 +348,7 @@ class FriendsMenu(Gtk.Menu):
             for friend in friends_model:
                 if friend.is_present():
                     menu_item = MenuItem(text_label=friend.get_nick(),
-                                         icon_name='computer-xo',
+                                         icon_name=XoIcon(),
                                          xo_color=friend.get_color())
                     menu_item.connect('activate', self.__item_activate_cb,
                                       friend)
@@ -409,7 +410,7 @@ class BuddyPalette(Palette):
         self._buddy = buddy
 
         nick, colors = buddy
-        buddy_icon = Icon(icon_name='computer-xo',
+        buddy_icon = Icon(icon_name=XoIcon(),
                           icon_size=style.STANDARD_ICON_SIZE,
                           xo_color=XoColor(colors))
 

--- a/src/jarabe/view/buddyicon.py
+++ b/src/jarabe/view/buddyicon.py
@@ -17,6 +17,7 @@
 from sugar3.graphics import style
 from sugar3.graphics.icon import CanvasIcon
 
+from jarabe.xoicon import get_name as XoIcon
 from jarabe.view.buddymenu import BuddyMenu
 from jarabe.util.normalize import normalize_string
 
@@ -26,7 +27,7 @@ _FILTERED_ALPHA = 0.33
 
 class BuddyIcon(CanvasIcon):
     def __init__(self, buddy, pixel_size=style.STANDARD_ICON_SIZE):
-        CanvasIcon.__init__(self, icon_name='computer-xo',
+        CanvasIcon.__init__(self, icon_name=XoIcon(),
                             pixel_size=pixel_size)
 
         self._filtered = False

--- a/src/jarabe/view/buddymenu.py
+++ b/src/jarabe/view/buddymenu.py
@@ -27,6 +27,7 @@ from sugar3.graphics.palette import Palette
 from sugar3.graphics.palettemenu import PaletteMenuItem
 from sugar3.graphics.icon import Icon
 
+from jarabe.xoicon import get_name as XoIcon
 from jarabe.model import shell
 from jarabe.model import friends
 from jarabe.model.session import get_session_manager
@@ -38,7 +39,7 @@ class BuddyMenu(Palette):
     def __init__(self, buddy):
         self._buddy = buddy
 
-        buddy_icon = Icon(icon_name='computer-xo',
+        buddy_icon = Icon(icon_name=XoIcon(),
                           xo_color=buddy.get_color(),
                           icon_size=Gtk.IconSize.LARGE_TOOLBAR)
         nick = buddy.get_nick()

--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -42,6 +42,7 @@ from sugar3.datastore import datastore
 from sugar3.env import get_user_activities_path
 from sugar3 import mime
 
+from jarabe.xoicon import get_name as XoIcon
 from jarabe.view import customizebundle
 
 _EXCLUDE_EXTENSIONS = ('.pyc', '.pyo', '.so', '.o', '.a', '.la', '.mo', '~',
@@ -388,7 +389,7 @@ class Toolbar(Gtk.Toolbar):
 
         if sugar_toolkit_path is not None:
             sugar_button = RadioToolButton()
-            icon = Icon(icon_name='computer-xo',
+            icon = Icon(icon_name=XoIcon(),
                         icon_size=Gtk.IconSize.LARGE_TOOLBAR,
                         fill_color=style.COLOR_TRANSPARENT.get_svg(),
                         stroke_color=style.COLOR_WHITE.get_svg())

--- a/src/jarabe/xoicon.py
+++ b/src/jarabe/xoicon.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2013 Ignacio Rodriguez
+# Copyright (C) 2013 Walter Bender
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+import os
+import logging
+
+from gi.repository import Gtk
+from gi.repository import GConf
+
+from jarabe.journal.model import get_documents_path
+
+
+def get_path():
+    path = get_documents_path()
+    if path is not None:
+        icon_theme = Gtk.IconTheme.get_default()
+        icon_search_path = icon_theme.get_search_path()
+        if path not in icon_search_path:
+            icon_theme.append_search_path(path)
+
+    return path
+
+
+def get_name():
+    client = GConf.Client.get_default()
+    icon_name = client.get_string('/desktop/sugar/user/icon')
+    if icon_name is not None:
+        get_path()
+        return icon_name
+    else:
+        return "computer-xo"
+
+
+def set_name(icon_name):
+    if icon_name is not None:
+        client = GConf.Client.get_default()
+        client.set_string('/desktop/sugar/user/icon', icon_name)


### PR DESCRIPTION
This patch uses xoicon.py to select the custom xoicon as per [1].

[1] http://wiki.sugarlabs.org/go/Features/Icon_Change

Changes since last pull request:
- Moved xoicon.py from the toolkit to jarabe.
- Moved icon path from ~/.sugar/icons to ~/Documents
