### PR TITLE
Support webservice repository

### DIFF
--- a/src/jarabe/webservice/accountsmanager.py
+++ b/src/jarabe/webservice/accountsmanager.py
@@ -16,58 +16,146 @@
 # Boston, MA 02111-1307, USA.
 
 import os
+import sys
 import logging
+from importlib import import_module
 
 from gi.repository import Gtk
 
 from jarabe import config
 from jarabe.webservice.account import Account
 
-_accounts = []
+_ACCOUNT_MODULE_NAME = 'account'
+
+_module_repository = {}
+
+
+def _append_sys_path():
+    for path in [os.path.join(os.path.expanduser('~'), '.sugar', 'extensions'),
+                 config.ext_path]:
+        if os.path.exists(path):
+            if path not in sys.path:
+                sys.path.append(path)
+
+
+def get_webservice_paths():
+    paths = []
+    for path in [os.path.join(os.path.expanduser('~'), '.sugar', 'extensions',
+                              'webservice'),
+                 os.path.join(config.ext_path, 'webservice')]:
+        if os.path.exists(path):
+            paths.append(path)
+    return paths
+
+
+def get_webaccount_paths():
+    paths = []
+    for path in [os.path.join(os.path.expanduser('~'), '.sugar', 'extensions',
+                              'cpsection', 'webaccount'),
+                 os.path.join(config.ext_path, 'cpsection', 'webaccount')]:
+        if os.path.exists(path):
+            paths.append(path)
+    return paths
 
 
 def get_all_accounts():
-    ''' Returns a list of all installed online account managers '''
-    global _accounts
-    if len(_accounts) > 0:
-        return _accounts
+    ''' Build repository of the online account managers and related
+    service modules and return a list of the accounts'''
+    global _module_repository
 
-    web_path = os.path.join(config.ext_path, 'webservice')
-    try:
-        web_path_dirs = os.listdir(web_path)
-    except OSError, e:
-        web_path_dirs = []
-        logging.warning('listdir: %s: %s' % (web_path, e))
+    _append_sys_path()
 
-    for d in web_path_dirs:
-        dir_path = os.path.join(web_path, d)
-        module = _load_module(dir_path)
-        if module is not None:
-            _accounts.append(module)
+    webservices = _get_webservices()
+    for dir_path in webservices:
+        service_name = _get_service_name(dir_path)
+        if service_name in _module_repository:
+            continue
+
+        service_module = _load_service_module(dir_path, service_name)
+        if service_module is None:
+            continue
+
+        _module_repository[service_name] = {'service': service_module}
+
+        account_module = None
+        module = _load_account_module(dir_path)
+ 
+        if module is not None and hasattr(module, 'get_account'):
+            try:
+                account_module = module.get_account()
+            except ImportError, e:
+                logging.error('Could not get_account() %s' % (e))
+            except AttributeError, e:
+                logging.error('Could not get_account() %s' % (e))
+
+        if account_module is not None:
+            _module_repository[service_name]['account'] = account_module
             _extend_icon_theme_search_path(dir_path)
+        else:
+            del _module_repository[service_name]
 
-    return _accounts
+    accounts = []
+    for key in _module_repository.keys():
+        accounts.append(_module_repository[key]['account'])
+
+    return accounts
 
 
-def _load_module(dir_path):
+def _get_service_name(service_path):
+    ''' service path is of the form:
+    /usr/share/sugar/extensions/webservice/my_service/my_service '''
+    parts = service_path.split('/')
+    return parts[parts.index('webservice') + 1]
+
+
+def _get_webservices():
+    webservices = []
+    for webservice_path in get_webservice_paths():
+        try:
+            for path in os.listdir(webservice_path):
+                service_path = os.path.join(webservice_path, path)
+                if os.path.isdir(service_path):
+                    webservices.append(service_path)
+        except OSError, e:
+            logging.warning('listdir: %s: %s' % (webservice_path, e))
+    return webservices
+
+
+def find_module(path, module):
+    mod = None
+    if 'extensions' not in path:
+        return ''
+
+    parts = []
+    while 'extensions' not in parts:
+        path, base = os.path.split(path)
+        parts.append(base)
+
+    parts.reverse()
+    path = '.'.join(parts[1:])
+
+    return '%s.%s' % (path, module)
+
+
+def _load_account_module(dir_path):
     module = None
     if os.path.isdir(dir_path):
-        for f in os.listdir(dir_path):
-            if f == 'account.py':
-                module_name = f[:-3]
-                logging.debug('OnlineAccountsManager loading %s' %
-                              (module_name))
-                module_path = 'webservice.%s.%s' % (os.path.basename(dir_path),
-                                                    module_name)
-                try:
-                    mod = __import__(module_path, globals(), locals(),
-                                     [module_name])
-                    if hasattr(mod, 'get_account'):
-                        module = mod.get_account()
+        if '%s.py' % _ACCOUNT_MODULE_NAME in os.listdir(dir_path):
+            module = import_module(
+                find_module(dir_path, _ACCOUNT_MODULE_NAME),
+                [_ACCOUNT_MODULE_NAME])
 
-                except Exception as e:
-                    logging.exception('Exception while loading %s: %s' %
-                                      (module_name, str(e)))
+    return module
+
+
+def _load_service_module(dir_path, service_name):
+    module = None
+    if os.path.isdir(dir_path):
+        if service_name in os.listdir(dir_path):
+            module = import_module(
+                find_module(os.path.join(dir_path, service_name),
+                            service_name),
+                [service_name])
 
     return module
 
@@ -75,19 +163,32 @@ def _load_module(dir_path):
 def _extend_icon_theme_search_path(dir_path):
     icon_theme = Gtk.IconTheme.get_default()
     icon_search_path = icon_theme.get_search_path()
-
     try:
         icon_path_dirs = os.listdir(dir_path)
     except OSError, e:
         icon_path_dirs = []
         logging.warning('listdir: %s: %s' % (dir_path, e))
 
-    for f in icon_path_dirs:
-        if f == 'icons':
-            icon_path = os.path.join(dir_path, f)
+    for file in icon_path_dirs:
+        if file == 'icons':
+            icon_path = os.path.join(dir_path, file)
             if os.path.isdir(icon_path) and \
                     icon_path not in icon_search_path:
                 icon_theme.append_search_path(icon_path)
+
+
+def get_account(service_name):
+    if service_name in _module_repository:
+        return _module_repository[service_name]['account']
+    else:
+        return None
+
+
+def get_service(service_name):
+    if service_name in _module_repository:
+        return _module_repository[service_name]['service']
+    else:
+        return None
 
 
 def get_configured_accounts():


### PR DESCRIPTION
This patch is a refactoring of the accounts manager for webservices to
enable services to be installed in both /usr/share/sugar/extensions
and ~/.sugar/extensions. The complexity is due to an issue with a
collision of namespace; hence a repository of loaded modules is
maintained to help disambiguate services installed in the two places.

(Now using pkgutil instead of local namespace and import_module helper method for forward compatibility to Python 3.0)
