### PR TITLE
Implement filter by mime types used by activities in the objectchooser

### DIFF
--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -88,9 +88,9 @@ class JournalActivityDBusService(dbus.service.Object):
         chooser.destroy()
         del chooser
 
-    @dbus.service.method(J_DBUS_INTERFACE, in_signature='is',
+    @dbus.service.method(J_DBUS_INTERFACE, in_signature='isb',
                          out_signature='s')
-    def ChooseObject(self, parent_xid, what_filter=''):
+    def ChooseObject(self, parent_xid, what_filter='', use_mime_types=False):
         chooser_id = uuid.uuid4().hex
         if parent_xid > 0:
             display = Gdk.Display.get_default()
@@ -98,7 +98,7 @@ class JournalActivityDBusService(dbus.service.Object):
                 display, parent_xid)
         else:
             parent = None
-        chooser = ObjectChooser(parent, what_filter)
+        chooser = ObjectChooser(parent, what_filter, use_mime_types)
         chooser.connect('response', self._chooser_response_cb, chooser_id)
         chooser.show()
 

--- a/src/jarabe/journal/objectchooser.py
+++ b/src/jarabe/journal/objectchooser.py
@@ -29,6 +29,7 @@ from jarabe.journal.listview import BaseListView
 from jarabe.journal.listmodel import ListModel
 from jarabe.journal.journaltoolbox import MainToolbox
 from jarabe.journal.volumestoolbar import VolumesToolbar
+from jarabe.model import bundleregistry
 
 
 class ObjectChooser(Gtk.Window):
@@ -39,7 +40,7 @@ class ObjectChooser(Gtk.Window):
         'response': (GObject.SignalFlags.RUN_FIRST, None, ([int])),
     }
 
-    def __init__(self, parent=None, what_filter=''):
+    def __init__(self, parent=None, what_filter='', use_mime_types=False):
         Gtk.Window.__init__(self)
         self.set_type_hint(Gdk.WindowTypeHint.DIALOG)
         self.set_decorated(False)
@@ -67,7 +68,7 @@ class ObjectChooser(Gtk.Window):
         self.add(vbox)
         vbox.show()
 
-        title_box = TitleBox()
+        title_box = TitleBox(what_filter, use_mime_types)
         title_box.connect('volume-changed', self.__volume_changed_cb)
         title_box.close_button.connect('clicked',
                                        self.__close_button_clicked_cb)
@@ -95,7 +96,7 @@ class ObjectChooser(Gtk.Window):
         height = Gdk.Screen.height() - style.GRID_CELL_SIZE * 2
         self.set_size_request(width, height)
 
-        self._toolbar.update_filters('/', what_filter)
+        self._toolbar.update_filters('/', what_filter, use_mime_types)
 
     def __realize_cb(self, chooser, parent):
         self.get_window().set_transient_for(parent)
@@ -142,11 +143,19 @@ class ObjectChooser(Gtk.Window):
 class TitleBox(VolumesToolbar):
     __gtype_name__ = 'TitleBox'
 
-    def __init__(self):
+    def __init__(self, what_filter='', use_mime_types=False):
         VolumesToolbar.__init__(self)
 
         label = Gtk.Label()
-        label.set_markup('<b>%s</b>' % _('Choose an object'))
+        title = _('Choose an object')
+        if use_mime_types:
+            registry = bundleregistry.get_registry()
+            bundle = registry.get_bundle(what_filter)
+            if bundle is not None:
+                title = _('Choose an object to open with %s activity') % \
+                    bundle.get_name()
+
+        label.set_markup('<b>%s</b>' % title)
         label.set_alignment(0, 0.5)
         self._add_widget(label, expand=True)
 


### PR DESCRIPTION
Add a optative parameter use_mime_types to ObjectChooser constructor.
If this parameter is True, the parameter what_filter should be a
bundle_id, and the filter will be set to the collection of mime types
the activity can manage, as configured in the activity.info file.
The title in the toolbar is changed, and the what_filter combo
is not visible when this parameter is used.

A example of use is:

chooser = ObjectChooser(parent=self, what_filter=self.get_bundle_id(),
                        use_mime_types=True)

This patch need a change in sugar-toolkit-gtk3 because a paramter was
added.

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
