### PR TITLE
Implement filter by mime types used by activities in the objectchooser

### DIFF
--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -88,9 +88,9 @@ class JournalActivityDBusService(dbus.service.Object):
         chooser.destroy()
         del chooser
 
-    @dbus.service.method(J_DBUS_INTERFACE, in_signature='is',
+    @dbus.service.method(J_DBUS_INTERFACE, in_signature='iss',
                          out_signature='s')
-    def ChooseObject(self, parent_xid, what_filter=''):
+    def ChooseObject(self, parent_xid, what_filter='', filter_type=None):
         chooser_id = uuid.uuid4().hex
         if parent_xid > 0:
             display = Gdk.Display.get_default()
@@ -98,7 +98,7 @@ class JournalActivityDBusService(dbus.service.Object):
                 display, parent_xid)
         else:
             parent = None
-        chooser = ObjectChooser(parent, what_filter)
+        chooser = ObjectChooser(parent, what_filter, filter_type)
         chooser.connect('response', self._chooser_response_cb, chooser_id)
         chooser.show()
 


### PR DESCRIPTION
Add a optative parameter filter_type to ObjectChooser constructor.
This parametrer have only a value possible right now,
but other can be added later. If is equals to 'mime_by_activity'
the parameter what_filter should be a bundle_id,
and the filter will be set to the collection of mime types
the activity can manage, as configured in the activity.info file.
The title in the toolbar is changed, and the what_filter combo
is not visible when this parameter is used.
If filter_type have a invalid value, a exeception is throw.

A example of use is:

from sugar3.graphics.objectchooser import ObjectChooser
from sugar3.graphics.objectchooser import FILTER_TYPE_MIME_BY_ACTIVITY

chooser = ObjectChooser(parent=self, what_filter=self.get_bundle_id(),
                        filter_type=FILTER_TYPE_MIME_BY_ACTIVITY)

This patch need a change in sugar-toolkit-gtk3 because a paramter was
added.

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
