### PR TITLE
Implement filter by mime types used by activities in the objectchooser

### DIFF
--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -88,9 +88,9 @@ class JournalActivityDBusService(dbus.service.Object):
         chooser.destroy()
         del chooser
 
-    @dbus.service.method(J_DBUS_INTERFACE, in_signature='is',
+    @dbus.service.method(J_DBUS_INTERFACE, in_signature='iss',
                          out_signature='s')
-    def ChooseObject(self, parent_xid, what_filter=''):
+    def ChooseObject(self, parent_xid, what_filter='', filter_type=None):
         chooser_id = uuid.uuid4().hex
         if parent_xid > 0:
             display = Gdk.Display.get_default()
@@ -98,7 +98,7 @@ class JournalActivityDBusService(dbus.service.Object):
                 display, parent_xid)
         else:
             parent = None
-        chooser = ObjectChooser(parent, what_filter)
+        chooser = ObjectChooser(parent, what_filter, filter_type)
         chooser.connect('response', self._chooser_response_cb, chooser_id)
         chooser.show()
 

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -40,6 +40,9 @@ from sugar3.graphics.xocolor import XoColor
 from sugar3.graphics.alert import Alert
 from sugar3.graphics import iconentry
 from sugar3 import mime
+from sugar3.graphics.objectchooser import FILTER_TYPE_MIME_BY_ACTIVITY
+from sugar3.graphics.objectchooser import FILTER_TYPE_GENERIC_MIME
+from sugar3.graphics.objectchooser import FILTER_TYPE_ACTIVITY
 
 from jarabe.model import bundleregistry
 from jarabe.journal import misc
@@ -77,6 +80,7 @@ class MainToolbox(ToolbarBox):
         ToolbarBox.__init__(self)
 
         self._mount_point = None
+        self._filter_type = None
 
         self.search_entry = iconentry.IconEntry()
         self.search_entry.set_icon_from_name(iconentry.ICON_ENTRY_PRIMARY,
@@ -177,12 +181,36 @@ class MainToolbox(ToolbarBox):
 
         if self._what_search_combo.props.value:
             value = self._what_search_combo.props.value
-            generic_type = mime.get_generic_type(value)
-            if generic_type:
-                mime_types = generic_type.mime_types
-                query['mime_type'] = mime_types
-            else:
-                query['activity'] = self._what_search_combo.props.value
+            filter_type = self._filter_type
+            if self._filter_type is None:
+                # for backward compatibility, try to guess the filter
+                generic_type = mime.get_generic_type(value)
+                if generic_type:
+                    filter_type = FILTER_TYPE_GENERIC_MIME
+                else:
+                    filter_type = FILTER_TYPE_ACTIVITY
+
+            if filter_type == FILTER_TYPE_GENERIC_MIME:
+                generic_type = mime.get_generic_type(value)
+                if generic_type:
+                    mime_types = generic_type.mime_types
+                    query['mime_type'] = mime_types
+                else:
+                    logging.error('filter_type="generic_mime", '
+                                  'but "%s" is not a generic mime' % value)
+
+            elif filter_type == FILTER_TYPE_ACTIVITY:
+                query['activity'] = value
+
+            elif self._filter_type == FILTER_TYPE_MIME_BY_ACTIVITY:
+                registry = bundleregistry.get_registry()
+                bundle = \
+                    registry.get_bundle(value)
+                if bundle is not None:
+                    query['mime_type'] = bundle.get_mime_types()
+                else:
+                    logging.error('Trying to filter using activity mimetype '
+                                  'but bundle id is wrong %s' % value)
 
         if self._when_search_combo.props.value:
             date_from, date_to = self._get_date_range()
@@ -227,6 +255,10 @@ class MainToolbox(ToolbarBox):
         self._update_if_needed()
 
     def _update_if_needed(self):
+        # check if the what_search combo should be visible
+        self._what_search_combo.set_visible(
+            self._filter_type != FILTER_TYPE_MIME_BY_ACTIVITY)
+
         new_query = self._build_query()
         if self._query != new_query:
             self._query = new_query
@@ -270,9 +302,14 @@ class MainToolbox(ToolbarBox):
         else:
             self._what_search_combo.set_active(what_filter_index)
 
-    def update_filters(self, mount_point, what_filter):
+    def update_filters(self, mount_point, what_filter, filter_type=None):
         self._mount_point = mount_point
+        self._filter_type = filter_type
         self.set_what_filter(what_filter)
+        self._update_if_needed()
+
+    def set_filter_type(self, filter_type):
+        self._filter_type = filter_type
         self._update_if_needed()
 
     def refresh_filters(self):


### PR DESCRIPTION
Add a optative parameter filter_type to ObjectChooser constructor.
Constants to define the different filter types are defined in
sugar-toolkit-gtk3 patch. If is equals to 'mime_by_activity'
the parameter what_filter should be a bundle_id,
and the filter will be set to the collection of mime types
the activity can manage, as configured in the activity.info file.
The title in the toolbar is changed, and the what_filter combo
is not visible when this parameter is used.
If filter_type have a invalid value, a exeception is throw,
if is not used, the filter type is guessed based on the what_filter
parameter as before.

A example of use is:

from sugar3.graphics.objectchooser import ObjectChooser
from sugar3.graphics.objectchooser import FILTER_TYPE_MIME_BY_ACTIVITY

chooser = ObjectChooser(parent=self, what_filter=self.get_bundle_id(),
                        filter_type=FILTER_TYPE_MIME_BY_ACTIVITY)

This patch need a change in sugar-toolkit-gtk3 because a parameter was
added.

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
