### PR TITLE
Implement filter by mime types used by activities in the objectchooser

### DIFF
--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -91,6 +91,9 @@ class JournalActivityDBusService(dbus.service.Object):
     @dbus.service.method(J_DBUS_INTERFACE, in_signature='is',
                          out_signature='s')
     def ChooseObject(self, parent_xid, what_filter=''):
+        """
+        This method is keep for backwards compatibility
+        """
         chooser_id = uuid.uuid4().hex
         if parent_xid > 0:
             display = Gdk.Display.get_default()
@@ -99,6 +102,23 @@ class JournalActivityDBusService(dbus.service.Object):
         else:
             parent = None
         chooser = ObjectChooser(parent, what_filter)
+        chooser.connect('response', self._chooser_response_cb, chooser_id)
+        chooser.show()
+
+        return chooser_id
+
+    @dbus.service.method(J_DBUS_INTERFACE, in_signature='iss',
+                         out_signature='s')
+    def ChooseObjectWithFilter(self, parent_xid, what_filter='',
+                               filter_type=None):
+        chooser_id = uuid.uuid4().hex
+        if parent_xid > 0:
+            display = Gdk.Display.get_default()
+            parent = GdkX11.X11Window.foreign_new_for_display(
+                display, parent_xid)
+        else:
+            parent = None
+        chooser = ObjectChooser(parent, what_filter, filter_type)
         chooser.connect('response', self._chooser_response_cb, chooser_id)
         chooser.show()
 


### PR DESCRIPTION
Add a optative parameter filter_type to ObjectChooser constructor.
Constants to define the different filter types are defined in
sugar-toolkit-gtk3 patch. If is equals to 'mime_by_activity'
the parameter what_filter should be a bundle_id,
and the filter will be set to the collection of mime types
the activity can manage, as configured in the activity.info file.

The title in the toolbar is changed, and the what_filter combo
is not visible when this parameter is used.

If filter_type have a invalid value, a exeception is throw,
if is not used, the filter type is guessed based on the what_filter
parameter as before.

A example of use is:

from sugar3.graphics.objectchooser import ObjectChooser
from sugar3.graphics.objectchooser import FILTER_TYPE_MIME_BY_ACTIVITY

chooser = ObjectChooser(parent=self, what_filter=self.get_bundle_id(),
                        filter_type=FILTER_TYPE_MIME_BY_ACTIVITY)

This patch need a change in sugar-toolkit-gtk3 because a parameter was
added.

As this change modify the dbus signature, a dbus method was added,
keeping the old one for backward compatibility, for use of non python
activities.

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
