### PR TITLE
Add support for multiple homeviews

### DIFF
--- a/src/jarabe/desktop/Makefile.am
+++ b/src/jarabe/desktop/Makefile.am
@@ -2,6 +2,7 @@ sugardir = $(pythondir)/jarabe/desktop
 sugar_PYTHON =			\
 	__init__.py		\
 	activitieslist.py	\
+	favorites.py		\
 	favoritesview.py	\
 	favoriteslayout.py	\
 	friendview.py		\

--- a/src/jarabe/desktop/activitieslist.py
+++ b/src/jarabe/desktop/activitieslist.py
@@ -1,5 +1,8 @@
 # Copyright (C) 2008 One Laptop Per Child
 # Copyright (C) 2009 Tomeu Vizoso
+# Copyright (C) 2008-2013 Sugar Labs
+# Copyright (C) 2013 Daniel Francis
+# Copyright (C) 2013 Walter Bender
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -37,6 +40,7 @@ from jarabe.model import bundleregistry
 from jarabe.view.palettes import ActivityPalette
 from jarabe.journal import misc
 from jarabe.util.normalize import normalize_string
+from jarabe.desktop.favorites import FAVORITE_ICONS, get_number_of_home_views
 
 
 class ActivitiesTreeView(Gtk.TreeView):
@@ -63,12 +67,16 @@ class ActivitiesTreeView(Gtk.TreeView):
         model.set_visible_func(self.__model_visible_cb)
         self.set_model(model)
 
-        cell_favorite = CellRendererFavorite(self)
-        cell_favorite.connect('clicked', self.__favorite_clicked_cb)
-
         column = Gtk.TreeViewColumn()
-        column.pack_start(cell_favorite, True)
-        column.set_cell_data_func(cell_favorite, self.__favorite_set_data_cb)
+
+        cell_favorites = []
+        for i in range(get_number_of_home_views()):
+            cell_favorites.append(CellRendererFavorite(self, i))
+            cell_favorites[i].connect('clicked', self.__favorite_clicked_cb)
+            column.pack_start(cell_favorites[i], True)
+            column.set_cell_data_func(cell_favorites[i],
+                                      self.__favorite_set_data_cb)
+
         self.append_column(column)
 
         cell_icon = CellRendererActivityIcon(self)
@@ -129,7 +137,8 @@ class ActivitiesTreeView(Gtk.TreeView):
         self.emit('erase-activated', bundle_id)
 
     def __favorite_set_data_cb(self, column, cell, model, tree_iter, data):
-        favorite = model[tree_iter][ListModel.COLUMN_FAVORITE]
+        favorite = \
+            model[tree_iter][ListModel.COLUMN_FAVORITES[cell.favorite_view]]
         if favorite:
             client = GConf.Client.get_default()
             color = XoColor(client.get_string('/desktop/sugar/user/color'))
@@ -140,9 +149,11 @@ class ActivitiesTreeView(Gtk.TreeView):
     def __favorite_clicked_cb(self, cell, path):
         row = self.get_model()[path]
         registry = bundleregistry.get_registry()
-        registry.set_bundle_favorite(row[ListModel.COLUMN_BUNDLE_ID],
-                                     row[ListModel.COLUMN_VERSION],
-                                     not row[ListModel.COLUMN_FAVORITE])
+        registry.set_bundle_favorite(
+            row[ListModel.COLUMN_BUNDLE_ID],
+            row[ListModel.COLUMN_VERSION],
+            not row[ListModel.COLUMN_FAVORITES[cell.favorite_view]],
+            cell.favorite_view)
 
     def __icon_clicked_cb(self, cell, path):
         self._start_activity(path)
@@ -179,16 +190,19 @@ class ListModel(Gtk.TreeModelSort):
     __gtype_name__ = 'SugarListModel'
 
     COLUMN_BUNDLE_ID = 0
-    COLUMN_FAVORITE = 1
-    COLUMN_ICON = 2
-    COLUMN_TITLE = 3
-    COLUMN_VERSION = 4
-    COLUMN_VERSION_TEXT = 5
-    COLUMN_DATE = 6
-    COLUMN_DATE_TEXT = 7
+    COLUMN_FAVORITES = []
+    for i in range(get_number_of_home_views()):
+        COLUMN_FAVORITES.append(i + 1)
+    COLUMN_ICON = COLUMN_FAVORITES[-1] + 1
+    COLUMN_TITLE = COLUMN_ICON + 1
+    COLUMN_VERSION = COLUMN_TITLE + 1
+    COLUMN_VERSION_TEXT = COLUMN_VERSION + 1
+    COLUMN_DATE = COLUMN_VERSION_TEXT + 1
+    COLUMN_DATE_TEXT = COLUMN_DATE + 1
 
     def __init__(self):
-        self._model = Gtk.ListStore(str, bool, str, str, str, str, int, str)
+        self._model = Gtk.ListStore(str, bool, bool, str, str, str, str, int,
+                                    str)
         self._model_filter = self._model.filter_new()
         Gtk.TreeModelSort.__init__(self, model=self._model_filter)
         self.set_sort_column_id(ListModel.COLUMN_TITLE, Gtk.SortType.ASCENDING)
@@ -209,11 +223,15 @@ class ListModel(Gtk.TreeModelSort):
     def __activity_changed_cb(self, activity_registry, activity_info):
         bundle_id = activity_info.get_bundle_id()
         version = activity_info.get_activity_version()
-        favorite = activity_registry.is_bundle_favorite(bundle_id, version)
+        favorites = []
+        for i in range(get_number_of_home_views()):
+            favorites.append(
+                activity_registry.is_bundle_favorite(bundle_id, version, i))
         for row in self._model:
             if row[ListModel.COLUMN_BUNDLE_ID] == bundle_id and \
                     row[ListModel.COLUMN_VERSION] == version:
-                row[ListModel.COLUMN_FAVORITE] = favorite
+                for i in range(get_number_of_home_views()):
+                    row[ListModel.COLUMN_FAVORITES[i]] = favorites[i]
                 return
 
     def __activity_removed_cb(self, activity_registry, activity_info):
@@ -233,8 +251,10 @@ class ListModel(Gtk.TreeModelSort):
         version = activity_info.get_activity_version()
 
         registry = bundleregistry.get_registry()
-        favorite = registry.is_bundle_favorite(activity_info.get_bundle_id(),
-                                               version)
+        favorites = []
+        for i in range(get_number_of_home_views()):
+            favorites.append(registry.is_bundle_favorite(
+                    activity_info.get_bundle_id(), version, i))
 
         tag_list = activity_info.get_tags()
         if tag_list is None or not tag_list:
@@ -245,14 +265,16 @@ class ListModel(Gtk.TreeModelSort):
                     '<span style="italic" weight="light">%s</span>' % \
                 (activity_info.get_name(), tags)
 
-        self._model.append([activity_info.get_bundle_id(),
-                            favorite,
-                            activity_info.get_icon(),
-                            title,
-                            version,
-                            _('Version %s') % version,
-                            int(timestamp),
-                            util.timestamp_to_elapsed_string(timestamp)])
+        model_list = [activity_info.get_bundle_id()]
+        for i in range(get_number_of_home_views()):
+            model_list.append(favorites[i])
+        model_list.append(activity_info.get_icon())
+        model_list.append(title)
+        model_list.append(version)
+        model_list.append(_('Version %s') % version)
+        model_list.append(int(timestamp))
+        model_list.append(util.timestamp_to_elapsed_string(timestamp))
+        self._model.append(model_list)
 
     def set_visible_func(self, func):
         self._model_filter.set_visible_func(func)
@@ -264,13 +286,14 @@ class ListModel(Gtk.TreeModelSort):
 class CellRendererFavorite(CellRendererIcon):
     __gtype_name__ = 'SugarCellRendererFavorite'
 
-    def __init__(self, tree_view):
+    def __init__(self, tree_view, favorite_view):
         CellRendererIcon.__init__(self, tree_view)
 
+        self.favorite_view = favorite_view
         self.props.width = style.GRID_CELL_SIZE
         self.props.height = style.GRID_CELL_SIZE
         self.props.size = style.SMALL_ICON_SIZE
-        self.props.icon_name = 'emblem-favorite'
+        self.props.icon_name = FAVORITE_ICONS[favorite_view]        
         self.props.mode = Gtk.CellRendererMode.ACTIVATABLE
         client = GConf.Client.get_default()
         prelit_color = XoColor(client.get_string('/desktop/sugar/user/color'))
@@ -500,28 +523,34 @@ class ActivityListPalette(ActivityPalette):
         self._version = activity_info.get_activity_version()
 
         registry = bundleregistry.get_registry()
-        self._favorite = registry.is_bundle_favorite(self._bundle_id,
-                                                     self._version)
-
-        self._favorite_item = PaletteMenuItem()
-        self._favorite_icon = Icon(icon_name='emblem-favorite',
-                                   icon_size=Gtk.IconSize.MENU)
-        self._favorite_item.set_image(self._favorite_icon)
-        self._favorite_icon.show()
-        self._favorite_item.connect('activate',
-                                    self.__change_favorite_activate_cb)
-        self.menu_box.append_item(self._favorite_item)
-        self._favorite_item.show()
+ 
+        self._favorites = []
+        self._favorite_items = []
+        self._favorite_icons = []
+ 
+        for i in range(get_number_of_home_views()):
+            self._favorites.append(
+                registry.is_bundle_favorite(self._bundle_id, self._version, i))
+            self._favorite_items.append(PaletteMenuItem())
+            self._favorite_icons.append(Icon(icon_name=FAVORITE_ICONS[i],
+                                             icon_size=Gtk.IconSize.MENU))
+            self._favorite_items[i].set_image(self._favorite_icons[i])
+            self._favorite_icons[i].show()
+            self._favorite_items[i].connect(
+                'activate', self.__change_favorite_activate_cb, i)
+            self.menu_box.append_item(self._favorite_items[i])
+            self._favorite_items[i].show()
 
         if activity_info.is_user_activity():
             self._add_erase_option(registry, activity_info)
 
         registry = bundleregistry.get_registry()
-        self._activity_changed_sid = \
-            registry.connect('bundle_changed',
-                             self.__activity_changed_cb)
-
-        self._update_favorite_item()
+        self._activity_changed_sid = []
+        for i in range(get_number_of_home_views()):
+            self._activity_changed_sid.append(
+                registry.connect('bundle_changed',
+                                 self.__activity_changed_cb, i))
+            self._update_favorite_item(i)
 
         self.menu_box.connect('destroy', self.__destroy_cb)
 
@@ -537,33 +566,36 @@ class ActivityListPalette(ActivityPalette):
 
     def __destroy_cb(self, palette):
         registry = bundleregistry.get_registry()
-        registry.disconnect(self._activity_changed_sid)
+        for i in range(get_number_of_home_views()):
+            registry.disconnect(self._activity_changed_sid[i])
 
-    def _update_favorite_item(self):
-        if self._favorite:
-            self._favorite_item.set_label(_('Remove favorite'))
+    def _update_favorite_item(self, favorite_view):
+        if self._favorites[favorite_view]:
+            self._favorite_items[favorite_view].set_label(_('Remove favorite'))
             xo_color = XoColor('%s,%s' % (style.COLOR_WHITE.get_svg(),
                                           style.COLOR_TRANSPARENT.get_svg()))
         else:
-            self._favorite_item.set_label(_('Make favorite'))
+            self._favorite_items[favorite_view].set_label(_('Make favorite'))
             client = GConf.Client.get_default()
             xo_color = XoColor(client.get_string('/desktop/sugar/user/color'))
 
-        self._favorite_icon.props.xo_color = xo_color
+        self._favorite_icons[favorite_view].props.xo_color = xo_color
 
-    def __change_favorite_activate_cb(self, menu_item):
+    def __change_favorite_activate_cb(self, menu_item, favorite_view):
         registry = bundleregistry.get_registry()
         registry.set_bundle_favorite(self._bundle_id,
                                      self._version,
-                                     not self._favorite)
+                                     not self._favorites[favorite_view],
+                                     favorite_view)
 
-    def __activity_changed_cb(self, activity_registry, activity_info):
+    def __activity_changed_cb(self, activity_registry, activity_info,
+                              favorite_view):
         if activity_info.get_bundle_id() == self._bundle_id and \
                 activity_info.get_activity_version() == self._version:
             registry = bundleregistry.get_registry()
-            self._favorite = registry.is_bundle_favorite(self._bundle_id,
-                                                         self._version)
-            self._update_favorite_item()
+            self._favorites[favorite_view] = registry.is_bundle_favorite(
+                self._bundle_id, self._version, favorite_view)
+            self._update_favorite_item(favorite_view)
 
     def __erase_activate_cb(self, menu_item):
         self.emit('erase-activated', self._bundle_id)

--- a/src/jarabe/desktop/favorites.py
+++ b/src/jarabe/desktop/favorites.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2008-2013 Sugar Labs
+# Copyright (C) 2013 Daniel Francis
+# Copyright (C) 2013 Walter Bender
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+FAVORITE_ICONS = ['school-server', 'go-home']
+
+
+def get_number_of_home_views():
+    return len(FAVORITE_ICONS)

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -1,5 +1,8 @@
 # Copyright (C) 2006-2007 Red Hat, Inc.
 # Copyright (C) 2008 One Laptop Per Child
+# Copyright (C) 2008-2013 Sugar Labs
+# Copyright (C) 2013 Daniel Francis
+# Copyright (C) 2013 Walter Bender
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -51,7 +54,7 @@ from jarabe.desktop.schoolserver import RegisterError
 from jarabe.desktop import favoriteslayout
 from jarabe.desktop.viewcontainer import ViewContainer
 from jarabe.util.normalize import normalize_string
-
+from jarabe.desktop.favorites import FAVORITE_ICONS, get_number_of_home_views
 
 _logger = logging.getLogger('FavoritesView')
 
@@ -74,9 +77,10 @@ _favorites_settings = None
 class FavoritesBox(Gtk.VBox):
     __gtype_name__ = 'SugarFavoritesBox'
 
-    def __init__(self):
+    def __init__(self, favorite_view):
         Gtk.VBox.__init__(self)
 
+        self.favorite_view = favorite_view
         self._view = FavoritesView(self)
         self.pack_start(self._view, True, True, 0)
         self._view.show()
@@ -146,19 +150,20 @@ class FavoritesView(ViewContainer):
 
         GLib.idle_add(self.__connect_to_bundle_registry_cb)
 
-        favorites_settings = get_settings()
+        favorites_settings = get_settings(self._box.favorite_view)
         favorites_settings.changed.connect(self.__settings_changed_cb)
         self._set_layout(favorites_settings.layout)
 
     def __settings_changed_cb(self, **kwargs):
-        favorites_settings = get_settings()
+        favorites_settings = get_settings(self._box.favorite_view)
         layout_set = self._set_layout(favorites_settings.layout)
         if layout_set:
             self.set_layout(self._layout)
             registry = bundleregistry.get_registry()
             for info in registry:
                 if registry.is_bundle_favorite(info.get_bundle_id(),
-                                               info.get_activity_version()):
+                                               info.get_activity_version(),
+                                               self._box.favorite_view):
                     self._add_activity(info)
 
     def _set_layout(self, layout):
@@ -290,7 +295,8 @@ class FavoritesView(ViewContainer):
 
         for info in registry:
             if registry.is_bundle_favorite(info.get_bundle_id(),
-                                           info.get_activity_version()):
+                                           info.get_activity_version(),
+                                           self._box.favorite_view):
                 self._add_activity(info)
 
         registry.connect('bundle-added', self.__activity_added_cb)
@@ -309,7 +315,8 @@ class FavoritesView(ViewContainer):
     def __activity_added_cb(self, activity_registry, activity_info):
         registry = bundleregistry.get_registry()
         if registry.is_bundle_favorite(activity_info.get_bundle_id(),
-                                       activity_info.get_activity_version()):
+                                       activity_info.get_activity_version(),
+                                       self._box.favorite_view):
             self._add_activity(activity_info)
 
     def __activity_removed_cb(self, activity_registry, activity_info):
@@ -335,7 +342,8 @@ class FavoritesView(ViewContainer):
 
         registry = bundleregistry.get_registry()
         if registry.is_bundle_favorite(activity_info.get_bundle_id(),
-                                       activity_info.get_activity_version()):
+                                       activity_info.get_activity_version(),
+                                       self._box.favorite_view):
             self._add_activity(activity_info)
 
     def set_filter(self, query):
@@ -672,9 +680,18 @@ class FavoritesSetting(object):
 
     _FAVORITES_KEY = '/desktop/sugar/desktop/favorites_layout'
 
-    def __init__(self):
+    def __init__(self, favorite_view):
         client = GConf.Client.get_default()
-        self._layout = client.get_string(self._FAVORITES_KEY)
+        # Special-case 0 for backward compatibility
+        if favorite_view == 0:
+            self._client_string = self._FAVORITES_KEY
+        else:
+            self._client_string = '%s_%d' % (self._FAVORITES_KEY,
+                                             favorite_view)
+
+        self._layout = client.get_string(self._client_string)
+        if self._layout is None:
+            self._layout = favoriteslayout.RingLayout.key
         logging.debug('FavoritesSetting layout %r', self._layout)
 
         self._mode = None
@@ -690,15 +707,18 @@ class FavoritesSetting(object):
             self._layout = layout
 
             client = GConf.Client.get_default()
-            client.set_string(self._FAVORITES_KEY, layout)
+            client.set_string(self._client_string, layout)
 
             self.changed.send(self)
 
     layout = property(get_layout, set_layout)
 
 
-def get_settings():
+def get_settings(favorite_view=0):
     global _favorites_settings
+
     if _favorites_settings is None:
-        _favorites_settings = FavoritesSetting()
-    return _favorites_settings
+        _favorites_settings = []
+        for i in range(get_number_of_home_views()):
+            _favorites_settings.append(FavoritesSetting(i))
+    return _favorites_settings[favorite_view]

--- a/src/jarabe/model/bundleregistry.py
+++ b/src/jarabe/model/bundleregistry.py
@@ -1,5 +1,8 @@
 # Copyright (C) 2006-2007 Red Hat, Inc.
 # Copyright (C) 2009 Aleksey Lim
+# Copyright (C) 2008-2013 Sugar Labs
+# Copyright (C) 2013 Daniel Francis
+# Copyright (C) 2013 Walter Bender
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -32,9 +35,10 @@ from sugar3.bundle.bundle import MalformedBundleException, \
     AlreadyInstalledException, RegistrationException
 from sugar3 import env
 
+from jarabe.desktop.favorites import get_number_of_home_views
 from jarabe.model import mimeregistry
 
-
+_DEFAULT_VIEW = 0
 _instance = None
 
 
@@ -73,8 +77,11 @@ class BundleRegistry(GObject.GObject):
             monitor.connect('changed', self.__file_monitor_changed_cb)
             self._gio_monitors.append(monitor)
 
-        self._last_defaults_mtime = -1
-        self._favorite_bundles = {}
+        self._last_defaults_mtime = []
+        self._favorite_bundles = []
+        for i in range(get_number_of_home_views()):
+            self._favorite_bundles.append({})
+            self._last_defaults_mtime.append(-1)
 
         client = GConf.Client.get_default()
         self._protected_activities = []
@@ -129,39 +136,49 @@ class BundleRegistry(GObject.GObject):
         return '%s %s' % (bundle_id, version)
 
     def _load_favorites(self):
-        favorites_path = env.get_profile_path('favorite_activities')
-        if os.path.exists(favorites_path):
-            favorites_data = json.load(open(favorites_path))
+        for i in range(get_number_of_home_views()):
+            # Special-case 0 for backward compatibility
+            if i == 0:
+                favorites_path = env.get_profile_path('favorite_activities')
+            else:
+                favorites_path = env.get_profile_path(
+                    'favorite_activities_%d' % (i))
+            if os.path.exists(favorites_path):
+                favorites_data = json.load(open(favorites_path))
 
-            favorite_bundles = favorites_data['favorites']
-            if not isinstance(favorite_bundles, dict):
-                raise ValueError('Invalid format in %s.' % favorites_path)
-            if favorite_bundles:
-                first_key = favorite_bundles.keys()[0]
-                if not isinstance(first_key, basestring):
+                favorite_bundles = favorites_data['favorites']
+                if not isinstance(favorite_bundles, dict):
                     raise ValueError('Invalid format in %s.' % favorites_path)
+                if favorite_bundles:
+                    first_key = favorite_bundles.keys()[0]
+                    if not isinstance(first_key, basestring):
+                        raise ValueError('Invalid format in %s.' %
+                                         favorites_path)
 
-                first_value = favorite_bundles.values()[0]
-                if first_value is not None and \
-                   not isinstance(first_value, dict):
-                    raise ValueError('Invalid format in %s.' % favorites_path)
+                    first_value = favorite_bundles.values()[0]
+                    if first_value is not None and \
+                       not isinstance(first_value, dict):
+                        raise ValueError('Invalid format in %s.' %
+                                         favorites_path)
 
-            self._last_defaults_mtime = float(favorites_data['defaults-mtime'])
-            self._favorite_bundles = favorite_bundles
+                self._last_defaults_mtime[i] = \
+                    float(favorites_data['defaults-mtime'])
+                self._favorite_bundles[i] = favorite_bundles
 
     def _merge_default_favorites(self):
+        # Only merge defaults to _DEFAULT_VIEW
         default_activities = []
         defaults_path = os.environ["SUGAR_ACTIVITIES_DEFAULTS"]
         if os.path.exists(defaults_path):
             file_mtime = os.stat(defaults_path).st_mtime
-            if file_mtime > self._last_defaults_mtime:
+            if file_mtime > self._last_defaults_mtime[_DEFAULT_VIEW]:
                 f = open(defaults_path, 'r')
                 for line in f.readlines():
                     line = line.strip()
                     if line and not line.startswith('#'):
                         default_activities.append(line)
                 f.close()
-                self._last_defaults_mtime = file_mtime
+                self._last_defaults_mtime[_DEFAULT_VIEW] = file_mtime
 
         if not default_activities:
             return
@@ -176,12 +193,13 @@ class BundleRegistry(GObject.GObject):
 
             key = self._get_favorite_key(bundle_id, max_version)
             if NormalizedVersion(max_version) > NormalizedVersion('0') and \
-                    key not in self._favorite_bundles:
-                self._favorite_bundles[key] = None
+                    key not in self._favorite_bundles[_DEFAULT_VIEW]:
+                self._favorite_bundles[_DEFAULT_VIEW][key] = None
 
-        logging.debug('After merging: %r', self._favorite_bundles)
+        logging.debug('After merging: %r',
+                      self._favorite_bundles[_DEFAULT_VIEW])
 
-        self._write_favorites_file()
+        self._write_favorites_file(_DEFAULT_VIEW)
 
     def get_bundle(self, bundle_id):
         """Returns an bundle given his service name"""
@@ -300,65 +318,75 @@ class BundleRegistry(GObject.GObject):
         raise ValueError('No bundle %r with version %r exists.' %
                         (bundle_id, version))
 
-    def set_bundle_favorite(self, bundle_id, version, favorite):
-        changed = self._set_bundle_favorite(bundle_id, version, favorite)
+    def set_bundle_favorite(self, bundle_id, version, favorite,
+                            favorite_view=0):
+        changed = self._set_bundle_favorite(bundle_id, version, favorite,
+                                            favorite_view)
         if changed:
             bundle = self._find_bundle(bundle_id, version)
             self.emit('bundle-changed', bundle)
 
-    def _set_bundle_favorite(self, bundle_id, version, favorite):
+    def _set_bundle_favorite(self, bundle_id, version, favorite,
+                             favorite_view):
         key = self._get_favorite_key(bundle_id, version)
-        if favorite and not key in self._favorite_bundles:
-            self._favorite_bundles[key] = None
-        elif not favorite and key in self._favorite_bundles:
-            del self._favorite_bundles[key]
+        if favorite and not key in self._favorite_bundles[favorite_view]:
+            self._favorite_bundles[favorite_view][key] = None
+        elif not favorite and key in self._favorite_bundles[favorite_view]:
+            del self._favorite_bundles[favorite_view][key]
         else:
             return False
 
-        self._write_favorites_file()
+        self._write_favorites_file(favorite_view)
         return True
 
-    def is_bundle_favorite(self, bundle_id, version):
+    def is_bundle_favorite(self, bundle_id, version, favorite_view=0):
         key = self._get_favorite_key(bundle_id, version)
-        return key in self._favorite_bundles
+        return key in self._favorite_bundles[favorite_view]
 
     def is_activity_protected(self, bundle_id):
         return bundle_id in self._protected_activities
 
-    def set_bundle_position(self, bundle_id, version, x, y):
+    def set_bundle_position(self, bundle_id, version, x, y, favorite_view=0):
         key = self._get_favorite_key(bundle_id, version)
-        if key not in self._favorite_bundles:
+        if key not in self._favorite_bundles[favorite_view]:
             raise ValueError('Bundle %s %s not favorite' %
                              (bundle_id, version))
 
-        if self._favorite_bundles[key] is None:
-            self._favorite_bundles[key] = {}
-        if 'position' not in self._favorite_bundles[key] or \
-                [x, y] != self._favorite_bundles[key]['position']:
-            self._favorite_bundles[key]['position'] = [x, y]
+        if self._favorite_bundles[favorite_view][key] is None:
+            self._favorite_bundles[favorite_view][key] = {}
+        if 'position' not in self._favorite_bundles[favorite_view][key] or \
+                [x, y] != \
+                self._favorite_bundles[favorite_view][key]['position']:
+            self._favorite_bundles[favorite_view][key]['position'] = [x, y]
         else:
             return
 
-        self._write_favorites_file()
+        self._write_favorites_file(favorite_view)
         bundle = self._find_bundle(bundle_id, version)
         self.emit('bundle-changed', bundle)
 
-    def get_bundle_position(self, bundle_id, version):
+    def get_bundle_position(self, bundle_id, version, favorite_view=0):
         """Get the coordinates where the user wants the representation of this
         bundle to be displayed. Coordinates are relative to a 1000x1000 area.
         """
         key = self._get_favorite_key(bundle_id, version)
-        if key not in self._favorite_bundles or \
-                self._favorite_bundles[key] is None or \
-                'position' not in self._favorite_bundles[key]:
+        if key not in self._favorite_bundles[favorite_view] or \
+                self._favorite_bundles[favorite_view][key] is None or \
+                'position' not in self._favorite_bundles[favorite_view][key]:
             return (-1, -1)
         else:
-            return tuple(self._favorite_bundles[key]['position'])
+            return \
+                tuple(self._favorite_bundles[favorite_view][key]['position'])
 
-    def _write_favorites_file(self):
-        path = env.get_profile_path('favorite_activities')
-        favorites_data = {'defaults-mtime': self._last_defaults_mtime,
-                          'favorites': self._favorite_bundles}
+    def _write_favorites_file(self, favorite_view):
+        if favorite_view == 0:
+            path = env.get_profile_path('favorite_activities')
+        else:
+            path = env.get_profile_path('favorite_activities_%d' %
+                                        (favorite_view))
+        favorites_data = {
+            'defaults-mtime': self._last_defaults_mtime[favorite_view],
+            'favorites': self._favorite_bundles[favorite_view]}
         json.dump(favorites_data, open(path, 'w'), indent=1)
 
     def is_installed(self, bundle):


### PR DESCRIPTION
This patch adds support for multiple home views as per [1]. The number
of home views is determined by the list of FAVORITE_ICONS found in
jarabe/desktop/favorites.py. The icons in the list are used both for
the home view selection on the Home View toolbar and the favorites
list in the Home List View. In this version of the patch, the
school-server and go-home icons are used, resulting in two home
views. Note that the go-home icon, which has no stroke elements, is
not well suited for the favorites icon selection since it is invisible
when not selected. A new icon should be designed for this purpose.

To revert to the current single home-view configuration, one need
simply set FAVORITE_ICONS with [view-radial].

[1] http://wiki.sugarlabs.org/go/Features/Multiple_home_views
