### PR TITLE
Add support for multiple homeviews

### DIFF
--- a/src/jarabe/desktop/Makefile.am
+++ b/src/jarabe/desktop/Makefile.am
@@ -2,6 +2,7 @@ sugardir = $(pythondir)/jarabe/desktop
 sugar_PYTHON =			\
 	__init__.py		\
 	activitieslist.py	\
+	config.py		\
 	favoritesview.py	\
 	favoriteslayout.py	\
 	friendview.py		\

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -1,5 +1,8 @@
 # Copyright (C) 2006-2007 Red Hat, Inc.
 # Copyright (C) 2008 One Laptop Per Child
+# Copyright (C) 2008-2013 Sugar Labs
+# Copyright (C) 2013 Daniel Francis
+# Copyright (C) 2013 Walter Bender
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -51,7 +54,7 @@ from jarabe.desktop.schoolserver import RegisterError
 from jarabe.desktop import favoriteslayout
 from jarabe.desktop.viewcontainer import ViewContainer
 from jarabe.util.normalize import normalize_string
-
+from jarabe.desktop.config import get_number_of_views
 
 _logger = logging.getLogger('FavoritesView')
 
@@ -74,9 +77,10 @@ _favorites_settings = None
 class FavoritesBox(Gtk.VBox):
     __gtype_name__ = 'SugarFavoritesBox'
 
-    def __init__(self):
+    def __init__(self, favorite_view):
         Gtk.VBox.__init__(self)
 
+        self.favorite_view = favorite_view
         self._view = FavoritesView(self)
         self.pack_start(self._view, True, True, 0)
         self._view.show()
@@ -146,19 +150,20 @@ class FavoritesView(ViewContainer):
 
         GLib.idle_add(self.__connect_to_bundle_registry_cb)
 
-        favorites_settings = get_settings()
+        favorites_settings = get_settings(self._box.favorite_view)
         favorites_settings.changed.connect(self.__settings_changed_cb)
         self._set_layout(favorites_settings.layout)
 
     def __settings_changed_cb(self, **kwargs):
-        favorites_settings = get_settings()
+        favorites_settings = get_settings(self._box.favorite_view)
         layout_set = self._set_layout(favorites_settings.layout)
         if layout_set:
             self.set_layout(self._layout)
             registry = bundleregistry.get_registry()
             for info in registry:
                 if registry.is_bundle_favorite(info.get_bundle_id(),
-                                               info.get_activity_version()):
+                                               info.get_activity_version(),
+                                               self._box.favorite_view):
                     self._add_activity(info)
 
     def _set_layout(self, layout):
@@ -290,7 +295,8 @@ class FavoritesView(ViewContainer):
 
         for info in registry:
             if registry.is_bundle_favorite(info.get_bundle_id(),
-                                           info.get_activity_version()):
+                                           info.get_activity_version(),
+                                           self._box.favorite_view):
                 self._add_activity(info)
 
         registry.connect('bundle-added', self.__activity_added_cb)
@@ -309,7 +315,8 @@ class FavoritesView(ViewContainer):
     def __activity_added_cb(self, activity_registry, activity_info):
         registry = bundleregistry.get_registry()
         if registry.is_bundle_favorite(activity_info.get_bundle_id(),
-                                       activity_info.get_activity_version()):
+                                       activity_info.get_activity_version(),
+                                       self._box.favorite_view):
             self._add_activity(activity_info)
 
     def __activity_removed_cb(self, activity_registry, activity_info):
@@ -335,7 +342,8 @@ class FavoritesView(ViewContainer):
 
         registry = bundleregistry.get_registry()
         if registry.is_bundle_favorite(activity_info.get_bundle_id(),
-                                       activity_info.get_activity_version()):
+                                       activity_info.get_activity_version(),
+                                       self._box.favorite_view):
             self._add_activity(activity_info)
 
     def set_filter(self, query):
@@ -672,9 +680,18 @@ class FavoritesSetting(object):
 
     _FAVORITES_KEY = '/desktop/sugar/desktop/favorites_layout'
 
-    def __init__(self):
+    def __init__(self, favorite_view):
         client = GConf.Client.get_default()
-        self._layout = client.get_string(self._FAVORITES_KEY)
+        # Special-case 0 for backward compatibility
+        if favorite_view == 0:
+            self._client_string = self._FAVORITES_KEY
+        else:
+            self._client_string = '%s_%d' % (self._FAVORITES_KEY,
+                                             favorite_view)
+
+        self._layout = client.get_string(self._client_string)
+        if self._layout is None:
+            self._layout = favoriteslayout.RingLayout.key
         logging.debug('FavoritesSetting layout %r', self._layout)
 
         self._mode = None
@@ -690,15 +707,18 @@ class FavoritesSetting(object):
             self._layout = layout
 
             client = GConf.Client.get_default()
-            client.set_string(self._FAVORITES_KEY, layout)
+            client.set_string(self._client_string, layout)
 
             self.changed.send(self)
 
     layout = property(get_layout, set_layout)
 
 
-def get_settings():
+def get_settings(favorite_view=0):
     global _favorites_settings
+
     if _favorites_settings is None:
-        _favorites_settings = FavoritesSetting()
-    return _favorites_settings
+        _favorites_settings = []
+        for i in range(get_number_of_views()):
+            _favorites_settings.append(FavoritesSetting(i))
+    return _favorites_settings[favorite_view]

--- a/src/jarabe/desktop/homebox.py
+++ b/src/jarabe/desktop/homebox.py
@@ -1,4 +1,7 @@
 # Copyright (C) 2008 One Laptop Per Child
+# Copyright (C) 2008-2013 Sugar Labs
+# Copyright (C) 2013 Daniel Francis
+# Copyright (C) 2013 Walter Bender
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,9 +30,12 @@ from sugar3.graphics.icon import Icon
 from jarabe.desktop import favoritesview
 from jarabe.desktop.activitieslist import ActivitiesList
 from jarabe.util.normalize import normalize_string
+from jarabe.desktop.config import get_number_of_views
 
-_FAVORITES_VIEW = 0
-_LIST_VIEW = 1
+_favorites_views = []
+for i in range(get_number_of_views()):
+    _favorites_views.append(i)
+_list_view = _favorites_views[-1] + 1
 
 
 class HomeBox(Gtk.VBox):
@@ -40,7 +46,9 @@ class HomeBox(Gtk.VBox):
 
         Gtk.VBox.__init__(self)
 
-        self._favorites_box = favoritesview.FavoritesBox()
+        self._favorites_boxes = []
+        for i in range(get_number_of_views()):
+            self._favorites_boxes.append(favoritesview.FavoritesBox(i))
         self._list_view = ActivitiesList()
 
         toolbar.connect('query-changed', self.__toolbar_query_changed_cb)
@@ -50,7 +58,7 @@ class HomeBox(Gtk.VBox):
         self._list_view.connect('clear-clicked',
                                 self.__activitylist_clear_clicked_cb, toolbar)
 
-        self._set_view(_FAVORITES_VIEW)
+        self._set_view(_favorites_views[0])
         self._query = ''
 
     def show_software_updates_alert(self):
@@ -71,17 +79,24 @@ class HomeBox(Gtk.VBox):
         erase_icon = Icon(icon_name='dialog-ok')
         alert.add_button(Gtk.ResponseType.OK, _('Check now'), erase_icon)
 
-        if self._list_view in self.get_children():
+        children = self.get_children()
+        if self._list_view in children:
             self._list_view.add_alert(alert)
         else:
-            self._favorites_box.add_alert(alert)
+            for i in range(get_number_of_views()):
+                if self._favorites_boxes[i] in children:
+                    self._favorites_boxes[i].add_alert(alert)
+                    break
         alert.connect('response', self.__software_update_response_cb)
 
     def __software_update_response_cb(self, alert, response_id):
-        if self._list_view in self.get_children():
+        children = self.get_children()
+        if self._list_view in children:
             self._list_view.remove_alert()
         else:
-            self._favorites_box.remove_alert()
+            for i in range(get_number_of_views()):
+                if self._favorites_boxes[i] in children:
+                    self._favorites_boxes[i].remove_alert()
 
         if response_id != Gtk.ResponseType.REJECT:
             update_trigger_file = os.path.expanduser('~/.sugar-update')
@@ -102,7 +117,8 @@ class HomeBox(Gtk.VBox):
     def __toolbar_query_changed_cb(self, toolbar, query):
         self._query = normalize_string(query.decode('utf-8'))
         self._list_view.set_filter(self._query)
-        self._favorites_box.set_filter(self._query)
+        for i in range(get_number_of_views()):
+            self._favorites_boxes[i].set_filter(self._query)
 
     def __toolbar_view_changed_cb(self, toolbar, view):
         self._set_view(view)
@@ -116,25 +132,37 @@ class HomeBox(Gtk.VBox):
     def grab_focus(self):
         # overwrite grab focus to be able to grab focus on the
         # views which are packed inside a box
-        if self._list_view in self.get_children():
+        children = self.get_children()
+        if self._list_view in children:
             self._list_view.grab_focus()
         else:
-            self._favorites_box.grab_focus()
+            for i in range(get_number_of_views()):
+                if self._favorites_boxes[i] in children:
+                    self._favorites_boxes[i].grab_focus()
 
     def _set_view(self, view):
-        if view == _FAVORITES_VIEW:
-            if self._list_view in self.get_children():
+        if view in _favorites_views:
+            favorite = _favorites_views.index(view)
+
+            children = self.get_children()
+            if self._list_view in children:
                 self.remove(self._list_view)
+            else:
+                for i in range(get_number_of_views()):
+                    if i != favorite and self._favorites_boxes[i] in children:
+                        self.remove(self._favorites_boxes[i])
 
-            if self._favorites_box not in self.get_children():
-                self.add(self._favorites_box)
-                self._favorites_box.show()
-                self._favorites_box.grab_focus()
-        elif view == _LIST_VIEW:
-            if self._favorites_box in self.get_children():
-                self.remove(self._favorites_box)
+            if self._favorites_boxes[favorite] not in children:
+                self.add(self._favorites_boxes[favorite])
+                self._favorites_boxes[favorite].show()
+                self._favorites_boxes[favorite].grab_focus()
+        elif view == _list_view:
+            children = self.get_children()
+            for i in range(get_number_of_views()):
+                if self._favorites_boxes[i] in children:
+                    self.remove(self._favorites_boxes[i])
 
-            if self._list_view not in self.get_children():
+            if self._list_view not in children:
                 self.add(self._list_view)
                 self._list_view.show()
                 self._list_view.grab_focus()
@@ -154,8 +182,9 @@ class HomeBox(Gtk.VBox):
         # return self._donut.has_activities()
         return False
 
-    def set_resume_mode(self, resume_mode):
-        self._favorites_box.set_resume_mode(resume_mode)
+    def set_resume_mode(self, resume_mode, favorite_view=0):
+        self._favorites_boxes[favorite_view].set_resume_mode(resume_mode)
         if resume_mode and self._query != '':
             self._list_view.set_filter(self._query)
-            self._favorites_box.set_filter(self._query)
+            for i in range(get_number_of_views()):
+                self._favorites_boxes[i].set_filter(self._query)

--- a/src/jarabe/desktop/viewtoolbar.py
+++ b/src/jarabe/desktop/viewtoolbar.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2009 Tomeu Vizoso, Simon Schampijer
 # Copyright (C) 2009-2012 One Laptop per Child
 # Copyright (C) 2010 Collabora Ltd. <http://www.collabora.co.uk/>
+# Copyright (C) 2008-2013 Sugar Labs
+# Copyright (C) 2013 Daniel Francis
+# Copyright (C) 2013 Walter Bender
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,10 +31,13 @@ from sugar3.graphics import iconentry
 from sugar3.graphics.radiotoolbutton import RadioToolButton
 
 from jarabe.desktop import favoritesview
+from jarabe.desktop.config import get_number_of_views, get_view_icons
 
 _AUTOSEARCH_TIMEOUT = 1000
-_FAVORITES_VIEW = 0
-_LIST_VIEW = 1
+_favorites_views = []
+for i in range(get_number_of_views()):
+    _favorites_views.append(i)
+_list_view = _favorites_views[-1] + 1
 
 
 class ViewToolbar(Gtk.Toolbar):
@@ -69,28 +75,35 @@ class ViewToolbar(Gtk.Toolbar):
 
         self._add_separator(expand=True)
 
-        self._favorites_button = FavoritesButton()
-        self._favorites_button.connect('toggled',
-                                       self.__view_button_toggled_cb,
-                                       _FAVORITES_VIEW)
-        self.insert(self._favorites_button, -1)
+        self._favorites_buttons = []
+        for i in range(get_number_of_views()):
+            self._favorites_buttons.append(FavoritesButton(i))
+            self._favorites_buttons[i].connect('toggled',
+                                               self.__view_button_toggled_cb,
+                                               _favorites_views[i])
+            if i > 0:
+                self._favorites_buttons[i].props.group = \
+                    self._favorites_buttons[0]
+            self.insert(self._favorites_buttons[i], -1)
 
         self._list_button = RadioToolButton(icon_name='view-list')
-        self._list_button.props.group = self._favorites_button
+        self._list_button.props.group = self._favorites_buttons[0]
         self._list_button.props.tooltip = _('List view')
         self._list_button.props.accelerator = _('<Ctrl>2')
         self._list_button.connect('toggled', self.__view_button_toggled_cb,
-                                  _LIST_VIEW)
+                                  _list_view)
         self.insert(self._list_button, -1)
 
         self._add_separator()
 
     def show_view_buttons(self):
-        self._favorites_button.show()
+        for i in range(get_number_of_views()):
+            self._favorites_buttons[i].show()
         self._list_button.show()
 
     def hide_view_buttons(self):
-        self._favorites_button.hide()
+        for i in range(get_number_of_views()):
+            self._favorites_buttons[i].hide()
         self._list_button.hide()
 
     def clear_query(self):
@@ -143,16 +156,16 @@ class ViewToolbar(Gtk.Toolbar):
 class FavoritesButton(RadioToolButton):
     __gtype_name__ = 'SugarFavoritesButton'
 
-    def __init__(self):
+    def __init__(self, favorite_view):
         RadioToolButton.__init__(self)
 
-        self.props.tooltip = _('Favorites view')
-        self.props.accelerator = _('<Ctrl>1')
+        self.props.tooltip = _('Favorites view %d' % (favorite_view + 1))
+        self.props.accelerator = _('<Ctrl>%d' % (favorite_view + 1))
         self.props.group = None
+        self.props.icon_name = get_view_icons()[favorite_view]
 
-        favorites_settings = favoritesview.get_settings()
+        favorites_settings = favoritesview.get_settings(favorite_view)
         self._layout = favorites_settings.layout
-        self._update_icon()
 
         # someday, this will be a Gtk.Table()
         layouts_grid = Gtk.HBox()
@@ -164,11 +177,11 @@ class FavoritesButton(RadioToolButton):
                 layout_item.set_active(True)
             layouts_grid.pack_start(layout_item, True, False, 0)
             layout_item.connect('toggled', self.__layout_activate_cb,
-                                layoutid)
+                                layoutid, favorite_view)
         layouts_grid.show_all()
         self.props.palette.set_content(layouts_grid)
 
-    def __layout_activate_cb(self, menu_item, layout):
+    def __layout_activate_cb(self, menu_item, layout, favorite_view):
         if not menu_item.get_active():
             return
         if self._layout == layout and self.props.active:
@@ -176,15 +189,11 @@ class FavoritesButton(RadioToolButton):
 
         if self._layout != layout:
             self._layout = layout
-            self._update_icon()
 
-            favorites_settings = favoritesview.get_settings()
+            favorites_settings = favoritesview.get_settings(favorite_view)
             favorites_settings.layout = layout
 
         if not self.props.active:
             self.props.active = True
         else:
             self.emit('toggled')
-
-    def _update_icon(self):
-        self.props.icon_name = favoritesview.LAYOUT_MAP[self._layout].icon_name

--- a/src/jarabe/model/bundleregistry.py
+++ b/src/jarabe/model/bundleregistry.py
@@ -1,5 +1,8 @@
 # Copyright (C) 2006-2007 Red Hat, Inc.
 # Copyright (C) 2009 Aleksey Lim
+# Copyright (C) 2008-2013 Sugar Labs
+# Copyright (C) 2013 Daniel Francis
+# Copyright (C) 2013 Walter Bender
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -32,9 +35,10 @@ from sugar3.bundle.bundle import MalformedBundleException, \
     AlreadyInstalledException, RegistrationException
 from sugar3 import env
 
+from jarabe.desktop.config import get_number_of_views
 from jarabe.model import mimeregistry
 
-
+_DEFAULT_VIEW = 0
 _instance = None
 
 
@@ -73,8 +77,11 @@ class BundleRegistry(GObject.GObject):
             monitor.connect('changed', self.__file_monitor_changed_cb)
             self._gio_monitors.append(monitor)
 
-        self._last_defaults_mtime = -1
-        self._favorite_bundles = {}
+        self._last_defaults_mtime = []
+        self._favorite_bundles = []
+        for i in range(get_number_of_views()):
+            self._favorite_bundles.append({})
+            self._last_defaults_mtime.append(-1)
 
         client = GConf.Client.get_default()
         self._protected_activities = []
@@ -129,39 +136,49 @@ class BundleRegistry(GObject.GObject):
         return '%s %s' % (bundle_id, version)
 
     def _load_favorites(self):
-        favorites_path = env.get_profile_path('favorite_activities')
-        if os.path.exists(favorites_path):
-            favorites_data = json.load(open(favorites_path))
+        for i in range(get_number_of_views()):
+            # Special-case 0 for backward compatibility
+            if i == 0:
+                favorites_path = env.get_profile_path('favorite_activities')
+            else:
+                favorites_path = env.get_profile_path(
+                    'favorite_activities_%d' % (i))
+            if os.path.exists(favorites_path):
+                favorites_data = json.load(open(favorites_path))
 
-            favorite_bundles = favorites_data['favorites']
-            if not isinstance(favorite_bundles, dict):
-                raise ValueError('Invalid format in %s.' % favorites_path)
-            if favorite_bundles:
-                first_key = favorite_bundles.keys()[0]
-                if not isinstance(first_key, basestring):
+                favorite_bundles = favorites_data['favorites']
+                if not isinstance(favorite_bundles, dict):
                     raise ValueError('Invalid format in %s.' % favorites_path)
+                if favorite_bundles:
+                    first_key = favorite_bundles.keys()[0]
+                    if not isinstance(first_key, basestring):
+                        raise ValueError('Invalid format in %s.' %
+                                         favorites_path)
 
-                first_value = favorite_bundles.values()[0]
-                if first_value is not None and \
-                   not isinstance(first_value, dict):
-                    raise ValueError('Invalid format in %s.' % favorites_path)
+                    first_value = favorite_bundles.values()[0]
+                    if first_value is not None and \
+                       not isinstance(first_value, dict):
+                        raise ValueError('Invalid format in %s.' %
+                                         favorites_path)
 
-            self._last_defaults_mtime = float(favorites_data['defaults-mtime'])
-            self._favorite_bundles = favorite_bundles
+                self._last_defaults_mtime[i] = \
+                    float(favorites_data['defaults-mtime'])
+                self._favorite_bundles[i] = favorite_bundles
 
     def _merge_default_favorites(self):
+        # Only merge defaults to _DEFAULT_VIEW
         default_activities = []
         defaults_path = os.environ["SUGAR_ACTIVITIES_DEFAULTS"]
         if os.path.exists(defaults_path):
             file_mtime = os.stat(defaults_path).st_mtime
-            if file_mtime > self._last_defaults_mtime:
+            if file_mtime > self._last_defaults_mtime[_DEFAULT_VIEW]:
                 f = open(defaults_path, 'r')
                 for line in f.readlines():
                     line = line.strip()
                     if line and not line.startswith('#'):
                         default_activities.append(line)
                 f.close()
-                self._last_defaults_mtime = file_mtime
+                self._last_defaults_mtime[_DEFAULT_VIEW] = file_mtime
 
         if not default_activities:
             return
@@ -176,12 +193,13 @@ class BundleRegistry(GObject.GObject):
 
             key = self._get_favorite_key(bundle_id, max_version)
             if NormalizedVersion(max_version) > NormalizedVersion('0') and \
-                    key not in self._favorite_bundles:
-                self._favorite_bundles[key] = None
+                    key not in self._favorite_bundles[_DEFAULT_VIEW]:
+                self._favorite_bundles[_DEFAULT_VIEW][key] = None
 
-        logging.debug('After merging: %r', self._favorite_bundles)
+        logging.debug('After merging: %r',
+                      self._favorite_bundles[_DEFAULT_VIEW])
 
-        self._write_favorites_file()
+        self._write_favorites_file(_DEFAULT_VIEW)
 
     def get_bundle(self, bundle_id):
         """Returns an bundle given his service name"""
@@ -300,65 +318,75 @@ class BundleRegistry(GObject.GObject):
         raise ValueError('No bundle %r with version %r exists.' %
                         (bundle_id, version))
 
-    def set_bundle_favorite(self, bundle_id, version, favorite):
-        changed = self._set_bundle_favorite(bundle_id, version, favorite)
+    def set_bundle_favorite(self, bundle_id, version, favorite,
+                            favorite_view=0):
+        changed = self._set_bundle_favorite(bundle_id, version, favorite,
+                                            favorite_view)
         if changed:
             bundle = self._find_bundle(bundle_id, version)
             self.emit('bundle-changed', bundle)
 
-    def _set_bundle_favorite(self, bundle_id, version, favorite):
+    def _set_bundle_favorite(self, bundle_id, version, favorite,
+                             favorite_view):
         key = self._get_favorite_key(bundle_id, version)
-        if favorite and not key in self._favorite_bundles:
-            self._favorite_bundles[key] = None
-        elif not favorite and key in self._favorite_bundles:
-            del self._favorite_bundles[key]
+        if favorite and not key in self._favorite_bundles[favorite_view]:
+            self._favorite_bundles[favorite_view][key] = None
+        elif not favorite and key in self._favorite_bundles[favorite_view]:
+            del self._favorite_bundles[favorite_view][key]
         else:
             return False
 
-        self._write_favorites_file()
+        self._write_favorites_file(favorite_view)
         return True
 
-    def is_bundle_favorite(self, bundle_id, version):
+    def is_bundle_favorite(self, bundle_id, version, favorite_view=0):
         key = self._get_favorite_key(bundle_id, version)
-        return key in self._favorite_bundles
+        return key in self._favorite_bundles[favorite_view]
 
     def is_activity_protected(self, bundle_id):
         return bundle_id in self._protected_activities
 
-    def set_bundle_position(self, bundle_id, version, x, y):
+    def set_bundle_position(self, bundle_id, version, x, y, favorite_view=0):
         key = self._get_favorite_key(bundle_id, version)
-        if key not in self._favorite_bundles:
+        if key not in self._favorite_bundles[favorite_view]:
             raise ValueError('Bundle %s %s not favorite' %
                              (bundle_id, version))
 
-        if self._favorite_bundles[key] is None:
-            self._favorite_bundles[key] = {}
-        if 'position' not in self._favorite_bundles[key] or \
-                [x, y] != self._favorite_bundles[key]['position']:
-            self._favorite_bundles[key]['position'] = [x, y]
+        if self._favorite_bundles[favorite_view][key] is None:
+            self._favorite_bundles[favorite_view][key] = {}
+        if 'position' not in self._favorite_bundles[favorite_view][key] or \
+                [x, y] != \
+                self._favorite_bundles[favorite_view][key]['position']:
+            self._favorite_bundles[favorite_view][key]['position'] = [x, y]
         else:
             return
 
-        self._write_favorites_file()
+        self._write_favorites_file(favorite_view)
         bundle = self._find_bundle(bundle_id, version)
         self.emit('bundle-changed', bundle)
 
-    def get_bundle_position(self, bundle_id, version):
+    def get_bundle_position(self, bundle_id, version, favorite_view=0):
         """Get the coordinates where the user wants the representation of this
         bundle to be displayed. Coordinates are relative to a 1000x1000 area.
         """
         key = self._get_favorite_key(bundle_id, version)
-        if key not in self._favorite_bundles or \
-                self._favorite_bundles[key] is None or \
-                'position' not in self._favorite_bundles[key]:
+        if key not in self._favorite_bundles[favorite_view] or \
+                self._favorite_bundles[favorite_view][key] is None or \
+                'position' not in self._favorite_bundles[favorite_view][key]:
             return (-1, -1)
         else:
-            return tuple(self._favorite_bundles[key]['position'])
+            return \
+                tuple(self._favorite_bundles[favorite_view][key]['position'])
 
-    def _write_favorites_file(self):
-        path = env.get_profile_path('favorite_activities')
-        favorites_data = {'defaults-mtime': self._last_defaults_mtime,
-                          'favorites': self._favorite_bundles}
+    def _write_favorites_file(self, favorite_view):
+        if favorite_view == 0:
+            path = env.get_profile_path('favorite_activities')
+        else:
+            path = env.get_profile_path('favorite_activities_%d' %
+                                        (favorite_view))
+        favorites_data = {
+            'defaults-mtime': self._last_defaults_mtime[favorite_view],
+            'favorites': self._favorite_bundles[favorite_view]}
         json.dump(favorites_data, open(path, 'w'), indent=1)
 
     def is_installed(self, bundle):


### PR DESCRIPTION
This patch adds support for multiple home views as per [1]. The number
of home views is determined by the list of VIEW_ICONS found in
/desktop/sugar/desktop/view_icons. If no gconf entry is found,
defaults from jarabe/desktop/config.py are used. The icons in the list
are used both for the home view selection on the Home View toolbar and
the favorites list in the Home List View. In this version of the
patch, view-radial is used, resulting in just one home view by
default. Similarly, in the list view, the favorities icons are found
in /desktop/sugar/desktop/favorite_icons. If not favorite icons are
found, emblem-favorites is used.

[1] http://wiki.sugarlabs.org/go/Features/Multiple_home_views
