### PR TITLE
Update for bundle helpers change (#4527)

### DIFF
--- a/src/jarabe/model/bundleregistry.py
+++ b/src/jarabe/model/bundleregistry.py
@@ -26,7 +26,7 @@ from gi.repository import Gio
 from gi.repository import Gtk
 import json
 
-from sugar3.bundle import bundle_from_dir
+from sugar3.bundle.helpers import bundle_from_dir
 from sugar3.bundle.activitybundle import ActivityBundle
 from sugar3.bundle.bundleversion import NormalizedVersion
 from sugar3.bundle.bundle import MalformedBundleException, \

--- a/src/jarabe/model/update/updater.py
+++ b/src/jarabe/model/update/updater.py
@@ -24,7 +24,7 @@ from gi.repository import GObject
 from gi.repository import GLib
 from gi.repository import GConf
 
-from sugar3.bundle import bundle_from_archive
+from sugar3.bundle.helpers import bundle_from_archive
 
 from jarabe.model import bundleregistry
 from jarabe.util.downloader import Downloader


### PR DESCRIPTION
The new bundle helpers caused Gi to be imported when running GTK2
activities. They have been moved to a place where they are not imported
in that situation. Update the users appropriately.
