### PR TITLE
Xkl item get_name(), get_description()

### DIFF
--- a/extensions/cpsection/keyboard/model.py
+++ b/extensions/cpsection/keyboard/model.py
@@ -17,8 +17,6 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 
-import logging
-
 from gi.repository import Xkl
 from gi.repository import GConf
 from gi.repository import SugarExt


### PR DESCRIPTION
Use Xkl configitem get_name() and get_description() to circumvent problem with byte-array conversion to string.
