### PR TITLE
Key dialog: pass key as-is to NetworkManager

### DIFF
--- a/src/jarabe/desktop/keydialog.py
+++ b/src/jarabe/desktop/keydialog.py
@@ -246,30 +246,7 @@ class WPAKeyDialog(KeyDialog):
         self.vbox.pack_start(self.hbox, True, True, 0)
 
     def _get_security(self):
-        ssid = self._ssid
-        key = self._entry.get_text()
-        is_hex = string_is_hex(key)
-
-        real_key = None
-        if len(key) == 64 and is_hex:
-            # Hex key
-            real_key = key
-        elif len(key) >= 8 and len(key) <= 63:
-            # passphrase
-            from subprocess import Popen, PIPE
-            p = Popen(['wpa_passphrase', ssid, key], stdout=PIPE)
-            for line in p.stdout:
-                if line.strip().startswith('psk='):
-                    real_key = line.strip()[4:]
-            if p.wait() != 0:
-                raise RuntimeError('Error hashing passphrase')
-            if real_key and len(real_key) != 64:
-                real_key = None
-
-        if not real_key:
-            raise RuntimeError('Invalid key')
-
-        return real_key
+        return self._entry.get_text()
 
     def print_security(self):
         key = self._get_security()


### PR DESCRIPTION
NetworkManager will perform the appropriate key generation
without us having to do this.
