### PR TITLE
Show preview in the clipboard button palette for images

### DIFF
--- a/src/jarabe/frame/clipboardmenu.py
+++ b/src/jarabe/frame/clipboardmenu.py
@@ -23,6 +23,7 @@ from gi.repository import GConf
 from gi.repository import GLib
 
 from gi.repository import Gtk
+from gi.repository import GdkPixbuf
 
 from sugar3.graphics.palette import Palette
 from sugar3.graphics.menuitem import MenuItem
@@ -148,7 +149,11 @@ class ClipboardMenu(Palette):
         self.props.primary_text = GLib.markup_escape_text(name)
         preview = self._cb_object.get_preview()
         if preview:
-            self.props.secondary_text = GLib.markup_escape_text(preview)
+            if isinstance(preview, str):
+                self.props.secondary_text = GLib.markup_escape_text(preview)
+            if isinstance(preview, GdkPixbuf.Pixbuf):
+                self.set_pixbuf(preview)
+
         self._update_items_visibility()
         self._update_open_submenu()
 

--- a/src/jarabe/frame/clipboardobject.py
+++ b/src/jarabe/frame/clipboardobject.py
@@ -23,6 +23,7 @@ from gi.repository import Gtk
 from gettext import gettext as _
 from sugar3 import mime
 from sugar3.bundle.activitybundle import ActivityBundle
+from sugar3.graphics.objectchooser import get_preview_pixbuf
 
 
 class ClipboardObject(object):
@@ -77,6 +78,11 @@ class ClipboardObject(object):
         for mime_type in ['text/plain']:
             if mime_type in self._formats:
                 return self._formats[mime_type].get_data()
+        for mime_type in ['image/png']:
+            if mime_type in self._formats:
+                pixbuf = get_preview_pixbuf(
+                    self._formats[mime_type].get_data())
+                return pixbuf
         return ''
 
     def is_bundle(self):


### PR DESCRIPTION
This was designed long time ago ([1] and [2]) but was not possible with
the old palettes. Now with gtk3, we can implement it.

[1] http://wiki.sugarlabs.org/go/Design_Team/Specifications/Clipboard#Previews
[2] http://wiki.sugarlabs.org/go/File:Frame-05.jpeg

The pull request https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/25 is needed by this feature
