### PR TITLE
Fix webservice copy-to menu items

### DIFF
--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -277,10 +277,11 @@ class CopyMenuBuilder():
             self.__mount_removed_cb)
 
         if self._add_webservices_menu:
+            metadata = model.get(self._get_uid_list_cb()[0])
             for account in accountsmanager.get_configured_accounts():
                 self._menu.append(
                     account.get_shared_journal_entry().get_share_menu(
-                        self._get_uid_list_cb))
+                        metadata))
 
     def update_mount_point(self):
         for menu_item in self._menu.get_children():


### PR DESCRIPTION
Retrieve metadata when populating the copy-to menu items
for webservices.

Pass metadata instead of the callback reference, to preserve
compatibility with current extensions.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
