### PR TITLE
Use find_icon_name method

### DIFF
--- a/extensions/deviceicon/volume.py
+++ b/extensions/deviceicon/volume.py
@@ -25,6 +25,7 @@ from gi.repository import GConf
 from sugar3.graphics.tray import TrayIcon
 from sugar3.graphics.xocolor import XoColor
 from sugar3.graphics.palettemenu import PaletteMenuItem
+from sugar3.graphics.icon import find_icon_name
 from sugar3.graphics.icon import Icon
 
 from jarabe.journal import journalactivity
@@ -43,24 +44,13 @@ class DeviceView(TrayIcon):
     def __init__(self, mount):
 
         self._mount = mount
-
-        self._icon_name = None
-        icon_theme = Gtk.IconTheme.get_default()
-        for icon_name in self._mount.get_icon().props.names:
-            icon_info = icon_theme.lookup_icon(icon_name,
-                                               Gtk.IconSize.LARGE_TOOLBAR, 0)
-            if icon_info is not None:
-                self._icon_name = icon_name
-                break
-
-        if self._icon_name is None:
-            self._icon_name = 'drive'
+        self._icon_name = find_icon_name(mount)
 
         # TODO: retrieve the colors from the owner of the device
         client = GConf.Client.get_default()
         color = XoColor(client.get_string('/desktop/sugar/user/color'))
 
-        TrayIcon.__init__(self, icon_name=icon_name, xo_color=color)
+        TrayIcon.__init__(self, icon_name=self._icon_name, xo_color=color)
 
         self.set_palette_invoker(FrameWidgetInvoker(self))
         self.palette_invoker.props.toggle_palette = True

--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -29,6 +29,7 @@ from gi.repository import GLib
 from sugar3.graphics import style
 from sugar3.graphics.palette import Palette
 from sugar3.graphics.menuitem import MenuItem
+from sugar3.graphics.icon import find_icon_name
 from sugar3.graphics.icon import Icon
 from sugar3.graphics.xocolor import XoColor
 from sugar3.graphics.alert import Alert
@@ -301,12 +302,8 @@ class CopyMenuBuilder():
         volume_menu = VolumeMenu(self._journalactivity,
                                  self._get_uid_list_cb, mount.get_name(),
                                  mount.get_root().get_path())
-        icon_theme = Gtk.IconTheme.get_default()
-        for name in mount.get_icon().props.names:
-            if icon_theme.has_icon(name):
-                volume_menu.set_image(Icon(icon_name=name,
-                                           icon_size=Gtk.IconSize.MENU))
-                break
+        volume_menu.set_image(Icon(icon_name=find_icon_name(mount),
+                                   icon_size=Gtk.IconSize.MENU))
         volume_menu.connect('volume-error', self.__volume_error_cb)
         self._menu.append(volume_menu)
         self._volumes[mount.get_root().get_path()] = volume_menu

--- a/src/jarabe/journal/volumestoolbar.py
+++ b/src/jarabe/journal/volumestoolbar.py
@@ -31,6 +31,7 @@ import json
 import tempfile
 import shutil
 
+from sugar3.graphics.icon import find_icon_name
 from sugar3.graphics.radiotoolbutton import RadioToolButton
 from sugar3.graphics.palette import Palette
 from sugar3.graphics.xocolor import XoColor
@@ -317,18 +318,7 @@ class VolumeButton(BaseButton):
         mount_point = mount.get_root().get_path()
         BaseButton.__init__(self, mount_point)
 
-        icon_name = None
-        icon_theme = Gtk.IconTheme.get_default()
-        for icon_name in mount.get_icon().props.names:
-            icon_info = icon_theme.lookup_icon(icon_name,
-                                               Gtk.IconSize.LARGE_TOOLBAR, 0)
-            if icon_info is not None:
-                break
-
-        if icon_name is None:
-            icon_name = 'drive'
-
-        self.props.icon_name = icon_name
+        self.props.icon_name = find_icon_name(mount)
 
         # TODO: retrieve the colors from the owner of the device
         client = GConf.Client.get_default()


### PR DESCRIPTION
Use the find_icon_name method instead of
repeating this search for volumes icons
names all over.

This patch solves the issue reported by
Suraj. Volumes with GFileIcon icons caused
Journal volumes toolbar, Journal copy-to
menu items and Frame device icon to break.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org

This change depends on https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/26
