### PR TITLE
Fix error when there is no locale defined

### DIFF
--- a/extensions/cpsection/modemconfiguration/model.py
+++ b/extensions/cpsection/modemconfiguration/model.py
@@ -281,7 +281,7 @@ class ServiceProviders(object):
         # Update status: countries, providers and plans
         self._countries = self._db.get_countries()
         country_idx = 0
-        if country_code:
+        if country_code is not None:
             country_idx = self._db.get_country_idx_by_code(country_code)
         self._current_country = country_idx
         self._providers = self._db.get_providers(self._current_country)
@@ -302,10 +302,10 @@ class ServiceProviders(object):
         """Return country based on locale lang attribute."""
         language_code = locale.getdefaultlocale()[0]
         if language_code is None:
-            country_code = ''
+            country_code = None
         else:
             lc_list = language_code.split('_')
-            country_code = lc_list[1].lower() if len(lc_list) >= 2 else ''
+            country_code = lc_list[1].lower() if len(lc_list) >= 2 else None
         return country_code
 
     def _get_initial_config(self):


### PR DESCRIPTION
It checks if language code is not defined and use default values in that case.
