### PR TITLE
Add missing attribute to info widget

### DIFF
--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -738,6 +738,7 @@ class MultiSelectEntriesInfoWidget(Gtk.ToolItem):
 
         self._box = Gtk.VBox()
         self._selected_entries = 0
+        self._total = 0
 
         self._label = Gtk.Label()
         self._box.pack_start(self._label, True, True, 0)


### PR DESCRIPTION
Add missing self._total attribute to
MultiSelectEntriesInfoWidget constructor.

Without it, the log keeps complaining about
this missing attribute.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
