### PR TITLE
Fix systemd check

### DIFF
--- a/src/jarabe/model/session.py
+++ b/src/jarabe/model/session.py
@@ -26,7 +26,7 @@ _session_manager = None
 
 
 def have_systemd():
-    return os.access("/run/systemd/seats", 0) >= 0
+    return os.access("/run/systemd/seats", os.F_OK)
 
 
 class SessionManager(session.SessionManager):


### PR DESCRIPTION
As mentioned in #4493 there is no need to check
for the >=0 condition.

Return os.access return value directly.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
