### PR TITLE
ShellModel: set is_main_window when home_activity is None - #4602

### DIFF
--- a/src/jarabe/model/shell.py
+++ b/src/jarabe/model/shell.py
@@ -584,6 +584,13 @@ class ShellModel(GObject.GObject):
                 color = self._shared_activities.get(activity_id, None)
                 home_activity = Activity(activity_info, activity_id,
                                          color, window)
+
+                # Check if window is the 'main' app window, not the
+                # launcher window.
+                is_main_window = window.get_window_type() != \
+                    Wnck.WindowType.SPLASHSCREEN and \
+                    home_activity.get_launch_status() == Activity.LAUNCHING
+
                 self._add_activity(home_activity)
 
             else:


### PR DESCRIPTION
In commit 58fa64 we forgot to set it in that case.  home_activity will
be None at least for the Journal.  The code in shell.py is not the
best, so we don't have another option than duplicating the code in
both parts of the conditional.

This fixes the Journal icon in the frame that was pulsing all the
time.
