### PR TITLE
Initialise the DBus mainloop explicitly

### DIFF
--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -35,6 +35,8 @@ reload(sys)
 sys.setdefaultencoding('utf-8')
 
 import gettext
+from dbus.mainloop.glib import DBusGMainLoop
+DBusGMainLoop(set_as_default=True)
 
 from gi.repository import Gio
 from gi.repository import GLib


### PR DESCRIPTION
So that asynchronous messages and signals can be used, python-dbus must
be initialised with a main loop. This currently happens because Sugar
imports the datastore module at some point during startup.

When working on some startup-time behaviour, this caught me out.
Trying to work with dbus before that import had happened resulted in
some really strange behaviour.

Make the DBus mainloop assignment explicit to avoid this in future.

also see https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/32
