### PR TITLE
Use focus-in/out events to set the visibility in the journal - SL# 4604

### DIFF
--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -155,14 +155,12 @@ class JournalActivity(JournalWindow):
         self._setup_main_view()
         self._setup_secondary_view()
 
-        self.add_events(Gdk.EventMask.ALL_EVENTS_MASK |
-                        Gdk.EventMask.VISIBILITY_NOTIFY_MASK)
+        self.add_events(Gdk.EventMask.ALL_EVENTS_MASK)
         self._realized_sid = self.connect('realize', self.__realize_cb)
-        self.connect('visibility-notify-event',
-                     self.__visibility_notify_event_cb)
         self.connect('window-state-event', self.__window_state_event_cb)
         self.connect('key-press-event', self._key_press_event_cb)
         self.connect('focus-in-event', self._focus_in_event_cb)
+        self.connect('focus-out-event', self._focus_out_event_cb)
 
         model.created.connect(self.__model_created_cb)
         model.updated.connect(self.__model_updated_cb)
@@ -351,7 +349,10 @@ class JournalActivity(JournalWindow):
             self.show_main_view()
 
     def _focus_in_event_cb(self, window, event):
-        self._list_view.update_dates()
+        self._list_view.set_is_visible(True)
+
+    def _focus_out_event_cb(self, window, event):
+        self._list_view.set_is_visible(False)
 
     def __window_state_event_cb(self, window, event):
         logging.debug('window_state_event_cb %r', self)
@@ -359,11 +360,6 @@ class JournalActivity(JournalWindow):
             state = event.new_window_state
             visible = not state & Gdk.WindowState.ICONIFIED
             self._list_view.set_is_visible(visible)
-
-    def __visibility_notify_event_cb(self, window, event):
-        logging.debug('visibility_notify_event_cb %r', self)
-        visible = event.get_state() != Gdk.VisibilityState.FULLY_OBSCURED
-        self._list_view.set_is_visible(visible)
 
     def _check_available_space(self):
         """Check available space on device


### PR DESCRIPTION
The callback method of the signal 'visibility-notify-event' receive
event.get_state() == None in the case of changing from the Journal to
another activity, but not when changing to other views using F1, F2, F3.
Use focus-in/focus-out events to set the visibility of the listview,
because this works with realibility. Fixes #4604

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
