### PR TITLE
Move debug file creation to the sugar script

### DIFF
--- a/bin/sugar.in
+++ b/bin/sugar.in
@@ -46,8 +46,34 @@ export MC_ACCOUNT_DIR=$HOME/.sugar/$SUGAR_PROFILE/accounts
 if [ -f ~/.i18n ]; then
         . ~/.i18n
 fi
-if [ -f $SUGAR_HOME/$SUGAR_PROFILE/debug ]; then
-        . $SUGAR_HOME/$SUGAR_PROFILE/debug
+
+profile_dir=$SUGAR_HOME/$SUGAR_PROFILE
+debug_file_path=$profile_dir/debug
+
+if [ -f $debug_file_path ]; then
+    . $debug_file_path
+else
+mkdir -p $profile_dir
+cat > $debug_file_path << EOF
+# Uncomment the following lines to turn on many sugar debugging
+# log files and features.
+
+#export LM_DEBUG=net
+#export GABBLE_DEBUG=all
+#export GABBLE_LOGFILE=$HOME/.sugar/$SUGAR_PROFILE/logs/telepathy-gabble.log
+#export SALUT_DEBUG=all
+#export SALUT_LOGFILE=$HOME/.sugar/$SUGAR_PROFILE/logs/telepathy-salut.log
+#export GIBBER_DEBUG=all
+#export WOCKY_DEBUG=all
+#export MC_LOGFILE='$HOME/.sugar/$SUGAR_PROFILE/logs/mission-control.log
+#export MC_DEBUG=all
+#export PRESENCESERVICE_DEBUG=1
+#export SUGAR_LOGGER_LEVEL=debug
+
+# Uncomment the following line to enable core dumps
+
+#ulimit -c unlimited
+EOF
 fi
 
 exec python -m jarabe.main

--- a/src/jarabe/intro/__init__.py
+++ b/src/jarabe/intro/__init__.py
@@ -7,9 +7,6 @@ from sugar3.profile import get_profile
 def check_profile():
     profile = get_profile()
 
-    if not os.path.exists(env.get_profile_path()):
-        profile.create_debug_file()
-
     path = os.path.join(env.get_profile_path(), 'config')
     if os.path.exists(path):
         profile.convert_profile()


### PR DESCRIPTION
It needs to happen as early as possible and it's more
readable in a shell script then in python code.
