### PR TITLE
Enable use of proxy in updater - SL #4630

### DIFF
--- a/src/jarabe/util/downloader.py
+++ b/src/jarabe/util/downloader.py
@@ -42,6 +42,7 @@ def get_soup_session():
         _session.set_property("timeout", 60)
         _session.set_property("idle-timeout", 60)
         _session.set_property("user-agent", "Sugar/%s" % config.version)
+        _session.add_feature_by_type(Soup.ProxyResolverDefault)
     return _session
 
 


### PR DESCRIPTION
As documented here [1](See Session features), the proxy resolver
is a optional feature and need be added to the session.
Fixes 4630

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org

[1] https://developer.gnome.org/libsoup/stable/libsoup-client-howto.html
