### PR TITLE
Use python2 shebang

### DIFF
--- a/bin/sugar-control-panel
+++ b/bin/sugar-control-panel
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (C) 2008, Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/bin/sugar-install-bundle
+++ b/bin/sugar-install-bundle
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 
 from sugar3.bundle.activitybundle import ActivityBundle

--- a/bin/sugar-launch
+++ b/bin/sugar-launch
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2007, Red Hat, Inc.
 #

--- a/bin/sugar.in
+++ b/bin/sugar.in
@@ -76,4 +76,4 @@ cat > $debug_file_path << EOF
 EOF
 fi
 
-exec python -m jarabe.main
+exec python2 -m jarabe.main

--- a/data/em.py
+++ b/data/em.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # $Id: //projects/empy/em.py#146 $ $Date: 2003/10/27 $
 

--- a/tests/extensions/webservice/mock/account.py
+++ b/tests/extensions/webservice/mock/account.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (c) 2013 Walter Bender
 
 #Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Some distributions have switched to python3 as default and our code
breaks because it's python2 specific. Follow the PEP 394
recommendation.
