### PR TITLE
Force python2 on configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,7 @@ AM_INIT_AUTOMAKE([1.9 foreign dist-xz no-dist-gzip])
 
 AM_MAINTAINER_MODE
 
+PYTHON=python2
 AM_PATH_PYTHON
 
 PKG_CHECK_MODULES(SHELL, gtk+-3.0 gconf-2.0)


### PR DESCRIPTION
Otherwise systems that default to python3 will install
the modules in the python3 site-package. We already
doing this in sugar-toolkit-gtk3 and sugar-datastore.
