### PR TITLE
Set favoritesview icons fill_color to white instead of transparent

### DIFF
--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -452,7 +452,7 @@ class ActivityIcon(CanvasIcon):
         self.palette = None
         if not self._resume_mode or not self._journal_entries:
             xo_color = XoColor('%s,%s' % (style.COLOR_BUTTON_GREY.get_svg(),
-                                          style.COLOR_TRANSPARENT.get_svg()))
+                                          style.COLOR_WHITE.get_svg()))
         else:
             xo_color = misc.get_icon_color(self._journal_entries[0])
         self.props.xo_color = xo_color
@@ -535,7 +535,7 @@ class FavoritePalette(ActivityPalette):
 
         if not journal_entries:
             xo_color = XoColor('%s,%s' % (style.COLOR_BUTTON_GREY.get_svg(),
-                                          style.COLOR_TRANSPARENT.get_svg()))
+                                          style.COLOR_WHITE.get_svg()))
         else:
             xo_color = misc.get_icon_color(journal_entries[0])
 


### PR DESCRIPTION
If an activity has not an instance in the journal, its icon fill color
is set to white.

This change improve visibility when user select a background image

Signed-off-by: Agustin Zubiaga aguz@sugarlabs.org
