### PR TITLE
Avoid race condition in background

### DIFF
--- a/extensions/cpsection/background/view.py
+++ b/extensions/cpsection/background/view.py
@@ -36,6 +36,7 @@ class Background(SectionView):
         SectionView.__init__(self)
 
         self._model = model
+        self._images_loaded = False
 
         self.connect('realize', self.__realize_cb)
 
@@ -129,10 +130,16 @@ class Background(SectionView):
             GObject.idle_add(self._append_to_store, file_paths)
         else:
             self._select_background()
-            self.get_window().set_cursor(None)
+            self._images_loaded = True
+            window = self.get_window()
+            if window is not None:
+                window.set_cursor(None)
 
     def __realize_cb(self, widget):
-        self.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
+        if self._images_loaded:
+            self.get_window().set_cursor(None)
+        else:
+            self.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
 
     def _set_alpha_cb(self, widget, value):
         self._model.set_background_alpha_level(value)


### PR DESCRIPTION
If the image loading finish before the window is realized, the cursor is set to None

Signed-off-by: Agustin Zubiaga aguz@sugarlabs.org
