### PR TITLE
Journal: index in the UI of batch operations should start on 1

### DIFF
--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -593,7 +593,7 @@ class BatchOperator(GObject.GObject):
             if title is None or title == '':
                 title = _('Untitled')
             alert_message = _('%(index)d of %(total)d : %(object_title)s') % {
-                'index': self._object_index,
+                'index': self._object_index + 1,
                 'total': len(self._uid_list),
                 'object_title': title}
 


### PR DESCRIPTION
When copy or delete multiple files, the message in the UI should start
"1 of N", and not "0 of N"

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
