### PR TITLE
Avoid switch to the Journal or change views when control panel is opened...

### DIFF
--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -30,6 +30,7 @@ from jarabe.model.session import get_session_manager
 from jarabe.controlpanel.toolbar import MainToolbar
 from jarabe.controlpanel.toolbar import SectionToolbar
 from jarabe import config
+from jarabe.view.keyhandler import set_control_panel_opened
 
 POWERD_FLAG_DIR = '/etc/powerd/flags'
 
@@ -88,6 +89,9 @@ class ControlPanel(Gtk.Window):
     def __realize_cb(self, widget):
         self.set_type_hint(Gdk.WindowTypeHint.DIALOG)
         self.get_window().set_accept_focus(True)
+
+        # Notify to the key handler the control panel is opened.
+        set_control_panel_opened(True)
 
     def __size_changed_cb(self, event):
         self._calculate_max_columns()
@@ -367,6 +371,8 @@ class ControlPanel(Gtk.Window):
         self._update(query)
 
     def __stop_clicked_cb(self, widget):
+        # Notify to the key handler the control panel is closed.
+        set_control_panel_opened(False)
         self.destroy()
 
     def __close_request_cb(self, widget, event=None):

--- a/src/jarabe/view/keyhandler.py
+++ b/src/jarabe/view/keyhandler.py
@@ -71,6 +71,7 @@ class KeyHandler(object):
         self._key_pressed = None
         self._keycode_pressed = 0
         self._keystate_pressed = 0
+        self._control_panel_opened = False
 
         self._key_grabber = SugarExt.KeyGrabber()
         self._key_grabber.connect('key-pressed',
@@ -168,6 +169,12 @@ class KeyHandler(object):
             self._keycode_pressed = keycode
             self._keystate_pressed = state
 
+            # avoid switch to the Journal or change views if the control panel
+            # is opened http://bugs.sugarlabs.org/ticket/4601
+            if key in ('F1', 'F2', 'F3', 'F4', 'F5', 'F6') and \
+                    self._control_panel_opened:
+                return
+
             action = _actions_table[key]
             if self._tabbing_handler.is_tabbing():
                 # Only accept window tabbing events, everything else
@@ -209,3 +216,12 @@ class KeyHandler(object):
 def setup(frame):
     global _instance
     _instance = KeyHandler(frame)
+
+
+def set_control_panel_opened(control_panel_opened):
+    """
+    The setup(frame) is already run at sugar-session startup.
+    So, we can safely assume the "_instance" is fully-grown up.
+    """
+
+    _instance._control_panel_opened = control_panel_opened


### PR DESCRIPTION
... - SL #4601

If the user switch to the Journal when the Control Panel is opened
using the hotkeys or the icon in the frame, when returns to the Home,
the Contro Panel window is not show, but is focused, then the Home is useless.
Trying to change views while the Control Panel is opened do not
have any effect, then is disabled.
This patch disable the keys F1 to F6 keys when the Control Panel is opened.

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
