### PR TITLE
Avoid switch to the Journal or change views when a modal window is opene...

### DIFF
--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -30,6 +30,7 @@ from jarabe.model.session import get_session_manager
 from jarabe.controlpanel.toolbar import MainToolbar
 from jarabe.controlpanel.toolbar import SectionToolbar
 from jarabe import config
+from jarabe.model import shell
 
 POWERD_FLAG_DIR = '/etc/powerd/flags'
 
@@ -88,6 +89,8 @@ class ControlPanel(Gtk.Window):
     def __realize_cb(self, widget):
         self.set_type_hint(Gdk.WindowTypeHint.DIALOG)
         self.get_window().set_accept_focus(True)
+        # the modal windows counter is updated to disable hot keys - SL#4601
+        shell.get_model().push_modal()
 
     def __size_changed_cb(self, event):
         self._calculate_max_columns()
@@ -367,6 +370,7 @@ class ControlPanel(Gtk.Window):
         self._update(query)
 
     def __stop_clicked_cb(self, widget):
+        shell.get_model().pop_modal()
         self.destroy()
 
     def __close_request_cb(self, widget, event=None):

--- a/src/jarabe/model/shell.py
+++ b/src/jarabe/model/shell.py
@@ -400,6 +400,7 @@ class ShellModel(GObject.GObject):
         self._active_activity = None
         self._tabbing_activity = None
         self._launchers = {}
+        self._modal_dialogs_counter = 0
 
         self._screen.toggle_showing_desktop(True)
 
@@ -711,6 +712,15 @@ class ShellModel(GObject.GObject):
                           activity_id)
             self.notify_launch_failed(activity_id)
         return False
+
+    def push_modal(self):
+        self._modal_dialogs_counter += 1
+
+    def pop_modal(self):
+        self._modal_dialogs_counter -= 1
+
+    def has_modal(self):
+        return self._modal_dialogs_counter > 0
 
 
 def get_model():

--- a/src/jarabe/view/keyhandler.py
+++ b/src/jarabe/view/keyhandler.py
@@ -61,6 +61,8 @@ _actions_table = {
     '<alt><shift>q': 'logout'
 }
 
+# These keys will not be trigger a action if a modal dialog is opened
+_non_modal_action_keys = ('F1', 'F2', 'F3', 'F4', 'F5', 'F6')
 
 _instance = None
 
@@ -167,6 +169,14 @@ class KeyHandler(object):
             self._key_pressed = key
             self._keycode_pressed = keycode
             self._keystate_pressed = state
+
+            # avoid switch to the Journal or change views if a modal dialog
+            # is opened http://bugs.sugarlabs.org/ticket/4601
+            if key in _non_modal_action_keys and \
+                    shell.get_model().has_modal():
+                logging.debug(
+                    'Key %s action stopped due to modal dialog open', key)
+                return
 
             action = _actions_table[key]
             if self._tabbing_handler.is_tabbing():


### PR DESCRIPTION
...d - SL #4601

If the user switch to the Journal when the Control Panel is opened
using the hotkeys or the icon in the frame, when returns to the Home,
the Contro Panel window is not show, but is focused, then the Home is useless.
Trying to change views while the Control Panel is opened do not
have any effect, then is disabled.

This patch disable the keys F1 to F6 keys when the Control Panel is opened.

Fixes - SL #4601

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
