### PR TITLE
Avoid popup the palette while a dragging in the Journal - SL #3999

### DIFF
--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -606,6 +606,9 @@ class ListView(BaseListView):
         column.pack_start(cell_detail, True)
         self.tree_view.append_column(column)
 
+    def is_dragging(self):
+        return self._is_dragging
+
     def __drag_begin_cb(self, widget, drag_context):
         self._is_dragging = True
 
@@ -720,6 +723,9 @@ class CellRendererActivityIcon(CellRendererIcon):
 
     def create_palette(self):
         if not self._show_palette:
+            return None
+
+        if self._journalactivity.get_list_view().is_dragging():
             return None
 
         tree_model = self.tree_view.get_model()

--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -197,6 +197,12 @@ class ObjectPalette(Palette):
         filetransfer.start_transfer(buddy, file_name, title, description,
                                     mime_type)
 
+    def popup(self, immediate=False, state=None):
+        if self._journalactivity.get_list_view().is_dragging():
+            return
+
+        Palette.popup(self, immediate)
+
 
 class CopyMenu(Gtk.Menu):
     __gtype_name__ = 'JournalCopyMenu'


### PR DESCRIPTION
This is was a pending issue. See more information in the ticket
Note than drag and drop is allowed only with the mouse, not with touch.
Fixes #3999.

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
