### PR TITLE
Set limit to open activities and open instances

### DIFF
--- a/src/jarabe/journal/misc.py
+++ b/src/jarabe/journal/misc.py
@@ -222,6 +222,8 @@ def resume(metadata, bundle_id=None, force_bundle_downgrade=False):
 
 def launch(bundle, activity_id=None, object_id=None, uri=None, color=None,
            invited=False):
+    shell_model = shell.get_model()
+
     if activity_id is None or not activity_id:
         activity_id = activityfactory.create_activity_id()
 
@@ -239,11 +241,16 @@ def launch(bundle, activity_id=None, object_id=None, uri=None, color=None,
         bundle = activities[0]
         logging.debug('Launching content bundle with uri %s', uri)
 
-    shell_model = shell.get_model()
     activity = shell_model.get_activity_by_id(activity_id)
     if activity is not None:
         logging.debug('re-launch %r', activity.get_window())
         activity.get_window().activate(Gtk.get_current_event_time())
+        return
+
+    if shell_model.reached_maximum_number_of_open_activities():
+        return
+
+    if shell_model.more_than_one_open_instance(bundle):
         return
 
     if color is None:

--- a/src/jarabe/view/launcher.py
+++ b/src/jarabe/view/launcher.py
@@ -120,6 +120,9 @@ def setup():
 def add_launcher(activity_id, icon_path, icon_color):
     model = shell.get_model()
 
+    if model.reached_maximum_number_of_open_activities():
+        return
+
     if model.get_launcher(activity_id) is not None:
         return
 


### PR DESCRIPTION
At the request of OLPC AU [1](in an effort to reduce OOM freezes)
this patch uses gconf to set a maximum number of open activities
[2]. An alert is shown if the user tries to launch more activities
than the maximum asking them to close an activity before opening a new
one. If maximum_number_of_open_activites is not set or == 0, then
there is no maximum limit applied.

Further, Some activities don't behave well if more than one instance
is open (e.g., SL #4554). This patch sets a limit on the number open
instances of an activity based on a new field in activity.info:
one_open_instance.

If and only if the maximum_instances field is present in
activity.info, is it used to set the limit of open instances.

NOTE: there is a patch to activitybundle.py in the toolkit necessary
for this patch to be used.

[1] http://wiki.sugarlabs.org/go/Features/Launch_Limits
[2] /desktop/sugar/maximum_number_of_open_activities
