### PR TITLE
Add a gconf option to show/hide the Register option - SL #4640

### DIFF
--- a/data/sugar.schemas.in
+++ b/data/sugar.schemas.in
@@ -216,6 +216,18 @@
     </schema>
 
     <schema>
+      <key>/schemas/desktop/sugar/show_register</key>
+      <applyto>/desktop/sugar/show_register</applyto>
+      <owner>sugar</owner>
+      <type>bool</type>
+      <default>true</default>
+      <locale name="C">
+        <short>Show Register</short>
+        <long>If TRUE, Sugar will show a "Register" option in the buddy palette.</long>
+      </locale>
+    </schema>
+
+    <schema>
       <key>/schemas/desktop/sugar/peripherals/keyboard/layouts</key>
       <applyto>/desktop/sugar/peripherals/keyboard/layouts</applyto>
       <owner>sugar</owner>

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -649,18 +649,20 @@ class OwnerIcon(BuddyIcon):
         palette = BuddyMenu(get_owner_instance())
 
         client = GConf.Client.get_default()
-        backup_url = client.get_string('/desktop/sugar/backup_url')
+        if client.get_bool('/desktop/sugar/show_register'):
+            backup_url = client.get_string('/desktop/sugar/backup_url')
 
-        if not backup_url:
-            self._register_menu = PaletteMenuItem(_('Register'),
-                                                  'media-record')
-        else:
-            self._register_menu = PaletteMenuItem(_('Register again'),
-                                                  'media-record')
+            if not backup_url:
+                self._register_menu = PaletteMenuItem(_('Register'),
+                                                      'media-record')
+            else:
+                self._register_menu = PaletteMenuItem(_('Register again'),
+                                                      'media-record')
 
-        self._register_menu.connect('activate', self.__register_activate_cb)
-        palette.menu_box.pack_end(self._register_menu, True, True, 0)
-        self._register_menu.show()
+            self._register_menu.connect('activate',
+                                        self.__register_activate_cb)
+            palette.menu_box.pack_end(self._register_menu, True, True, 0)
+            self._register_menu.show()
 
         self.connect_to_palette_pop_events(palette)
 


### PR DESCRIPTION
In deplpoyments where a school server is not available,
the Register menu o nothing and confuse to the users.

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
