### PR TITLE
Do not update the journal when in the detail view - SL #4658

### DIFF
--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -400,10 +400,12 @@ class BaseListView(Gtk.Bin):
         logging.debug('ListView.__map_cb %r', self._scroll_position)
         self.tree_view.props.vadjustment.props.value = self._scroll_position
         self.tree_view.props.vadjustment.value_changed()
+        self.set_is_visible(True)
 
     def __unrealize_cb(self, widget):
         self._scroll_position = self.tree_view.props.vadjustment.props.value
-        logging.debug('ListView.__map_cb %r', self._scroll_position)
+        self.set_is_visible(False)
+        logging.debug('ListView.__unrealize_cb %r', self._scroll_position)
 
     def _is_query_empty(self):
         # FIXME: This is a hack, we shouldn't have to update this every time


### PR DESCRIPTION
If the user modify the object metadata, by editing a field,
or toggle the star, the journal should not change to the list view.

Fixes #4658

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
