### PR TITLE
remove OLPC specific code from sugar-control-panel

### DIFF
--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -32,8 +32,6 @@ from jarabe.controlpanel.toolbar import SectionToolbar
 from jarabe import config
 from jarabe.model import shell
 
-POWERD_FLAG_DIR = '/etc/powerd/flags'
-
 _logger = logging.getLogger('ControlPanel')
 
 
@@ -153,10 +151,6 @@ class ControlPanel(Gtk.Window):
                                    self.__search_changed_cb)
 
     def _setup_options(self):
-        if not os.access(POWERD_FLAG_DIR, os.W_OK):
-            del self._options['power']
-            del self._options['keyboard']
-
         # If the screen width only supports two columns, start
         # placing from the second row.
         if self._max_columns == 2:


### PR DESCRIPTION
This tests out fine on SoaS-F20-5 installed to harddisk, but powerd is now shown also. What is needed is the change to the sugar.spec file noted in http://lists.sugarlabs.org/archive/soas/2013-November/002579.html
