### PR TITLE
Shows path instead of activity name in Title bar. Fixes #3073

### DIFF
--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -461,7 +461,7 @@ class Toolbar(Gtk.Toolbar):
             sugar_button.show()
             self._add_separator()
 
-        self.activity_title_text = _('View source: %s') % title
+        self.activity_title_text = _('View source: %s') % bundle_path
         self.sugar_toolkit_title_text = _('View source: %r') % 'Sugar Toolkit'
         self.label = Gtk.Label()
         self.label.set_markup('<b>%s</b>' % self.activity_title_text)


### PR DESCRIPTION
The path contains the activity name too. So, displaying path instead of activity name preserves the name and displays the path as well.

Fixes #3073
