### PR TITLE
Set limit to open activities and open instances

### DIFF
--- a/src/jarabe/desktop/activitieslist.py
+++ b/src/jarabe/desktop/activitieslist.py
@@ -166,7 +166,8 @@ class ActivitiesTreeView(Gtk.TreeView):
         registry = bundleregistry.get_registry()
         bundle = registry.get_bundle(row[self._model.column_bundle_id])
 
-        misc.launch(bundle)
+        if misc.is_safe_to_launch(bundle.get_bundle_id()):
+            misc.launch(bundle)
 
     def set_filter(self, query):
         """Set a new query and refilter the model, return the number

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -486,7 +486,9 @@ class ActivityIcon(CanvasIcon):
     def _resume(self, journal_entry):
         if not journal_entry['activity_id']:
             journal_entry['activity_id'] = activityfactory.create_activity_id()
-        misc.resume(journal_entry, self._activity_info.get_bundle_id())
+        bundle_id = self._activity_info.get_bundle_id()
+        if misc.is_safe_to_launch(bundle_id, metadata=journal_entry):
+            misc.resume(journal_entry, bundle_id)
 
     def _activate(self):
         if self.palette is not None:
@@ -495,7 +497,8 @@ class ActivityIcon(CanvasIcon):
         if self._resume_mode and self._journal_entries:
             self._resume(self._journal_entries[0])
         else:
-            misc.launch(self._activity_info)
+            if misc.is_safe_to_launch(self._activity_info.get_bundle_id()):
+                misc.launch(self._activity_info)
 
     def get_bundle_id(self):
         return self._activity_info.get_bundle_id()

--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -97,8 +97,16 @@ class HomeWindow(Gtk.Window):
         self._transition_box.connect('completed',
                                      self._transition_completed_cb)
 
-        shell.get_model().zoom_level_changed.connect(
-            self.__zoom_level_changed_cb)
+        shell_model = shell.get_model()
+        shell_model.set_default_alert_window(self)
+        shell_model.zoom_level_changed.connect(self.__zoom_level_changed_cb)
+
+    def add_alert(self, alert):
+        self._box.pack_start(alert, False, True, 0)
+        self._box.reorder_child(alert, 1)
+
+    def remove_alert(self, alert):
+        self._box.remove(alert)
 
     def _deactivate_view(self, level):
         group = palettegroup.get_group('default')

--- a/src/jarabe/desktop/meshbox.py
+++ b/src/jarabe/desktop/meshbox.py
@@ -101,8 +101,9 @@ class _ActivityIcon(CanvasIcon):
 
     def __palette_item_clicked_cb(self, item):
         bundle = self._model.get_bundle()
-        misc.launch(bundle, activity_id=self._model.activity_id,
-                    color=self._model.get_color())
+        if misc.is_safe_to_launch(bundle.get_bundle_id()):
+            misc.launch(bundle, activity_id=self._model.activity_id,
+                        color=self._model.get_color())
 
 
 class ActivityView(SnowflakeLayout):

--- a/src/jarabe/frame/clipboardmenu.py
+++ b/src/jarabe/frame/clipboardmenu.py
@@ -158,7 +158,10 @@ class ClipboardMenu(Palette):
         if percent < 100 or menu_item.get_submenu() is not None:
             return
         jobject = self._copy_to_journal()
-        misc.resume(jobject.metadata, self._get_activities()[0])
+        if misc.is_safe_to_launch(
+                misc.get_bundle_id_from_metadata(jobject.metadata),
+                metadata=jobject.metadata):
+            misc.resume(jobject.metadata, self._get_activities()[0])
         jobject.destroy()
 
     def _open_submenu_item_activate_cb(self, menu_item, service_name):
@@ -167,7 +170,10 @@ class ClipboardMenu(Palette):
         if percent < 100:
             return
         jobject = self._copy_to_journal()
-        misc.resume(jobject.metadata, service_name)
+        if misc.is_safe_to_launch(
+                misc.get_bundle_id_from_metadata(jobject.metadata),
+                metadata=jobject.metadata):
+            misc.resume(jobject.metadata, service_name)
         jobject.destroy()
 
     def _remove_item_activate_cb(self, menu_item):

--- a/src/jarabe/journal/expandedentry.py
+++ b/src/jarabe/journal/expandedentry.py
@@ -539,10 +539,18 @@ class ExpandedEntry(Gtk.EventBox):
 
     def _icon_button_release_event_cb(self, button, event):
         logging.debug('_icon_button_release_event_cb')
-        misc.resume(self._metadata)
+        if misc.is_safe_to_launch(
+                misc.get_bundle_id_from_metadata(self._metadata),
+                metadata=self._metadata,
+                alert_window=journalwindow.get_journal_window()):
+            misc.resume(self._metadata)
         return True
 
     def _preview_box_button_release_event_cb(self, button, event):
         logging.debug('_preview_box_button_release_event_cb')
-        misc.resume(self._metadata)
+        if misc.is_safe_to_launch(
+                misc.get_bundle_id_from_metadata(self._metadata),
+                metadata=self._metadata,
+                alert_window=journalwindow.get_journal_window()):
+            misc.resume(self._metadata)
         return True

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -453,7 +453,11 @@ class DetailToolbox(ToolbarBox):
         self._refresh_resume_palette()
 
     def _resume_clicked_cb(self, button):
-        misc.resume(self._metadata)
+        if misc.is_safe_to_launch(
+                misc.get_bundle_id_from_metadata(self._metadata),
+                metadata=self._metadata,
+                alert_window=journalwindow.get_journal_window()):
+            misc.resume(self._metadata)
 
     def _copy_clicked_cb(self, button):
         button.palette.popup(immediate=True, state=Palette.SECONDARY)
@@ -496,7 +500,11 @@ class DetailToolbox(ToolbarBox):
             model.delete(self._metadata['uid'])
 
     def _resume_menu_item_activate_cb(self, menu_item, service_name):
-        misc.resume(self._metadata, service_name)
+        if misc.is_safe_to_launch(
+                misc.get_bundle_id_from_metadata(self._metadata),
+                metadata=self._metadata,
+                alert_window=journalwindow.get_journal_window()):
+            misc.resume(self._metadata, service_name)
 
     def _refresh_copy_palette(self):
         palette = self._copy.get_palette()

--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -34,6 +34,7 @@ from jarabe.journal.listmodel import ListModel
 from jarabe.journal.palettes import ObjectPalette, BuddyPalette
 from jarabe.journal import model
 from jarabe.journal import misc
+from jarabe.journal import journalwindow
 
 
 UPDATE_INTERVAL = 300
@@ -651,7 +652,11 @@ class ListView(BaseListView):
     def __icon_clicked_cb(self, cell, path):
         row = self.tree_view.get_model()[path]
         metadata = model.get(row[ListModel.COLUMN_UID])
-        misc.resume(metadata)
+        if misc.is_safe_to_launch(
+                misc.get_bundle_id_from_metadata(metadata),
+                metadata=metadata,
+                alert_window=journalwindow.get_journal_window()):
+            misc.resume(metadata)
 
     def __cell_title_edited_cb(self, cell, path, new_text):
         row = self._model[path]

--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -138,7 +138,11 @@ class ObjectPalette(Palette):
         return [self._metadata['uid']]
 
     def __start_activate_cb(self, menu_item):
-        misc.resume(self._metadata)
+        if misc.is_safe_to_launch(
+                misc.get_bundle_id_from_metadata(self._metadata),
+                metadata=self._metadata,
+                alert_window=journalwindow.get_journal_window()):
+            misc.resume(self._metadata)
 
     def __duplicate_activate_cb(self, menu_item):
         try:
@@ -502,7 +506,11 @@ class StartWithMenu(Gtk.Menu):
         if mime_type:
             mime_registry = mimeregistry.get_registry()
             mime_registry.set_default_activity(mime_type, service_name)
-        misc.resume(self._metadata, service_name)
+        if misc.is_safe_to_launch(
+                misc.get_bundle_id_from_metadata(self._metadata),
+                metadata=self._metadata,
+                alert_window=journalwindow.get_journal_window()):
+            misc.resume(self._metadata, service_name)
 
 
 class BuddyPalette(Palette):

--- a/src/jarabe/model/invites.py
+++ b/src/jarabe/model/invites.py
@@ -114,8 +114,9 @@ class ActivityInvite(BaseInvite):
 
         model = neighborhood.get_model()
         activity_id = model.get_activity_by_room(self._handle).activity_id
-        misc.launch(bundle, color=self.get_color(), invited=True,
-                    activity_id=activity_id)
+        if misc.is_safe_to_launch(bundle_id):
+            misc.launch(bundle, color=self.get_color(), invited=True,
+                        activity_id=activity_id)
 
 
 class PrivateInvite(BaseInvite):
@@ -140,8 +141,9 @@ class PrivateInvite(BaseInvite):
                                 'NameOwnerChanged',
                                 'org.freedesktop.DBus',
                                 arg0=self._handler)
-        misc.launch(bundle, color=self.get_color(), invited=True,
-                    uri=self._private_channel)
+        if misc.is_safe_to_launch(bundle_id):
+            misc.launch(bundle, color=self.get_color(), invited=True,
+                        uri=self._private_channel)
 
 
 class Invites(GObject.GObject):

--- a/src/jarabe/view/Makefile.am
+++ b/src/jarabe/view/Makefile.am
@@ -1,6 +1,7 @@
 sugardir = $(pythondir)/jarabe/view
 sugar_PYTHON =				\
 	__init__.py			\
+	alerts.py			\
 	buddyicon.py			\
 	buddymenu.py			\
 	cursortracker.py		\

--- a/src/jarabe/view/alerts.py
+++ b/src/jarabe/view/alerts.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2013 Sugar Labs
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+import logging
+from gettext import gettext as _
+
+from sugar3.graphics.alert import ErrorAlert
+
+
+class BaseErrorAlert(ErrorAlert):
+
+    def __init__(self, title, message):
+        ErrorAlert.__init__(self)
+
+        logging.error('%s: %s' % (title, message))
+        self.props.title = title
+        self.props.msg = message
+
+
+class OpenInstanceAlert(BaseErrorAlert):
+
+    def __init__(self, name):
+        BaseErrorAlert.__init__(
+            self,
+            _('Activity launcher'),
+            _('%s is already running. \
+Please stop %s before launching it again.' % (name, name)))
+
+
+class MaximumInstancesAlert(BaseErrorAlert):
+
+    def __init__(self):
+        BaseErrorAlert.__init__(
+            self,
+            _('Activity launcher'),
+            _('The maximum number of open activities has been reached. \
+Please close an activity before launching a new one.'))
+
+
+def _alert_response_cb(alert, response_id, window):
+    window.remove_alert(alert)
+
+
+def open_instance(window, activity_name):
+    alert = OpenInstanceAlert(activity_name)
+    alert.connect('response', _alert_response_cb, window)
+    window.add_alert(alert)
+    alert.show()
+
+
+def maximum_instances(window):
+    alert = MaximumInstancesAlert()
+    alert.connect('response', _alert_response_cb, window)
+    window.add_alert(alert)
+    alert.show()

--- a/src/jarabe/view/palettes.py
+++ b/src/jarabe/view/palettes.py
@@ -162,7 +162,8 @@ class ActivityPalette(Palette):
         # TODO: start-with
 
     def __start_activate_cb(self, menu_item):
-        misc.launch(self._activity_info)
+        if misc.is_safe_to_launch(self._activity_info.get_bundle_id()):
+            misc.launch(self._activity_info)
 
 
 class JournalPalette(BasePalette):


### PR DESCRIPTION
At the request of OLPC AU (in an effort to reduce OOM freezes) this
patch uses gconf to set a maximum number of open activities [1]. An
alert is shown if the user tries to launch more activities than the
maximum asking them to close an activity before opening a new one. If
maximum_number_of_open_activites is not set or == 0, then there is no
maximum limit applied.

Further, Some activities don't behave well if more than one instance
is open (e.g., SL #4554). This patch sets a limit on the number open
instances of an activity based on a new field in activity.info:
single_instance.

If and only if single_instance = yes in activity.info, is it used to
limit open instances to a single instance.

NOTE: there is a patch to activitybundle.py in the toolkit necessary
for this patch to be used.

[1] /desktop/sugar/maximum_number_of_open_activities
