### PR TITLE
Set limit to open activities and open instances

### DIFF
--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -495,7 +495,8 @@ class ActivityIcon(CanvasIcon):
         if self._resume_mode and self._journal_entries:
             self._resume(self._journal_entries[0])
         else:
-            misc.launch(self._activity_info)
+            misc.launch(self._activity_info,
+                        metadata=self._journal_entries[0])
 
     def get_bundle_id(self):
         return self._activity_info.get_bundle_id()

--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -100,6 +100,13 @@ class HomeWindow(Gtk.Window):
         shell.get_model().zoom_level_changed.connect(
             self.__zoom_level_changed_cb)
 
+    def add_alert(self, alert):
+        self._box.pack_start(alert, False, True, 0)
+        self._box.reorder_child(alert, 1)
+
+    def remove_alert(self, alert):
+        self._box.remove(alert)
+
     def _deactivate_view(self, level):
         group = palettegroup.get_group('default')
         group.popdown()

--- a/src/jarabe/journal/expandedentry.py
+++ b/src/jarabe/journal/expandedentry.py
@@ -539,10 +539,12 @@ class ExpandedEntry(Gtk.EventBox):
 
     def _icon_button_release_event_cb(self, button, event):
         logging.debug('_icon_button_release_event_cb')
-        misc.resume(self._metadata)
+        misc.resume(self._metadata,
+                    alert_window=journalwindow.get_journal_window())
         return True
 
     def _preview_box_button_release_event_cb(self, button, event):
         logging.debug('_preview_box_button_release_event_cb')
-        misc.resume(self._metadata)
+        misc.resume(self._metadata,
+                    alert_window=journalwindow.get_journal_window())
         return True

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -453,7 +453,8 @@ class DetailToolbox(ToolbarBox):
         self._refresh_resume_palette()
 
     def _resume_clicked_cb(self, button):
-        misc.resume(self._metadata)
+        misc.resume(self._metadata,
+                    alert_window=journalwindow.get_journal_window())
 
     def _copy_clicked_cb(self, button):
         button.palette.popup(immediate=True, state=Palette.SECONDARY)
@@ -496,7 +497,8 @@ class DetailToolbox(ToolbarBox):
             model.delete(self._metadata['uid'])
 
     def _resume_menu_item_activate_cb(self, menu_item, service_name):
-        misc.resume(self._metadata, service_name)
+        misc.resume(self._metadata,
+                    alert_window=journalwindow.get_journal_window())
 
     def _refresh_copy_palette(self):
         palette = self._copy.get_palette()

--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -34,6 +34,7 @@ from jarabe.journal.listmodel import ListModel
 from jarabe.journal.palettes import ObjectPalette, BuddyPalette
 from jarabe.journal import model
 from jarabe.journal import misc
+from jarabe.journal import journalwindow
 
 
 UPDATE_INTERVAL = 300
@@ -651,7 +652,8 @@ class ListView(BaseListView):
     def __icon_clicked_cb(self, cell, path):
         row = self.tree_view.get_model()[path]
         metadata = model.get(row[ListModel.COLUMN_UID])
-        misc.resume(metadata)
+        misc.resume(metadata,
+                    alert_window=journalwindow.get_journal_window())
 
     def __cell_title_edited_cb(self, cell, path, new_text):
         row = self._model[path]

--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -138,7 +138,8 @@ class ObjectPalette(Palette):
         return [self._metadata['uid']]
 
     def __start_activate_cb(self, menu_item):
-        misc.resume(self._metadata)
+        misc.resume(self._metadata,
+                    alert_window=journalwindow.get_journal_window())
 
     def __duplicate_activate_cb(self, menu_item):
         try:
@@ -502,7 +503,8 @@ class StartWithMenu(Gtk.Menu):
         if mime_type:
             mime_registry = mimeregistry.get_registry()
             mime_registry.set_default_activity(mime_type, service_name)
-        misc.resume(self._metadata, service_name)
+        misc.resume(self._metadata, bundle_id=service_name,
+                    alert_window=journalwindow.get_journal_window())
 
 
 class BuddyPalette(Palette):

--- a/src/jarabe/model/shell.py
+++ b/src/jarabe/model/shell.py
@@ -193,6 +193,13 @@ class Activity(GObject.GObject):
         """
         return self._activity_id
 
+    def get_bundle_id(self):
+        """ Returns the activity's bundle id"""
+        if self._activity_info is None:
+            return None
+        else:
+            return self._activity_info.get_bundle_id()
+
     def get_xid(self):
         """Retrieve the X-windows ID of our root window"""
         if self._windows:
@@ -403,6 +410,10 @@ class ShellModel(GObject.GObject):
         self._modal_dialogs_counter = 0
 
         self._screen.toggle_showing_desktop(True)
+
+        client = GConf.Client.get_default()
+        self._maximum_open_activities = client.get_int(
+            '/desktop/sugar/maximum_number_of_open_activities')
 
     def get_launcher(self, activity_id):
         return self._launchers.get(str(activity_id))
@@ -645,6 +656,28 @@ class ShellModel(GObject.GObject):
             self._set_active_activity(act)
 
         self._update_zoom_level(window)
+
+    def get_name_from_bundle_id(self, bundle_id):
+        for activity in self._get_activities_with_window():
+            if activity.get_bundle_id() == bundle_id:
+                return activity.get_activity_name()
+        return ''
+
+    def can_launch_activity_instance(self, bundle):
+        if bundle.get_single_instance():
+            bundle_id = bundle.get_bundle_id()
+            for activity in self._get_activities_with_window():
+                if activity.get_bundle_id() == bundle_id:
+                    return False
+        return True
+
+    def can_launch_activity(self):
+        activities = self._get_activities_with_window()
+        if self._maximum_open_activities > 0 and \
+           len(activities) > self._maximum_open_activities:
+            return False
+        else:
+            return True
 
     def _add_activity(self, home_activity):
         self._activities.append(home_activity)

--- a/src/jarabe/view/Makefile.am
+++ b/src/jarabe/view/Makefile.am
@@ -1,6 +1,7 @@
 sugardir = $(pythondir)/jarabe/view
 sugar_PYTHON =				\
 	__init__.py			\
+	alerts.py			\
 	buddyicon.py			\
 	buddymenu.py			\
 	cursortracker.py		\

--- a/src/jarabe/view/alerts.py
+++ b/src/jarabe/view/alerts.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2013 Sugar Labs
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+import logging
+from gettext import gettext as _
+
+from sugar3.graphics.alert import ErrorAlert
+
+
+class BaseErrorAlert(ErrorAlert):
+
+    def __init__(self, title, message):
+        ErrorAlert.__init__(self)
+
+        logging.error('%s: %s' % (title, message))
+        self.props.title = title
+        self.props.msg = message
+
+
+class MultipleInstanceAlert(BaseErrorAlert):
+
+    def __init__(self, name):
+        BaseErrorAlert.__init__(
+            self,
+            _('Activity launcher'),
+            _('%s is already running. \
+Please stop %s before launching it again.' % (name, name)))
+
+
+class MaxOpenActivitiesAlert(BaseErrorAlert):
+
+    def __init__(self):
+        BaseErrorAlert.__init__(
+            self,
+            _('Activity launcher'),
+            _('The maximum number of open activities has been reached. \
+Please close an activity before launching a new one.'))
+
+
+def _alert_response_cb(alert, response_id, window):
+    window.remove_alert(alert)
+
+
+def show_multiple_instance_alert(window, activity_name):
+    alert = MultipleInstanceAlert(activity_name)
+    alert.connect('response', _alert_response_cb, window)
+    window.add_alert(alert)
+    alert.show()
+
+
+def show_max_open_activities_alert(window):
+    alert = MaxOpenActivitiesAlert()
+    alert.connect('response', _alert_response_cb, window)
+    window.add_alert(alert)
+    alert.show()


### PR DESCRIPTION
At the request of OLPC AU (in an effort to reduce OOM freezes) this
patch uses gconf to set a maximum number of open activities [1]. An
alert is shown if the user tries to launch more activities than the
maximum asking them to close an activity before opening a new one. If
maximum_number_of_open_activites is not set or == 0, then there is no
maximum limit applied.

Further, Some activities don't behave well if more than one instance
is open (e.g., SL #4554). This patch sets a limit on the number open
instances of an activity based on a new field in activity.info:
single_instance.

If and only if single_instance = yes in activity.info, is it used to
limit open instances to a single instance.

NOTE: there is a patch to activitybundle.py in the toolkit necessary
for this patch to be used.

[1] /desktop/sugar/maximum_number_of_open_activities
