### PR TITLE
Set limit to open activities and open instances

### DIFF
--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -100,6 +100,13 @@ class HomeWindow(Gtk.Window):
         shell.get_model().zoom_level_changed.connect(
             self.__zoom_level_changed_cb)
 
+    def add_alert(self, alert):
+        self._box.pack_start(alert, False, True, 0)
+        self._box.reorder_child(alert, 1)
+
+    def remove_alert(self, alert):
+        self._box.remove(alert)
+
     def _deactivate_view(self, level):
         group = palettegroup.get_group('default')
         group.popdown()

--- a/src/jarabe/journal/expandedentry.py
+++ b/src/jarabe/journal/expandedentry.py
@@ -539,10 +539,12 @@ class ExpandedEntry(Gtk.EventBox):
 
     def _icon_button_release_event_cb(self, button, event):
         logging.debug('_icon_button_release_event_cb')
-        misc.resume(self._metadata)
+        misc.resume(self._metadata,
+                    alert_window=journalwindow.get_journal_window())
         return True
 
     def _preview_box_button_release_event_cb(self, button, event):
         logging.debug('_preview_box_button_release_event_cb')
-        misc.resume(self._metadata)
+        misc.resume(self._metadata,
+                    alert_window=journalwindow.get_journal_window())
         return True

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -453,7 +453,8 @@ class DetailToolbox(ToolbarBox):
         self._refresh_resume_palette()
 
     def _resume_clicked_cb(self, button):
-        misc.resume(self._metadata)
+        misc.resume(self._metadata,
+                    alert_window=journalwindow.get_journal_window())
 
     def _copy_clicked_cb(self, button):
         button.palette.popup(immediate=True, state=Palette.SECONDARY)
@@ -496,7 +497,8 @@ class DetailToolbox(ToolbarBox):
             model.delete(self._metadata['uid'])
 
     def _resume_menu_item_activate_cb(self, menu_item, service_name):
-        misc.resume(self._metadata, service_name)
+        misc.resume(self._metadata,
+                    alert_window=journalwindow.get_journal_window())
 
     def _refresh_copy_palette(self):
         palette = self._copy.get_palette()

--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -34,6 +34,7 @@ from jarabe.journal.listmodel import ListModel
 from jarabe.journal.palettes import ObjectPalette, BuddyPalette
 from jarabe.journal import model
 from jarabe.journal import misc
+from jarabe.journal import journalwindow
 
 
 UPDATE_INTERVAL = 300
@@ -651,7 +652,8 @@ class ListView(BaseListView):
     def __icon_clicked_cb(self, cell, path):
         row = self.tree_view.get_model()[path]
         metadata = model.get(row[ListModel.COLUMN_UID])
-        misc.resume(metadata)
+        misc.resume(metadata,
+                    alert_window=journalwindow.get_journal_window())
 
     def __cell_title_edited_cb(self, cell, path, new_text):
         row = self._model[path]

--- a/src/jarabe/journal/misc.py
+++ b/src/jarabe/journal/misc.py
@@ -36,6 +36,7 @@ from sugar3.bundle.contentbundle import ContentBundle
 from sugar3 import util
 
 from jarabe.view import launcher
+from jarabe.view import alerts
 from jarabe.model import bundleregistry, shell
 from jarabe.journal.journalentrybundle import JournalEntryBundle
 from jarabe.journal import model
@@ -179,7 +180,17 @@ def get_activities(metadata):
     return activities
 
 
-def resume(metadata, bundle_id=None, force_bundle_downgrade=False):
+def get_bundle_id_from_metadata(metadata):
+    activities = get_activities(metadata)
+    if not activities:
+        logging.warning('No activity can open this object, %s.',
+                        metadata.get('mime_type', None))
+        return None
+    return activities[0].get_bundle_id()
+
+
+def resume(metadata, bundle_id=None, alert_window=None,
+           force_bundle_downgrade=False):
     registry = bundleregistry.get_registry()
 
     ds_bundle, downgrade_required = \
@@ -217,11 +228,14 @@ def resume(metadata, bundle_id=None, force_bundle_downgrade=False):
         object_id = model.copy(metadata, '/')
 
     launch(bundle, activity_id=activity_id, object_id=object_id,
-           color=get_icon_color(metadata))
+           color=get_icon_color(metadata), alert_window=alert_window)
 
 
 def launch(bundle, activity_id=None, object_id=None, uri=None, color=None,
-           invited=False):
+           invited=False, metadata=None, alert_window=None):
+
+    bundle_id = bundle.get_bundle_id()
+
     if activity_id is None or not activity_id:
         activity_id = activityfactory.create_activity_id()
 
@@ -244,6 +258,23 @@ def launch(bundle, activity_id=None, object_id=None, uri=None, color=None,
     if activity is not None:
         logging.debug('re-launch %r', activity.get_window())
         activity.get_window().activate(Gtk.get_current_event_time())
+        return
+
+    if not shell_model.can_launch_activity():
+        if alert_window is None:
+            from jarabe.desktop import homewindow
+            alert_window = homewindow.get_instance()
+        if alert_window is not None:
+            alerts.show_max_open_activities_alert(alert_window)
+        return
+
+    if not shell_model.can_launch_activity_instance(bundle):
+        if alert_window is None:
+            from jarabe.desktop import homewindow
+            alert_window = homewindow.get_instance()
+        if alert_window is not None:
+            alerts.show_multiple_instance_alert(
+                alert_window, shell_model.get_name_from_bundle_id(bundle_id))
         return
 
     if color is None:

--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -138,7 +138,8 @@ class ObjectPalette(Palette):
         return [self._metadata['uid']]
 
     def __start_activate_cb(self, menu_item):
-        misc.resume(self._metadata)
+        misc.resume(self._metadata,
+                    alert_window=journalwindow.get_journal_window())
 
     def __duplicate_activate_cb(self, menu_item):
         try:
@@ -502,7 +503,8 @@ class StartWithMenu(Gtk.Menu):
         if mime_type:
             mime_registry = mimeregistry.get_registry()
             mime_registry.set_default_activity(mime_type, service_name)
-        misc.resume(self._metadata, service_name)
+        misc.resume(self._metadata, bundle_id=service_name,
+                    alert_window=journalwindow.get_journal_window())
 
 
 class BuddyPalette(Palette):

--- a/src/jarabe/view/Makefile.am
+++ b/src/jarabe/view/Makefile.am
@@ -1,6 +1,7 @@
 sugardir = $(pythondir)/jarabe/view
 sugar_PYTHON =				\
 	__init__.py			\
+	alerts.py			\
 	buddyicon.py			\
 	buddymenu.py			\
 	cursortracker.py		\

--- a/src/jarabe/view/alerts.py
+++ b/src/jarabe/view/alerts.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2013 Sugar Labs
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+import logging
+from gettext import gettext as _
+
+from sugar3.graphics.alert import ErrorAlert
+
+
+class BaseErrorAlert(ErrorAlert):
+
+    def __init__(self, title, message):
+        ErrorAlert.__init__(self)
+
+        logging.error('%s: %s' % (title, message))
+        self.props.title = title
+        self.props.msg = message
+
+
+class MultipleInstanceAlert(BaseErrorAlert):
+
+    def __init__(self, name):
+        BaseErrorAlert.__init__(
+            self,
+            _('Activity launcher'),
+            _('%s is already running. \
+Please stop %s before launching it again.' % (name, name)))
+
+
+class MaxOpenActivitiesAlert(BaseErrorAlert):
+
+    def __init__(self):
+        BaseErrorAlert.__init__(
+            self,
+            _('Activity launcher'),
+            _('The maximum number of open activities has been reached. \
+Please close an activity before launching a new one.'))
+
+
+def _alert_response_cb(alert, response_id, window):
+    window.remove_alert(alert)
+
+
+def show_multiple_instance_alert(window, activity_name):
+    alert = MultipleInstanceAlert(activity_name)
+    alert.connect('response', _alert_response_cb, window)
+    window.add_alert(alert)
+    alert.show()
+
+
+def show_max_open_activities_alert(window):
+    alert = MaxOpenActivitiesAlert()
+    alert.connect('response', _alert_response_cb, window)
+    window.add_alert(alert)
+    alert.show()


### PR DESCRIPTION
At the request of OLPC AU (in an effort to reduce OOM freezes) this
patch uses gconf to set a maximum number of open activities [1]. An
alert is shown if the user tries to launch more activities than the
maximum asking them to close an activity before opening a new one. If
maximum_number_of_open_activites is not set or == 0, then there is no
maximum limit applied.

Further, Some activities don't behave well if more than one instance
is open (e.g., SL #4554). This patch sets a limit on the number open
instances of an activity based on a new field in activity.info:
single_instance.

If and only if single_instance = yes in activity.info, is it used to
limit open instances to a single instance.

NOTE: there is a patch to activitybundle.py in the toolkit necessary
for this patch to be used.

[1] /desktop/sugar/maximum_number_of_open_activities
