### PR TITLE
Fixed issue with spaces in bundle_ids - issue #4634

### DIFF
--- a/src/jarabe/model/bundleregistry.py
+++ b/src/jarabe/model/bundleregistry.py
@@ -172,7 +172,8 @@ class BundleRegistry(GObject.GObject):
         as a dictionary key.
         """
         if ' ' in bundle_id:
-            raise ValueError('bundle_id cannot contain spaces')
+            logging.exception("Spaces found in bundle_id %s", bundle_id)
+            bundle_id = bundle_id.replace(' ', '.')
         return '%s %s' % (bundle_id, version)
 
     def _load_favorites(self):


### PR DESCRIPTION
Fixed the issue in the bundle registry file where a space in the bundle_id would cause a ValueError and result in that app not being displayed on the home screen. The error is logged and the space replaced with a dot.
