### PR TITLE
Fix regression introduced by ae54fc4e6d23a1b7f145810ea5e9edd12fa220bb

### DIFF
--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -497,7 +497,7 @@ class DetailToolbox(ToolbarBox):
             model.delete(self._metadata['uid'])
 
     def _resume_menu_item_activate_cb(self, menu_item, service_name):
-        misc.resume(self._metadata,
+        misc.resume(self._metadata, service_name,
                     alert_window=journalwindow.get_journal_window())
 
     def _refresh_copy_palette(self):


### PR DESCRIPTION
In the detail view of the journal, the user can resume a object,
and in some cases, is possible do it with more than one activity (ex. images)
Whitout this patch, do not matter what activity is selected to open
the object, the default activity is used.

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
