### PR TITLE
Fix Clone of gtk3 activities - SL #4608

### DIFF
--- a/src/jarabe/view/customizebundle.py
+++ b/src/jarabe/view/customizebundle.py
@@ -80,7 +80,7 @@ def generate_bundle(nick, new_basename):
 
     config = bundlebuilder.Config(source_dir=os.path.join(
         user_activities_path, new_basename),
-        dist_name='%s-1.xo' % (new_activity_name))
+        dist_name='%s-1' % (new_activity_name))
     bundlebuilder.cmd_dist_xo(config, None)
 
     dsobject = datastore.create()


### PR DESCRIPTION
As we changed the way the dist_name parameter is used in
sugar-toolkit-gtk3, we need aply this change in sugar.

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
