### PR TITLE
Add capability to name the Favorite Views

### DIFF
--- a/src/jarabe/desktop/viewtoolbar.py
+++ b/src/jarabe/desktop/viewtoolbar.py
@@ -205,7 +205,7 @@ class FavoritesButton(RadioToolButton):
     def __init__(self, favorite_view):
         RadioToolButton.__init__(self)
 
-        self.props.tooltip = _('Favorites view %d' % (favorite_view + 1))
+        self.props.tooltip = desktop.get_favorite_names()[favorite_view]
         self.props.accelerator = _('<Ctrl>%d' % (favorite_view + 1))
         self.props.group = None
         self.props.icon_name = desktop.get_view_icons()[favorite_view]

--- a/src/jarabe/model/desktop.py
+++ b/src/jarabe/model/desktop.py
@@ -15,6 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
+from gettext import gettext as _
 from gi.repository import GObject
 from gi.repository import GConf
 
@@ -22,12 +23,15 @@ _desktop_view_instance = None
 
 _VIEW_ICONS = ['view-radial']
 _FAVORITE_ICONS = ['emblem-favorite']
+_FAVORITE_NAME = _("Favorites view %d")
 
 _VIEW_DIR = '/desktop/sugar/desktop'
 _VIEW_ENTRY = 'view_icons'
 _FAVORITE_ENTRY = 'favorite_icons'
+_FAVORITE_NAME_ENTRY = 'favorite_names'
 _VIEW_KEY = '%s/%s' % (_VIEW_DIR, _VIEW_ENTRY)
 _FAVORITE_KEY = '%s/%s' % (_VIEW_DIR, _FAVORITE_ENTRY)
+_FAVORITE_NAME_KEY = '%s/%s' % (_VIEW_DIR, _FAVORITE_NAME_ENTRY)
 
 
 class DesktopViewModel(GObject.GObject):
@@ -43,6 +47,7 @@ class DesktopViewModel(GObject.GObject):
         self._number_of_views = 1
         self._view_icons = None
         self._favorite_icons = None
+        self._favorite_labels = None
 
         self._ensure_view_icons()
 
@@ -65,6 +70,11 @@ class DesktopViewModel(GObject.GObject):
         return self._favorite_icons
 
     favorite_icons = GObject.property(type=object, getter=get_favorite_icons)
+
+    def get_favorite_names(self):
+        return self._favorite_names
+
+    favorite_names = GObject.property(type=object, getter=get_favorite_names)
 
     def _ensure_view_icons(self, update=False):
         if self._view_icons is not None and not update:
@@ -90,6 +100,26 @@ class DesktopViewModel(GObject.GObject):
                 self._favorite_icons.append(gval.get_string())
         else:
             self._favorite_icons = _FAVORITE_ICONS[:]
+
+        options = client.get(_FAVORITE_NAME_KEY)
+        total_views = self._number_of_views
+        if options is not None:
+            self._favorite_names = []
+            for gval in options.get_list():
+                self._favorite_names.append(gval.get_string())
+
+            if len(self._favorite_names) is not self._number_of_views:
+                if len(self._favorite_names) > self._number_of_views:
+                    self._favorite_names = \
+                        self._favorite_names[:self._number_of_views]
+                elif len(self._favorite_names) < self._number_of_views:
+                    defaults = [_FAVORITE_NAME % i for i in range(
+                        len(self._favorite_names)+1, total_views+1)]
+                    self._favorite_names.extend(defaults)
+        else:
+            default_names = \
+                [_FAVORITE_NAME % i for i in range(1, total_views+1)]
+            self._favorite_names = default_names
 
         if len(self._favorite_icons) < self._number_of_views:
             for i in range(self._number_of_views - len(self._favorite_icons)):
@@ -118,6 +148,10 @@ def get_view_icons():
 
 def get_favorite_icons():
     return get_model().get_favorite_icons()
+
+
+def get_favorite_names():
+    return get_model().get_favorite_names()
 
 
 def get_number_of_views():


### PR DESCRIPTION
Now there is a GConf setting to set names of the views.

This is related to a [Google Code In task](https://www.google-melange.com/gci/task/view/google/gci2013/5876491694899200).
