### PR TITLE
Remove monochrome from battery icon while charging

### DIFF
--- a/extensions/deviceicon/battery.py
+++ b/extensions/deviceicon/battery.py
@@ -88,8 +88,7 @@ class DeviceView(TrayIcon):
         elif self._model.props.charging:
             status = _STATUS_CHARGING
             name += '-charging'
-            xo_color = XoColor('%s,%s' % (style.COLOR_WHITE.get_svg(),
-                                          style.COLOR_WHITE.get_svg()))
+
         elif self._model.props.discharging:
             status = _STATUS_DISCHARGING
             if current_level <= _WARN_MIN_PERCENTAGE:


### PR DESCRIPTION
Fixes #44 .  This is part of the fix.  Previously the charging state was
distinguished with the monochrome, but was too ambiguous.  Now we added
a Z lightinng bolt inside the icon.
