### PR TITLE
Fix typo in GConf code

### DIFF
--- a/extensions/cpsection/aboutme/model.py
+++ b/extensions/cpsection/aboutme/model.py
@@ -53,7 +53,7 @@ def set_nick(nick):
 
     # DEPRECATED
     from gi.repository import GConf
-    client = GConf.CLient.get_default()
+    client = GConf.Client.get_default()
     client.set_string('/desktop/sugar/user/nick', nick)
     return 1
 
@@ -116,7 +116,7 @@ def set_color(stroke, fill, stroke_modifier='medium', fill_modifier='medium'):
 
     # DEPRECATED
     from gi.repository import GConf
-    client = GConf.CLient.get_default()
+    client = GConf.Client.get_default()
     client.set_string('/desktop/sugar/user/color', color)
     return 1
 
@@ -135,6 +135,6 @@ def set_color_xo(color):
 
     # DEPRECATED
     from gi.repository import GConf
-    client = GConf.CLient.get_default()
+    client = GConf.Client.get_default()
     client.set_string('/desktop/sugar/user/color', color)
     return 1

--- a/extensions/cpsection/network/model.py
+++ b/extensions/cpsection/network/model.py
@@ -57,7 +57,7 @@ def set_jabber(server):
 
     # DEPRECATED
     from gi.repository import GConf
-    client = GConf.CLient.get_default()
+    client = GConf.Client.get_default()
     client.set_string('/desktop/sugar/collaboration/jabber_server', server)
 
     return 0
@@ -116,7 +116,7 @@ def clear_registration():
 
     # DEPRECATED
     from gi.repository import GConf
-    client = GConf.CLient.get_default()
+    client = GConf.Client.get_default()
     client.set_string('/desktop/sugar/backup_url', '')
     return 1
 

--- a/extensions/cpsection/power/model.py
+++ b/extensions/cpsection/power/model.py
@@ -94,6 +94,6 @@ def set_automatic_pm(enabled):
 
     # DEPRECATED
     from gi.repository import GConf
-    client = GConf.CLient.get_default()
+    client = GConf.Client.get_default()
     client.set_string('/desktop/sugar/power/automatic', enabled)
     return


### PR DESCRIPTION
In a recent commit, a typo was introduced: GConf.CLient
This patch fixes the typo.
