### PR TITLE
Add age and gender options to intro sequence

### DIFF
--- a/data/org.sugarlabs.gschema.xml
+++ b/data/org.sugarlabs.gschema.xml
@@ -66,6 +66,16 @@
             <summary>User Color</summary>
             <description>Color for the XO icon that is used throughout the desktop. The string is composed of the stroke color and fill color, format is that of rgb colors. Example: #AC32FF,#9A5200</description>
         </key>
+        <key name="gender" type="s">
+            <default>''</default>
+            <summary>User Gender</summary>
+            <description>Gender of the Sugar user, either male, female, or unassigned</description>
+        </key>
+        <key name="birth-timestamp" type="i">
+            <default>0</default>
+            <summary>User Birth Timestamp</summary>
+            <description>Timestamp of Sugar user (time.time() minus the user's age times the number of seconds in a year</description>
+        </key>
         <child name="background" schema="org.sugarlabs.user.background" />
     </schema>
     <schema id="org.sugarlabs.user.background" path="/org/sugarlabs/user/background/">

--- a/data/sugar.schemas.in
+++ b/data/sugar.schemas.in
@@ -37,6 +37,30 @@
 	</long>
       </locale>
     </schema>
+    <schema>
+      <key>/schemas/desktop/sugar/user/gender</key>
+      <applyto>/desktop/sugar/user/gender</applyto>
+      <owner>sugar</owner>
+      <type>string</type>
+      <default></default>
+      <locale name="C">
+        <short>User Gender</short>
+        <long>Gender of the Sugar user, either male, female, or unassigned
+	</long>
+      </locale>
+    </schema>
+    <schema>
+      <key>/schemas/desktop/sugar/user/birth_timestamp</key>
+      <applyto>/desktop/sugar/user/birth_timestamp</applyto>
+      <owner>sugar</owner>
+      <type>int</type>
+      <default></default>
+      <locale name="C">
+        <short>User Birth Timestamp</short>
+        <long>Timestamp of Sugar user (time.time() minus the user's age times the number of seconds in a year
+	</long>
+      </locale>
+    </schema>
 
     <schema>
       <key>/schemas/desktop/sugar/sound/volume</key>

--- a/src/jarabe/intro/Makefile.am
+++ b/src/jarabe/intro/Makefile.am
@@ -1,5 +1,7 @@
 sugardir = $(pythondir)/jarabe/intro
 sugar_PYTHON = 		\
 	__init__.py	\
+	agepicker.py	\
 	colorpicker.py	\
+	genderpicker.py	\
 	window.py

--- a/src/jarabe/intro/agepicker.py
+++ b/src/jarabe/intro/agepicker.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2007, Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+from gi.repository import Gtk
+from gi.repository import Gdk
+
+from gettext import gettext as _
+
+from sugar3.graphics.icon import EventIcon
+from sugar3.graphics import style
+from sugar3.graphics.xocolor import XoColor
+
+AGES = [3, 5, 7, 9, 11, 12, 15, 25]
+AGE_LABELS = [_('0-3'), _('4-5'), _('6-7'), _('8-9'), _('10-11'), _('12'),
+              _('13-17'), _('Adult')]
+
+
+class AgePicker(Gtk.Grid):
+
+    def __init__(self, gender):
+        Gtk.Grid.__init__(self)
+        self.set_row_spacing(style.DEFAULT_SPACING)
+        self.set_column_spacing(style.DEFAULT_SPACING)
+
+        self._gender = gender
+        self._age = 5
+        self._buttons = []
+        self._nocolor = XoColor('#010101,#ffffff')
+        self._color = XoColor()
+
+        if self._gender is None or self._gender == 'None':
+            self._gender = 'male'
+
+        for i in range(8):
+            self._buttons.append(
+                EventIcon(pixel_size=style.LARGE_ICON_SIZE,
+                          icon_name='%s-%d' % (self._gender, i)))
+            self._buttons[-1].show()
+
+            eventbox = Gtk.EventBox()
+            eventbox.connect('button-press-event',
+                             self._button_press_cb, i)
+            eventbox.add(self._buttons[-1])
+            eventbox.show()
+
+            label = Gtk.Label()
+            label.set_text(AGE_LABELS[i])
+            label.show()
+
+            self.attach(eventbox, i, 0, 1, 1)
+            self.attach(label, i, 1, 1, 1)
+
+    def _button_press_cb(self, widget, event, age):
+        if event.button == 1 and event.type == Gdk.EventType.BUTTON_PRESS:
+            if self._age is not None:
+                self._buttons[self._age].xo_color = self._nocolor
+            self._set_age(age)
+            self._buttons[age].xo_color = self._color
+
+    def get_age(self):
+        if self._age is None:
+            return None
+        else:
+            return AGES[self._age]
+
+    def _set_age(self, age):
+        self._age = age
+
+    def update_color(self, color):
+        self._color = color
+        if self._age is not None:
+            self._buttons[self._age].xo_color = self._color
+
+    def update_gender(self, gender):
+        self._gender = gender
+        for i in range(8):
+            self._buttons[i].set_icon_name('%s-%d' % (self._gender, i))
+            self._buttons[i].show()

--- a/src/jarabe/intro/genderpicker.py
+++ b/src/jarabe/intro/genderpicker.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2007, Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+from gi.repository import Gtk
+from gi.repository import Gdk
+
+from sugar3.graphics.icon import EventIcon
+from sugar3.graphics import style
+from sugar3.graphics.xocolor import XoColor
+
+
+class GenderPicker(Gtk.Grid):
+    def __init__(self):
+        Gtk.Grid.__init__(self)
+        self.set_row_spacing(style.DEFAULT_SPACING)
+        self.set_column_spacing(style.DEFAULT_SPACING)
+
+        self._gender = None
+        self._buttons = []
+        self._nocolor = XoColor('#010101,#ffffff')
+        self._color = XoColor()
+
+        eventbox = Gtk.EventBox()
+        self._buttons.append(EventIcon(pixel_size=style.XLARGE_ICON_SIZE,
+                                       icon_name='female-6'))
+        self._buttons[-1].show()
+        eventbox.connect('button-press-event', self._button_press_cb, 'female')
+        eventbox.add(self._buttons[-1])
+        eventbox.show()
+        self.attach(eventbox, 0, 0, 1, 1)
+
+        eventbox = Gtk.EventBox()
+        self._buttons.append(EventIcon(pixel_size=style.XLARGE_ICON_SIZE,
+                                       icon_name='male-6'))
+        self._buttons[-1].show()
+        eventbox.connect('button-press-event', self._button_press_cb, 'male')
+        eventbox.add(self._buttons[-1])
+        eventbox.show()
+        self.attach(eventbox, 1, 0, 1, 1)
+
+    def _button_press_cb(self, widget, event, gender):
+        if event.button == 1 and event.type == Gdk.EventType.BUTTON_PRESS:
+            self._set_gender(gender)
+            if gender == 'female':
+                self._buttons[0].xo_color = self._color
+                self._buttons[1].xo_color = self._nocolor
+            else:
+                self._buttons[1].xo_color = self._color
+                self._buttons[0].xo_color = self._nocolor
+
+    def get_gender(self):
+        return self._gender
+
+    def _set_gender(self, gender):
+        self._gender = gender
+
+    def update_color(self, color):
+        self._color = color
+        if self._gender == 'female':
+            self._buttons[0].xo_color = self._color
+        elif self._gender == 'male':
+            self._buttons[1].xo_color = self._color

--- a/src/jarabe/intro/window.py
+++ b/src/jarabe/intro/window.py
@@ -19,6 +19,8 @@ import os.path
 import logging
 from gettext import gettext as _
 import pwd
+import time
+import commands
 
 from gi.repository import Gtk
 from gi.repository import Gdk
@@ -32,23 +34,48 @@ from sugar3.graphics import style
 from sugar3.graphics.icon import Icon
 from sugar3.graphics.xocolor import XoColor
 
+from jarabe.intro import agepicker
 from jarabe.intro import colorpicker
+from jarabe.intro import genderpicker
+
+_SECONDS_PER_YEAR = 365 * 24 * 60 * 60
 
 
-def create_profile(name, color=None):
-    if not color:
-        color = XoColor()
+def calculate_birth_timestamp(age):
+    age_in_seconds = age * _SECONDS_PER_YEAR
+    birth_timestamp = int(time.time() - age_in_seconds)
+    return birth_timestamp
 
+
+def calculate_age(birth_timestamp):
+    age_in_seconds = time.time() - birth_timestamp
+    age = int(age_in_seconds / _SECONDS_PER_YEAR)
+    return age
+
+
+def create_profile(user_profile):
     settings = Gio.Settings('org.sugarlabs.user')
-    settings.set_string('nick', name)
-    settings.set_string('color', color.to_string())
+    settings.set_string('nick', user_profile.props.nick)
+    colors = user_profile.props.colors
+    if colors is None:
+        colors = XoColor()
+    settings.set_string('color', colors.to_string())
+    if user_profile.props.gender is not None:
+        settings.set_string('gender', user_profile.props.gender)
+    settings.set_int('birth-timestamp',
+                     calculate_birth_timestamp(user_profile.props.age))
     # settings.sync()
 
     # DEPRECATED
     from gi.repository import GConf
     client = GConf.Client.get_default()
-    client.set_string('/desktop/sugar/user/nick', name)
-    client.set_string('/desktop/sugar/user/color', color.to_string())
+    client.set_string('/desktop/sugar/user/nick', user_profile.props.nick)
+    client.set_string('/desktop/sugar/user/color', colors.to_string())
+    if user_profile.props.gender is not None:
+        client.set_string('/desktop/sugar/user/gender',
+                          user_profile.props.gender)
+    client.set_int('/desktop/sugar/user/birth_timestamp',
+                   calculate_birth_timestamp(user_profile.props.age))
     client.suggest_sync()
 
     if profile.get_pubkey() and profile.get_profile().privkey_hash:
@@ -56,7 +83,6 @@ def create_profile(name, color=None):
         return
 
     # Generate keypair
-    import commands
     keypath = os.path.join(env.get_profile_path(), 'owner.key')
     if os.path.exists(keypath):
         os.rename(keypath, keypath + '.broken')
@@ -107,17 +133,22 @@ class _NamePage(_Page):
         alignment = Gtk.Alignment.new(0.5, 0.5, 0, 0)
         self.pack_start(alignment, expand=True, fill=True, padding=0)
 
-        hbox = Gtk.HBox(spacing=style.DEFAULT_SPACING)
-        alignment.add(hbox)
+        grid = Gtk.Grid()
+        grid.set_column_spacing(style.DEFAULT_SPACING)
+        alignment.add(grid)
 
         label = Gtk.Label(label=_('Name:'))
-        hbox.pack_start(label, False, True, 0)
+        grid.attach(label, 0, 0, 1, 1)
+        label.show()
 
         self._entry = Gtk.Entry()
         self._entry.connect('notify::text', self._text_changed_cb)
         self._entry.set_size_request(style.zoom(300), -1)
         self._entry.set_max_length(45)
-        hbox.pack_start(self._entry, False, True, 0)
+        grid.attach(self._entry, 0, 1, 1, 1)
+
+        grid.show()
+        alignment.show()
 
     def _text_changed_cb(self, entry, pspec):
         valid = len(entry.props.text.strip()) > 0
@@ -137,14 +168,23 @@ class _ColorPage(_Page):
     def __init__(self):
         _Page.__init__(self)
 
-        vbox = Gtk.VBox(spacing=style.DEFAULT_SPACING)
-        self.pack_start(vbox, expand=True, fill=False, padding=0)
+        alignment = Gtk.Alignment.new(0.5, 0.5, 0, 0)
+        self.pack_start(alignment, expand=True, fill=True, padding=0)
 
-        self._label = Gtk.Label(label=_('Click to change color:'))
-        vbox.pack_start(self._label, True, True, 0)
+        grid = Gtk.Grid()
+        grid.set_column_spacing(style.DEFAULT_SPACING)
+        alignment.add(grid)
+
+        label = Gtk.Label(label=_('Click to change color:'))
+        grid.attach(label, 0, 0, 1, 1)
+        label.show()
 
         self._cp = colorpicker.ColorPicker()
-        vbox.pack_start(self._cp, True, True, 0)
+        grid.attach(self._cp, 0, 1, 1, 1)
+        self._cp.show()
+
+        grid.show()
+        alignment.show()
 
         self._color = self._cp.get_color()
         self.set_valid(True)
@@ -153,17 +193,86 @@ class _ColorPage(_Page):
         return self._cp.get_color()
 
 
+class _GenderPage(_Page):
+    def __init__(self):
+        _Page.__init__(self)
+
+        alignment = Gtk.Alignment.new(0.5, 0.5, 0, 0)
+        self.pack_start(alignment, expand=True, fill=True, padding=0)
+
+        grid = Gtk.Grid()
+        grid.set_column_spacing(style.DEFAULT_SPACING)
+        alignment.add(grid)
+
+        label = Gtk.Label(label=_('Select gender:'))
+        grid.attach(label, 0, 0, 1, 1)
+        label.show()
+
+        self._gp = genderpicker.GenderPicker()
+        grid.attach(self._gp, 0, 1, 1, 1)
+        self._gp.show()
+
+        grid.show()
+        alignment.show()
+
+        self._gender = self._gp.get_gender()
+        self.set_valid(True)
+
+    def get_gender(self):
+        return self._gp.get_gender()
+
+    def update_color(self, color):
+        self._gp.update_color(color)
+
+
+class _AgePage(_Page):
+    def __init__(self, gender):
+        _Page.__init__(self)
+
+        alignment = Gtk.Alignment.new(0.5, 0.5, 0, 0)
+        self.pack_start(alignment, expand=True, fill=True, padding=0)
+
+        grid = Gtk.Grid()
+        grid.set_column_spacing(style.DEFAULT_SPACING)
+        alignment.add(grid)
+
+        label = Gtk.Label(label=_('Select age:'))
+        grid.attach(label, 0, 0, 1, 1)
+        label.show()
+
+        self._ap = agepicker.AgePicker(gender)
+        grid.attach(self._ap, 0, 1, 1, 1)
+        self._ap.show()
+
+        grid.show()
+        alignment.show()
+
+        self._age = self._ap.get_age()
+        self.set_valid(True)
+
+    def update_gender(self, gender):
+        self._ap.update_gender(gender)
+
+    def update_color(self, color):
+        self._ap.update_color(color)
+
+    def get_age(self):
+        return self._ap.get_age()
+
+
 class _IntroBox(Gtk.VBox):
     __gsignals__ = {
         'done': (GObject.SignalFlags.RUN_FIRST, None,
-                 ([GObject.TYPE_PYOBJECT, GObject.TYPE_PYOBJECT])),
+                 ([GObject.TYPE_PYOBJECT])),
     }
 
     PAGE_NAME = 0
     PAGE_COLOR = 1
+    PAGE_GENDER = 2
+    PAGE_AGE = 3
 
     PAGE_FIRST = PAGE_NAME
-    PAGE_LAST = PAGE_COLOR
+    PAGE_LAST = PAGE_AGE
 
     def __init__(self):
         Gtk.VBox.__init__(self)
@@ -172,6 +281,8 @@ class _IntroBox(Gtk.VBox):
         self._page = self.PAGE_NAME
         self._name_page = _NamePage(self)
         self._color_page = _ColorPage()
+        self._gender_page = _GenderPage()
+        self._age_page = _AgePage(None)
         self._current_page = None
         self._next_button = None
 
@@ -195,6 +306,16 @@ class _IntroBox(Gtk.VBox):
             self._current_page = self._name_page
         elif self._page == self.PAGE_COLOR:
             self._current_page = self._color_page
+        elif self._page == self.PAGE_GENDER:
+            if self._color_page.get_color() is not None:
+                self._gender_page.update_color(self._color_page.get_color())
+            self._current_page = self._gender_page
+        elif self._page == self.PAGE_AGE:
+            if self._gender_page.get_gender() is not None:
+                self._age_page.update_gender(self._gender_page.get_gender())
+            if self._color_page.get_color() is not None:
+                self._age_page.update_color(self._color_page.get_color())
+            self._current_page = self._age_page
 
         self.pack_start(self._current_page, True, True, 0)
 
@@ -260,10 +381,56 @@ class _IntroBox(Gtk.VBox):
         self.done()
 
     def done(self):
-        name = self._name_page.get_name()
-        color = self._color_page.get_color()
+        user_profile = _UserProfile()
+        user_profile.props.nick = self._name_page.get_name()
+        user_profile.props.colors = self._color_page.get_color()
+        user_profile.props.gender = self._gender_page.get_gender()
+        user_profile.props.age = self._age_page.get_age()
 
-        self.emit('done', name, color)
+        self.emit('done', user_profile)
+
+
+class _UserProfile(GObject.GObject):
+    def __init__(self):
+        GObject.GObject.__init__(self)
+        self._nick = None
+        self._colors = None
+        self._gender = None
+        self._age = 12
+
+    def get_nick(self):
+        return self._nick
+
+    def set_nick(self, nick):
+        self._nick = nick
+
+    nick = GObject.property(type=object, setter=set_nick, getter=get_nick)
+
+    def get_colors(self):
+        return self._colors
+
+    def set_colors(self, colors):
+        self._colors = colors
+
+    colors = GObject.property(type=object, setter=set_colors,
+                              getter=get_colors)
+
+    def get_gender(self):
+        return self._gender
+
+    def set_gender(self, gender):
+        self._gender = gender
+
+    gender = GObject.property(type=object, setter=set_gender,
+                              getter=get_gender)
+
+    def get_age(self):
+        return self._age
+
+    def set_age(self, age):
+        self._age = age
+
+    age = GObject.property(type=object, setter=set_age, getter=get_age)
 
 
 class IntroWindow(Gtk.Window):
@@ -286,12 +453,12 @@ class IntroWindow(Gtk.Window):
         self._intro_box.show()
         self.connect('key-press-event', self.__key_press_cb)
 
-    def _done_cb(self, box, name, color):
+    def _done_cb(self, box, user_profile):
         self.hide()
-        GLib.idle_add(self._create_profile_cb, name, color)
+        GLib.idle_add(self._create_profile_cb, user_profile)
 
-    def _create_profile_cb(self, name, color):
-        create_profile(name, color)
+    def _create_profile_cb(self, user_profile):
+        create_profile(user_profile)
         self.emit("done")
 
         return False


### PR DESCRIPTION
As per [1], this patch adds support for gender and age attributes to
the user's profile. This patch is restricted to modifications to the
intro screens (gender and age selection are included after the user
selects a color).  The AboutMe section of the Control Panel, which
includes mechanisms for adjusting gender and age will be in a
follow-on patch. The artwork used on these screens is added by [2].

Note: This feature as discussed and approved by the design team [3].

The birth time is stored in GConf:

'/desktop/sugar/user/age'
'/desktop/sugar/user/birth_timestamp'

and in gsetting:
'/desktop/sugar/user/birth-timestamp'

The gender is stored in GConf and gsettings:

'/desktop/sugar/user/gender'

[1] http://wiki.sugarlabs.org/go/Features/About_Me
[2] sugarlabs/sugar-artwork#23
[3] http://meeting.sugarlabs.org/sugar-meeting/meetings/2014-01-07T22:18:04
