### PR TITLE
Removed Pulsing Icon, moved it to Sugar Toolkit

### DIFF
--- a/extensions/deviceicon/network.py
+++ b/extensions/deviceicon/network.py
@@ -38,12 +38,12 @@ from sugar3.graphics.palettemenu import PaletteMenuItemSeparator
 from sugar3.graphics.toolbutton import ToolButton
 from sugar3.graphics.tray import TrayIcon
 from sugar3.graphics.icon import Icon
+from sugar3.graphics.pulsingicon import PulsingIcon
 from sugar3.graphics import xocolor
 from sugar3 import profile
 
 from jarabe.model import network
 from jarabe.frame.frameinvoker import FrameWidgetInvoker
-from jarabe.view.pulsingicon import PulsingIcon
 
 
 IP_ADDRESS_TEXT_TEMPLATE = _('IP address: %s')

--- a/src/jarabe/desktop/networkviews.py
+++ b/src/jarabe/desktop/networkviews.py
@@ -27,6 +27,7 @@ from gi.repository import GLib
 from gi.repository import Gtk
 
 from sugar3.graphics.icon import Icon
+from sugar3.graphics.icon import EventPulsingIcon
 from sugar3.graphics.xocolor import XoColor
 from sugar3.graphics import xocolor
 from sugar3.graphics import style
@@ -35,7 +36,7 @@ from sugar3.graphics import palette
 from sugar3.graphics.palettemenu import PaletteMenuItem
 from sugar3 import profile
 
-from jarabe.view.pulsingicon import EventPulsingIcon
+
 from jarabe.desktop import keydialog
 from jarabe.util.normalize import normalize_string
 from jarabe.model import network

--- a/src/jarabe/frame/activitiestray.py
+++ b/src/jarabe/frame/activitiestray.py
@@ -32,6 +32,7 @@ from sugar3.graphics.xocolor import XoColor
 from sugar3.graphics.radiotoolbutton import RadioToolButton
 from sugar3.graphics.toolbutton import ToolButton
 from sugar3.graphics.icon import Icon, get_icon_file_name
+from sugar3.graphics.pulsingicon import PulsingIcon
 from sugar3.graphics.palette import Palette
 from sugar3.graphics.menuitem import MenuItem
 from sugar3.graphics.palettemenu import PaletteMenuBox
@@ -47,7 +48,6 @@ from jarabe.model import invites
 from jarabe.model import bundleregistry
 from jarabe.model import filetransfer
 from jarabe.view.palettes import JournalPalette, CurrentActivityPalette
-from jarabe.view.pulsingicon import PulsingIcon
 from jarabe.frame.frameinvoker import FrameWidgetInvoker
 from jarabe.frame.notification import NotificationIcon
 import jarabe.frame

--- a/src/jarabe/frame/notification.py
+++ b/src/jarabe/frame/notification.py
@@ -20,8 +20,7 @@ from gi.repository import Gdk
 
 from sugar3.graphics import style
 from sugar3.graphics.xocolor import XoColor
-
-from jarabe.view.pulsingicon import PulsingIcon
+from sugar3.graphics.pulsingicon import PulsingIcon
 
 
 class NotificationIcon(Gtk.EventBox):

--- a/src/jarabe/view/launcher.py
+++ b/src/jarabe/view/launcher.py
@@ -22,9 +22,9 @@ from gi.repository import Gdk
 
 from gi.repository import SugarExt
 from sugar3.graphics import style
+from sugar3.graphics.pulsingicon import PulsingIcon
 
 from jarabe.model import shell
-from jarabe.view.pulsingicon import PulsingIcon
 
 
 class LaunchWindow(Gtk.Window):


### PR DESCRIPTION
This remove the PulsingIcon from sugar core.
And add prelight to frame buttons (this fixes: #3293)
