### PR TITLE
Fix method name in journal multiple objects operation

### DIFF
--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -578,7 +578,7 @@ class BatchOperator(GObject.GObject):
             self._journalactivity.remove_alert(alert)
             # this is only in the case the operation already started
             # and the user want stop it.
-            self._stop_batch_operation()
+            self._stop_batch_execution()
         else:
             GObject.idle_add(self._prepare_batch_execution)
 


### PR DESCRIPTION
This was a error in the implementation, the call do not match
the method name.

Signed-off-by: Gonzalo Odiard godiard@sugarlabs.org
