### PR TITLE
Add age and gender to user profile

### DIFF
--- a/data/org.sugarlabs.gschema.xml
+++ b/data/org.sugarlabs.gschema.xml
@@ -66,6 +66,16 @@
             <summary>User Color</summary>
             <description>Color for the XO icon that is used throughout the desktop. The string is composed of the stroke color and fill color, format is that of rgb colors. Example: #AC32FF,#9A5200</description>
         </key>
+        <key name="gender" type="s">
+            <default>''</default>
+            <summary>User Gender</summary>
+            <description>Gender of the Sugar user, either male, female, or unassigned</description>
+        </key>
+        <key name="birth-timestamp" type="i">
+            <default>0</default>
+            <summary>User Birth Timestamp</summary>
+            <description>Timestamp of Sugar user (time.time() minus the user's age times the number of seconds in a year</description>
+        </key>
         <child name="background" schema="org.sugarlabs.user.background" />
     </schema>
     <schema id="org.sugarlabs.user.background" path="/org/sugarlabs/user/background/">

--- a/extensions/cpsection/aboutme/model.py
+++ b/extensions/cpsection/aboutme/model.py
@@ -1,4 +1,6 @@
 # Copyright (C) 2008 One Laptop Per Child
+# Copyright (C) 2010-14, Sugar Labs
+# Copyright (C) 2010-14, Walter Bender
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,9 +17,15 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 
+import logging
 from gettext import gettext as _
+
 from gi.repository import Gio
+
 from sugar3 import profile
+
+from jarabe.intro.window import calculate_birth_timestamp, calculate_age
+from jarabe.intro.agepicker import AGES
 
 
 _COLORS = {
@@ -55,12 +63,7 @@ def set_nick(nick):
     from gi.repository import GConf
     client = GConf.Client.get_default()
     client.set_string('/desktop/sugar/user/nick', nick)
-    return 1
-
-
-def get_color():
-    settings = Gio.Settings('org.sugarlabs.user')
-    return settings.get_string('color')
+    return
 
 
 def print_color():
@@ -87,46 +90,12 @@ def print_color():
         print _('fill:     %s') % (tmp[1])
 
 
-def set_color(stroke, fill, stroke_modifier='medium', fill_modifier='medium'):
-    """Set the system color by setting a fill and stroke color.
-    fill : [red, orange, yellow, blue, green, purple]
-    stroke : [red, orange, yellow, blue, green, purple]
-    hue stroke : [dark, medium, light] (optional)
-    hue fill : [dark, medium, light] (optional)
-    """
-
-    if stroke_modifier not in _MODIFIERS or fill_modifier not in _MODIFIERS:
-        print (_('Error in specified color modifiers.'))
-        return
-    if stroke not in _COLORS or fill not in _COLORS:
-        print (_('Error in specified colors.'))
-        return
-
-    if stroke_modifier == fill_modifier:
-        if fill_modifier == 'medium':
-            fill_modifier = 'light'
-        else:
-            fill_modifier = 'medium'
-
-    color = _COLORS[stroke][stroke_modifier] + ',' \
-        + _COLORS[fill][fill_modifier]
-
-    settings = Gio.Settings('org.sugarlabs.user')
-    settings.set_string('color', color)
-
-    # DEPRECATED
-    from gi.repository import GConf
-    client = GConf.Client.get_default()
-    client.set_string('/desktop/sugar/user/color', color)
-    return 1
-
-
-def get_color_xo():
+def get_color():
     settings = Gio.Settings('org.sugarlabs.user')
     return settings.get_string('color')
 
 
-def set_color_xo(color):
+def set_color(color):
     """Set a color with an XoColor
     This method is used by the graphical user interface
     """
@@ -137,4 +106,70 @@ def set_color_xo(color):
     from gi.repository import GConf
     client = GConf.Client.get_default()
     client.set_string('/desktop/sugar/user/color', color)
-    return 1
+    return
+
+
+def get_gender():
+    settings = Gio.Settings('org.sugarlabs.user')
+    return settings.get_string('gender')
+
+
+def print_gender():
+    print get_gender()
+
+
+def set_gender(gender):
+    """Set the gender, e.g. 'female'
+    """
+    if not gender or not gender in ['male', 'female']:
+        raise ValueError(_('Gender must be male or female.'))
+
+    settings = Gio.Settings('org.sugarlabs.user')
+    settings.set_string('gender', gender)
+    return
+
+
+def get_age():
+    settings = Gio.Settings('org.sugarlabs.user')
+    birth_timestamp = settings.get_int('birth-timestamp')
+
+    if birth_timestamp == 0:
+        return None
+
+    birth_age = calculate_age(birth_timestamp)
+
+    age = (AGES[-2] + AGES[-1]) / 2.
+    if birth_age >= age:
+        return AGES[-1]
+
+    for i in range(len(AGES) - 1):
+        age = (AGES[i] + AGES[i + 1]) / 2.
+        if birth_age < age:
+            return AGES[i]
+
+    return None
+
+
+def print_age():
+    print get_age()
+
+
+def set_age(age):
+    """Set the age and an approximate birth timestamp
+    age: e.g. 8
+    birth_timestamp: time - age * #seconds per year
+    """
+    try:
+        i = int(age)
+    except ValueError, e:
+        logging.error('set_age: %s' % (e))
+        i = None
+
+    if i is None or i < 1:
+        raise ValueError(_('Age must be a positive integer.'))
+
+    birth_timestamp = calculate_birth_timestamp(age)
+
+    settings = Gio.Settings('org.sugarlabs.user')
+    settings.set_int('birth-timestamp', birth_timestamp)
+    return

--- a/extensions/cpsection/aboutme/view.py
+++ b/extensions/cpsection/aboutme/view.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2008, OLPC
-# Copyright (C) 2010, Sugar Labs
+# Copyright (C) 2010-14, Sugar Labs
+# Copyright (C) 2010-14, Walter Bender
+# Copyright (C) 2014, Ignacio Rodriguez
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,13 +23,16 @@ from gettext import gettext as _
 
 from sugar3.graphics import style
 from sugar3.graphics.xocolor import XoColor, colors
-from sugar3.graphics.icon import CanvasIcon
+from sugar3.graphics.icon import EventIcon
 
 from jarabe.controlpanel.sectionview import SectionView
 from jarabe.controlpanel.inlinealert import InlineAlert
+from jarabe.intro.agepicker import AGES, AGE_LABELS
+
 
 _STROKE_COLOR = 0
 _FILL_COLOR = 1
+_NOCOLOR = XoColor('#010101,#FFFFFF')
 
 
 def _get_next_stroke_color(color):
@@ -111,7 +116,7 @@ _NEXT_STROKE_COLOR = 3
 _PREVIOUS_STROKE_COLOR = 4
 
 
-class ColorPicker(CanvasIcon):
+class ColorPicker(EventIcon):
     __gsignals__ = {
         'color-changed': (GObject.SignalFlags.RUN_FIRST,
                           None,
@@ -119,14 +124,14 @@ class ColorPicker(CanvasIcon):
     }
 
     def __init__(self, picker):
-        CanvasIcon.__init__(self, icon_name='computer-xo',
-                            pixel_size=style.XLARGE_ICON_SIZE)
+        EventIcon.__init__(self, icon_name='computer-xo',
+                           pixel_size=style.LARGE_ICON_SIZE)
         self._picker = picker
         self._color = None
 
         self.connect('button_press_event', self.__pressed_cb, picker)
 
-    def update(self, color):
+    def set_color(self, color):
         if self._picker == _PREVIOUS_FILL_COLOR:
             self._color = XoColor(_get_previous_fill_color(color))
         elif self._picker == _PREVIOUS_STROKE_COLOR:
@@ -139,9 +144,102 @@ class ColorPicker(CanvasIcon):
             self._color = color
         self.props.xo_color = self._color
 
+    color = GObject.property(type=object, setter=set_color)
+
     def __pressed_cb(self, button, event, picker):
         if picker != _CURRENT_COLOR:
             self.emit('color-changed', self._color)
+
+
+class GenderPicker(EventIcon):
+    __gsignals__ = {
+        'gender-changed': (GObject.SignalFlags.RUN_FIRST,
+                           None,
+                           ([object])),
+    }
+
+    def __init__(self, color, gender):
+        EventIcon.__init__(self, icon_name='%s-6' % (gender),
+                           pixel_size=style.XLARGE_ICON_SIZE)
+        self._gender = gender
+        self._color = color
+
+        self.set_gender()
+
+        self.connect('button_press_event', self.__pressed_cb)
+
+    def set_color(self, color, gender):
+        self._color = color
+        self.set_gender(gender)
+
+    def set_gender(self, gender=None):
+        if self._gender == gender:
+            self.props.xo_color = self._color
+        else:
+            self.props.xo_color = _NOCOLOR
+
+    gender = GObject.property(type=object, setter=set_gender)
+
+    def __pressed_cb(self, button, event):
+        self.emit('gender-changed', self._gender)
+
+
+class AgePicker(Gtk.Grid):
+    __gsignals__ = {
+        'age-changed': (GObject.SignalFlags.RUN_FIRST,
+                        None,
+                        ([object])),
+    }
+
+    def __init__(self, color, gender, age):
+        Gtk.Grid.__init__(self)
+        self._color = color
+        self._gender = gender
+        self._age = age
+
+        if self._gender is None:
+            # Used for graphic only; does not set user's gender preference.
+            self._gender = 'female'
+
+        self._icon = EventIcon(icon_name='%s-%d' % (self._gender, self._age),
+                               pixel_size=style.LARGE_ICON_SIZE)
+        self._icon.connect('button-press-event', self.__pressed_cb)
+        self.attach(self._icon, 0, 0, 1, 1)
+        self._icon.show()
+
+        label = Gtk.Label()
+        label.set_text(AGE_LABELS[self._age])
+        self.attach(label, 0, 1, 1, 1)
+        label.show()
+
+        self.set_age()
+
+    def set_color(self, color, age):
+        self._color = color
+        self.set_age(age)
+
+    def set_age(self, age=None):
+        if age in AGES:
+            age_index = AGES.index(age)
+        else:
+            age_index = None
+
+        if age_index == self._age:
+            self._icon.props.xo_color = self._color
+        else:
+            self._icon.props.xo_color = _NOCOLOR
+        self._icon.show()
+
+    age = GObject.property(type=object, setter=set_age)
+
+    def set_gender(self, gender):
+        self._icon.set_icon_name('%s-%d' % (gender, self._age))
+        self._icon.show()
+
+    gender = GObject.property(type=object, setter=set_gender)
+
+    def __pressed_cb(self, button, event):
+        self.emit('age-changed', self._age)
 
 
 class AboutMe(SectionView):
@@ -154,20 +252,70 @@ class AboutMe(SectionView):
         self._nick_sid = 0
         self._color_valid = True
         self._nick_valid = True
+        self._color = None
+        self._gender = None
+        self._age = None
 
         self.set_border_width(style.DEFAULT_SPACING * 2)
         self.set_spacing(style.DEFAULT_SPACING)
-        self._group = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
 
-        self._color_label = Gtk.Grid()
-        self._color_label.set_row_spacing(style.DEFAULT_SPACING)
-        self._color_label.set_column_spacing(style.DEFAULT_SPACING)
+        self._color = XoColor(self._model.get_color())
 
-        self._color_box = Gtk.Grid()
-        self._color_box.set_row_spacing(style.DEFAULT_SPACING)
-        self._color_box.set_column_spacing(style.DEFAULT_SPACING)
+        self._setup_color()
+        self._setup_nick()
+        self._setup_gender()
+        self._setup_age()
 
-        self._color_alert_box = Gtk.Grid()
+        self._update_pickers(self._color)
+
+        self._nick_entry.set_text(self._model.get_nick())
+        self._color_valid = True
+        self._nick_valid = True
+        self.needs_restart = False
+
+        self._nick_entry.connect('changed', self.__nick_changed_cb)
+        for picker in self._pickers.values():
+            picker.connect('color-changed', self.__color_changed_cb)
+        self._female_picker.connect('gender-changed', self.__gender_changed_cb)
+        self._male_picker.connect('gender-changed', self.__gender_changed_cb)
+        for picker in self._age_pickers:
+            picker.connect('age-changed', self.__age_changed_cb)
+
+    def _setup_nick(self):
+        grid = Gtk.Grid()
+        grid.set_row_spacing(style.DEFAULT_SPACING)
+        grid.set_column_spacing(style.DEFAULT_SPACING)
+
+        self._nick_entry = Gtk.Entry()
+        self._nick_entry.set_width_chars(25)
+        grid.attach(self._nick_entry, 0, 0, 1, 1)
+        self._nick_entry.show()
+
+        alert_grid = Gtk.Grid()
+        self._nick_alert = InlineAlert()
+        alert_grid.attach(self._nick_alert, 0, 0, 1, 1)
+        if 'nick' in self.restart_alerts:
+            self._nick_alert.props.msg = self.restart_msg
+            self._nick_alert.show()
+
+        center_in_panel = Gtk.Alignment.new(0.5, 0, 0, 0)
+        center_in_panel.add(grid)
+        grid.show()
+
+        center_alert = Gtk.Alignment.new(0.5, 0, 0, 0)
+        center_alert.add(alert_grid)
+        alert_grid.show()
+
+        self.pack_start(center_in_panel, False, False, 0)
+        self.pack_start(center_alert, False, False, 0)
+        center_in_panel.show()
+        center_alert.show()
+
+    def _setup_color(self):
+        grid = Gtk.Grid()
+        grid.set_row_spacing(style.DEFAULT_SPACING)
+        grid.set_column_spacing(style.DEFAULT_SPACING)
+
         self._color_alert = None
 
         self._pickers = {
@@ -178,117 +326,124 @@ class AboutMe(SectionView):
             _PREVIOUS_STROKE_COLOR: ColorPicker(_PREVIOUS_STROKE_COLOR),
         }
 
-        self._setup_color()
-        initial_color = XoColor(self._model.get_color_xo())
-        self._update_pickers(initial_color)
-
-        self._nick_box = Gtk.Grid()
-        self._nick_box.set_row_spacing(style.DEFAULT_SPACING)
-        self._nick_box.set_column_spacing(style.DEFAULT_SPACING)
-
-        self._nick_alert_box = Gtk.Grid()
-
-        self._nick_entry = None
-        self._nick_alert = None
-        self._setup_nick()
-        self.setup()
-
-    def _setup_nick(self):
-        self._nick_entry = Gtk.Entry()
-        self._nick_entry.set_width_chars(25)
-        self._nick_box.attach(self._nick_entry, 0, 0, 1, 1)
-        self._nick_entry.show()
-
-        self._nick_alert = InlineAlert()
-        self._nick_alert_box.attach(self._nick_alert, 0, 0, 1, 1)
-        if 'nick' in self.restart_alerts:
-            self._nick_alert.props.msg = self.restart_msg
-            self._nick_alert.show()
-
-        self._center_in_panel = Gtk.Alignment.new(0.5, 0, 0, 0)
-        self._center_in_panel.add(self._nick_box)
-
-        center_alert = Gtk.Alignment.new(0.5, 0, 0, 0)
-        center_alert.add(self._nick_alert_box)
-
-        self.pack_start(self._center_in_panel, False, False, 0)
-        self.pack_start(center_alert, False, False, 0)
-        self._nick_box.show()
-        self._nick_alert_box.show()
-        self._center_in_panel.show()
-        center_alert.show()
-
-    def _setup_color(self):
         label_color = Gtk.Label(label=_('Click to change your color:'))
         label_color.modify_fg(Gtk.StateType.NORMAL,
                               style.COLOR_SELECTION_GREY.get_gdk_color())
-        self._group.add_widget(label_color)
-        self._color_label.attach(label_color, 0, 0, 1, 1)
+        grid.attach(label_color, 0, 0, 3, 1)
         label_color.show()
 
-        current = 1
+        current = 0
         for picker_index in sorted(self._pickers.keys()):
             if picker_index == _CURRENT_COLOR:
                 left_separator = Gtk.SeparatorToolItem()
-                self._color_box.attach(left_separator, current, 0, 1, 1)
+                grid.attach(left_separator, current, 1, 1, 1)
                 left_separator.show()
                 current += 1
 
             picker = self._pickers[picker_index]
             picker.show()
-            self._color_box.attach(picker, current, 0, 1, 1)
+            grid.attach(picker, current, 1, 1, 1)
             current += 1
 
             if picker_index == _CURRENT_COLOR:
                 right_separator = Gtk.SeparatorToolItem()
                 right_separator.show()
-                self._color_box.attach(right_separator, current, 0, 1, 1)
+                grid.attach(right_separator, current, 1, 1, 1)
                 current += 1
 
         label_color_error = Gtk.Label()
-        self._group.add_widget(label_color_error)
-        self._color_alert_box.attach(label_color_error, 0, 0, 1, 1)
+        grid.attach(label_color_error, 0, 2, 3, 1)
         label_color_error.show()
 
         self._color_alert = InlineAlert()
-        self._color_alert_box.attach(self._color_alert, 0, 0, 1, 1)
+        grid.attach(self._color_alert, 0, 3, 3, 1)
         if 'color' in self.restart_alerts:
             self._color_alert.props.msg = self.restart_msg
             self._color_alert.show()
 
-        self._center_in_panel = Gtk.Alignment.new(0.5, 0, 0, 0)
-        self._center_in_panel.add(self._color_box)
+        center_in_panel = Gtk.Alignment.new(0.5, 0, 0, 0)
+        center_in_panel.add(grid)
+        grid.show()
 
-        center_alert = Gtk.Alignment.new(0.5, 0, 0, 0)
-        center_alert.add(self._color_alert_box)
+        self.pack_start(center_in_panel, False, False, 0)
+        center_in_panel.show()
 
-        self.pack_start(self._color_label, False, False, 0)
-        self.pack_start(self._center_in_panel, False, False, 0)
-        self.pack_start(center_alert, False, False, 0)
-        self._color_label.show()
-        self._color_box.show()
-        self._color_alert_box.show()
-        self._center_in_panel.show()
-        center_alert.show()
+    def _setup_gender(self):
+        self._gender = self._model.get_gender()
+
+        grid = Gtk.Grid()
+        grid.set_row_spacing(style.DEFAULT_SPACING)
+        grid.set_column_spacing(style.DEFAULT_SPACING)
+
+        label_gender = Gtk.Label(label=_('Select gender:'))
+        label_gender.modify_fg(Gtk.StateType.NORMAL,
+                               style.COLOR_SELECTION_GREY.get_gdk_color())
+        grid.attach(label_gender, 0, 0, 1, 1)
+        label_gender.show()
+
+        self._female_picker = GenderPicker(self._color, 'female')
+        grid.attach(self._female_picker, 0, 1, 1, 1)
+        self._female_picker.props.gender = self._gender
+        self._female_picker.show()
+
+        self._male_picker = GenderPicker(self._color, 'male')
+        grid.attach(self._male_picker, 1, 1, 1, 1)
+        self._male_picker.props.gender = self._gender
+        self._male_picker.show()
+
+        center_in_panel = Gtk.Alignment.new(0.5, 0, 0, 0)
+        center_in_panel.add(grid)
+        grid.show()
+
+        self.pack_start(center_in_panel, False, False, 0)
+        center_in_panel.show()
+
+    def _setup_age(self):
+        self._age = self._model.get_age()
+
+        grid = Gtk.Grid()
+        grid.set_row_spacing(style.DEFAULT_SPACING)
+        grid.set_column_spacing(style.DEFAULT_SPACING)
+
+        self._age_pickers = []
+        for i in range(len(AGES)):
+            self._age_pickers.append(AgePicker(self._color, self._gender, i))
+
+        label_age = Gtk.Label(label=_('Select age:'))
+        label_age.modify_fg(Gtk.StateType.NORMAL,
+                            style.COLOR_SELECTION_GREY.get_gdk_color())
+        grid.attach(label_age, 0, 0, 1, 1)
+        label_age.show()
+
+        for i in range(len(AGES)):
+            grid.attach(self._age_pickers[i], i, 1, 1, 1)
+            self._age_pickers[i].set_age(self._age)
+            self._age_pickers[i].show()
+
+        center_in_panel = Gtk.Alignment.new(0.5, 0, 0, 0)
+        center_in_panel.add(grid)
+        grid.show()
+        self.pack_start(center_in_panel, False, False, 0)
+        center_in_panel.show()
 
     def setup(self):
-        self._nick_entry.set_text(self._model.get_nick())
-        self._color_valid = True
-        self._nick_valid = True
-        self.needs_restart = False
-
-        self._nick_entry.connect('changed', self.__nick_changed_cb)
-        for picker in self._pickers.values():
-            picker.connect('color-changed', self.__color_changed_cb)
+        pass
 
     def undo(self):
         self._model.undo()
         self._nick_alert.hide()
         self._color_alert.hide()
 
+        self._model.set_gender(self._gender)
+        self._model.set_age(self._age)
+
     def _update_pickers(self, color):
         for picker in self._pickers.values():
-            picker.update(color)
+            picker.props.color = color
+        self._female_picker.set_color(color, self._gender)
+        self._male_picker.set_color(color, self._gender)
+        for i in range(len(AGES)):
+            self._age_pickers[i].set_color(color, self._age)
 
     def _validate(self):
         if self._nick_valid and self._color_valid:
@@ -322,7 +477,7 @@ class AboutMe(SectionView):
         return False
 
     def __color_changed_cb(self, colorpicker, color):
-        self._model.set_color_xo(color.to_string())
+        self._model.set_color(color.to_string())
         self.needs_restart = True
         self._color_alert.props.msg = self.restart_msg
         self._color_valid = True
@@ -332,5 +487,18 @@ class AboutMe(SectionView):
         self._color_alert.show()
 
         self._update_pickers(color)
+        return False
 
+    def __gender_changed_cb(self, genderpicker, gender):
+        self._model.set_gender(gender)
+        self._female_picker.props.gender = gender
+        self._male_picker.props.gender = gender
+        for i in range(len(AGES)):
+            self._age_pickers[i].props.gender = gender
+        return False
+
+    def __age_changed_cb(self, agepicker, age):
+        self._model.set_age(AGES[age])
+        for i in range(len(AGES)):
+            self._age_pickers[i].props.age = AGES[age]
         return False

--- a/src/jarabe/intro/Makefile.am
+++ b/src/jarabe/intro/Makefile.am
@@ -1,5 +1,7 @@
 sugardir = $(pythondir)/jarabe/intro
 sugar_PYTHON = 		\
 	__init__.py	\
+	agepicker.py	\
 	colorpicker.py	\
+	genderpicker.py	\
 	window.py

--- a/src/jarabe/intro/agepicker.py
+++ b/src/jarabe/intro/agepicker.py
@@ -1,0 +1,87 @@
+# Copyright (C) 2007, Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+from gi.repository import Gtk
+from gi.repository import Gdk
+
+from gettext import gettext as _
+
+from sugar3.graphics.icon import EventIcon
+from sugar3.graphics import style
+from sugar3.graphics.xocolor import XoColor
+
+AGES = [3, 5, 7, 9, 11, 12, 15, 25]
+AGE_LABELS = [_('0-3'), _('4-5'), _('6-7'), _('8-9'), _('10-11'), _('12'),
+              _('13-17'), _('Adult')]
+
+
+class AgePicker(Gtk.Grid):
+
+    def __init__(self, gender):
+        Gtk.Grid.__init__(self)
+        self.set_row_spacing(style.DEFAULT_SPACING)
+        self.set_column_spacing(style.DEFAULT_SPACING)
+
+        self._gender = gender
+        self._age = 5
+        self._buttons = []
+        self._nocolor = XoColor('#010101,#ffffff')
+        self._color = XoColor()
+
+        if self._gender is None or self._gender == 'None':
+            self._gender = 'male'
+
+        for i in range(len(AGES)):
+            self._buttons.append(
+                EventIcon(pixel_size=style.LARGE_ICON_SIZE,
+                          icon_name='%s-%d' % (self._gender, i)))
+            self._buttons[-1].show()
+            self._buttons[-1].connect('button-press-event',
+                                      self._button_press_cb, i)
+
+            label = Gtk.Label()
+            label.set_text(AGE_LABELS[i])
+            label.show()
+
+            self.attach(self._buttons[-1], i, 0, 1, 1)
+            self.attach(label, i, 1, 1, 1)
+
+    def _button_press_cb(self, widget, event, age):
+        if event.button == 1 and event.type == Gdk.EventType.BUTTON_PRESS:
+            if self._age is not None:
+                self._buttons[self._age].xo_color = self._nocolor
+            self._set_age(age)
+            self._buttons[age].xo_color = self._color
+
+    def get_age(self):
+        if self._age is None:
+            return None
+        else:
+            return AGES[self._age]
+
+    def _set_age(self, age):
+        self._age = age
+
+    def update_color(self, color):
+        self._color = color
+        if self._age is not None:
+            self._buttons[self._age].xo_color = self._color
+
+    def update_gender(self, gender):
+        self._gender = gender
+        for i in range(8):
+            self._buttons[i].set_icon_name('%s-%d' % (self._gender, i))
+            self._buttons[i].show()

--- a/src/jarabe/intro/genderpicker.py
+++ b/src/jarabe/intro/genderpicker.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2007, Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+from gi.repository import Gtk
+from gi.repository import Gdk
+
+from sugar3.graphics.icon import EventIcon
+from sugar3.graphics import style
+from sugar3.graphics.xocolor import XoColor
+
+
+GENDERS = ['female', 'male']
+
+
+class GenderPicker(Gtk.Grid):
+    def __init__(self):
+        Gtk.Grid.__init__(self)
+        self.set_row_spacing(style.DEFAULT_SPACING)
+        self.set_column_spacing(style.DEFAULT_SPACING)
+
+        self._gender = None
+        self._buttons = []
+        self._nocolor = XoColor('#010101,#ffffff')
+        self._color = XoColor()
+
+        for i, gender in enumerate(GENDERS):
+            self._buttons.append(EventIcon(pixel_size=style.XLARGE_ICON_SIZE,
+                                           icon_name='%s-6' % (gender)))
+            self._buttons[-1].show()
+            self._buttons[-1].connect('button-press-event',
+                                      self._button_press_cb, i)
+
+            self.attach(self._buttons[-1], i, 0, 1, 1)
+
+    def _button_press_cb(self, widget, event, gender_index):
+        if event.button == 1 and event.type == Gdk.EventType.BUTTON_PRESS:
+            self._set_gender(GENDERS[gender_index])
+            self._buttons[gender_index].xo_color = self._color
+            self._buttons[1 - gender_index].xo_color = self._nocolor
+
+    def get_gender(self):
+        return self._gender
+
+    def _set_gender(self, gender):
+        self._gender = gender
+
+    def update_color(self, color):
+        self._color = color
+        if self._gender in GENDERS:
+            self._buttons[GENDERS.index(self._gender)].xo_color = self._color

--- a/src/jarabe/intro/window.py
+++ b/src/jarabe/intro/window.py
@@ -19,6 +19,8 @@ import os.path
 import logging
 from gettext import gettext as _
 import pwd
+import time
+import commands
 
 from gi.repository import Gtk
 from gi.repository import Gdk
@@ -32,23 +34,48 @@ from sugar3.graphics import style
 from sugar3.graphics.icon import Icon
 from sugar3.graphics.xocolor import XoColor
 
+from jarabe.intro import agepicker
 from jarabe.intro import colorpicker
+from jarabe.intro import genderpicker
+
+_SECONDS_PER_YEAR = 365 * 24 * 60 * 60.
 
 
-def create_profile(name, color=None):
-    if not color:
-        color = XoColor()
+def calculate_birth_timestamp(age):
+    age_in_seconds = age * _SECONDS_PER_YEAR
+    birth_timestamp = int(time.time() - age_in_seconds)
+    return birth_timestamp
 
+
+def calculate_age(birth_timestamp):
+    age_in_seconds = time.time() - birth_timestamp
+    age = int((age_in_seconds / _SECONDS_PER_YEAR) + 0.5)
+    return age
+
+
+def create_profile(user_profile):
     settings = Gio.Settings('org.sugarlabs.user')
-    settings.set_string('nick', name)
-    settings.set_string('color', color.to_string())
+    settings.set_string('nick', user_profile.props.nick)
+    colors = user_profile.props.colors
+    if colors is None:
+        colors = XoColor()
+    settings.set_string('color', colors.to_string())
+    if user_profile.props.gender is not None:
+        settings.set_string('gender', user_profile.props.gender)
+    settings.set_int('birth-timestamp',
+                     calculate_birth_timestamp(user_profile.props.age))
     # settings.sync()
 
     # DEPRECATED
     from gi.repository import GConf
     client = GConf.Client.get_default()
-    client.set_string('/desktop/sugar/user/nick', name)
-    client.set_string('/desktop/sugar/user/color', color.to_string())
+    client.set_string('/desktop/sugar/user/nick', user_profile.props.nick)
+    client.set_string('/desktop/sugar/user/color', colors.to_string())
+    if user_profile.props.gender is not None:
+        client.set_string('/desktop/sugar/user/gender',
+                          user_profile.props.gender)
+    client.set_int('/desktop/sugar/user/birth_timestamp',
+                   calculate_birth_timestamp(user_profile.props.age))
     client.suggest_sync()
 
     if profile.get_pubkey() and profile.get_profile().privkey_hash:
@@ -56,7 +83,6 @@ def create_profile(name, color=None):
         return
 
     # Generate keypair
-    import commands
     keypath = os.path.join(env.get_profile_path(), 'owner.key')
     if os.path.exists(keypath):
         os.rename(keypath, keypath + '.broken')
@@ -107,17 +133,22 @@ class _NamePage(_Page):
         alignment = Gtk.Alignment.new(0.5, 0.5, 0, 0)
         self.pack_start(alignment, expand=True, fill=True, padding=0)
 
-        hbox = Gtk.HBox(spacing=style.DEFAULT_SPACING)
-        alignment.add(hbox)
+        grid = Gtk.Grid()
+        grid.set_column_spacing(style.DEFAULT_SPACING)
+        alignment.add(grid)
 
         label = Gtk.Label(label=_('Name:'))
-        hbox.pack_start(label, False, True, 0)
+        grid.attach(label, 0, 0, 1, 1)
+        label.show()
 
         self._entry = Gtk.Entry()
         self._entry.connect('notify::text', self._text_changed_cb)
         self._entry.set_size_request(style.zoom(300), -1)
         self._entry.set_max_length(45)
-        hbox.pack_start(self._entry, False, True, 0)
+        grid.attach(self._entry, 0, 1, 1, 1)
+
+        grid.show()
+        alignment.show()
 
     def _text_changed_cb(self, entry, pspec):
         valid = len(entry.props.text.strip()) > 0
@@ -137,14 +168,23 @@ class _ColorPage(_Page):
     def __init__(self):
         _Page.__init__(self)
 
-        vbox = Gtk.VBox(spacing=style.DEFAULT_SPACING)
-        self.pack_start(vbox, expand=True, fill=False, padding=0)
+        alignment = Gtk.Alignment.new(0.5, 0.5, 0, 0)
+        self.pack_start(alignment, expand=True, fill=True, padding=0)
 
-        self._label = Gtk.Label(label=_('Click to change color:'))
-        vbox.pack_start(self._label, True, True, 0)
+        grid = Gtk.Grid()
+        grid.set_column_spacing(style.DEFAULT_SPACING)
+        alignment.add(grid)
+
+        label = Gtk.Label(label=_('Click to change color:'))
+        grid.attach(label, 0, 0, 1, 1)
+        label.show()
 
         self._cp = colorpicker.ColorPicker()
-        vbox.pack_start(self._cp, True, True, 0)
+        grid.attach(self._cp, 0, 1, 1, 1)
+        self._cp.show()
+
+        grid.show()
+        alignment.show()
 
         self._color = self._cp.get_color()
         self.set_valid(True)
@@ -153,17 +193,86 @@ class _ColorPage(_Page):
         return self._cp.get_color()
 
 
+class _GenderPage(_Page):
+    def __init__(self):
+        _Page.__init__(self)
+
+        alignment = Gtk.Alignment.new(0.5, 0.5, 0, 0)
+        self.pack_start(alignment, expand=True, fill=True, padding=0)
+
+        grid = Gtk.Grid()
+        grid.set_column_spacing(style.DEFAULT_SPACING)
+        alignment.add(grid)
+
+        label = Gtk.Label(label=_('Select gender:'))
+        grid.attach(label, 0, 0, 1, 1)
+        label.show()
+
+        self._gp = genderpicker.GenderPicker()
+        grid.attach(self._gp, 0, 1, 1, 1)
+        self._gp.show()
+
+        grid.show()
+        alignment.show()
+
+        self._gender = self._gp.get_gender()
+        self.set_valid(True)
+
+    def get_gender(self):
+        return self._gp.get_gender()
+
+    def update_color(self, color):
+        self._gp.update_color(color)
+
+
+class _AgePage(_Page):
+    def __init__(self, gender):
+        _Page.__init__(self)
+
+        alignment = Gtk.Alignment.new(0.5, 0.5, 0, 0)
+        self.pack_start(alignment, expand=True, fill=True, padding=0)
+
+        grid = Gtk.Grid()
+        grid.set_column_spacing(style.DEFAULT_SPACING)
+        alignment.add(grid)
+
+        label = Gtk.Label(label=_('Select age:'))
+        grid.attach(label, 0, 0, 1, 1)
+        label.show()
+
+        self._ap = agepicker.AgePicker(gender)
+        grid.attach(self._ap, 0, 1, 1, 1)
+        self._ap.show()
+
+        grid.show()
+        alignment.show()
+
+        self._age = self._ap.get_age()
+        self.set_valid(True)
+
+    def update_gender(self, gender):
+        self._ap.update_gender(gender)
+
+    def update_color(self, color):
+        self._ap.update_color(color)
+
+    def get_age(self):
+        return self._ap.get_age()
+
+
 class _IntroBox(Gtk.VBox):
     __gsignals__ = {
         'done': (GObject.SignalFlags.RUN_FIRST, None,
-                 ([GObject.TYPE_PYOBJECT, GObject.TYPE_PYOBJECT])),
+                 ([GObject.TYPE_PYOBJECT])),
     }
 
     PAGE_NAME = 0
     PAGE_COLOR = 1
+    PAGE_GENDER = 2
+    PAGE_AGE = 3
 
     PAGE_FIRST = PAGE_NAME
-    PAGE_LAST = PAGE_COLOR
+    PAGE_LAST = PAGE_AGE
 
     def __init__(self):
         Gtk.VBox.__init__(self)
@@ -172,6 +281,8 @@ class _IntroBox(Gtk.VBox):
         self._page = self.PAGE_NAME
         self._name_page = _NamePage(self)
         self._color_page = _ColorPage()
+        self._gender_page = _GenderPage()
+        self._age_page = _AgePage(None)
         self._current_page = None
         self._next_button = None
 
@@ -195,6 +306,16 @@ class _IntroBox(Gtk.VBox):
             self._current_page = self._name_page
         elif self._page == self.PAGE_COLOR:
             self._current_page = self._color_page
+        elif self._page == self.PAGE_GENDER:
+            if self._color_page.get_color() is not None:
+                self._gender_page.update_color(self._color_page.get_color())
+            self._current_page = self._gender_page
+        elif self._page == self.PAGE_AGE:
+            if self._gender_page.get_gender() is not None:
+                self._age_page.update_gender(self._gender_page.get_gender())
+            if self._color_page.get_color() is not None:
+                self._age_page.update_color(self._color_page.get_color())
+            self._current_page = self._age_page
 
         self.pack_start(self._current_page, True, True, 0)
 
@@ -260,10 +381,56 @@ class _IntroBox(Gtk.VBox):
         self.done()
 
     def done(self):
-        name = self._name_page.get_name()
-        color = self._color_page.get_color()
+        user_profile = UserProfile()
+        user_profile.props.nick = self._name_page.get_name()
+        user_profile.props.colors = self._color_page.get_color()
+        user_profile.props.gender = self._gender_page.get_gender()
+        user_profile.props.age = self._age_page.get_age()
 
-        self.emit('done', name, color)
+        self.emit('done', user_profile)
+
+
+class UserProfile(GObject.GObject):
+    def __init__(self):
+        GObject.GObject.__init__(self)
+        self._nick = None
+        self._colors = None
+        self._gender = None
+        self._age = 12
+
+    def get_nick(self):
+        return self._nick
+
+    def set_nick(self, nick):
+        self._nick = nick
+
+    nick = GObject.property(type=object, setter=set_nick, getter=get_nick)
+
+    def get_colors(self):
+        return self._colors
+
+    def set_colors(self, colors):
+        self._colors = colors
+
+    colors = GObject.property(type=object, setter=set_colors,
+                              getter=get_colors)
+
+    def get_gender(self):
+        return self._gender
+
+    def set_gender(self, gender):
+        self._gender = gender
+
+    gender = GObject.property(type=object, setter=set_gender,
+                              getter=get_gender)
+
+    def get_age(self):
+        return self._age
+
+    def set_age(self, age):
+        self._age = age
+
+    age = GObject.property(type=object, setter=set_age, getter=get_age)
 
 
 class IntroWindow(Gtk.Window):
@@ -286,12 +453,12 @@ class IntroWindow(Gtk.Window):
         self._intro_box.show()
         self.connect('key-press-event', self.__key_press_cb)
 
-    def _done_cb(self, box, name, color):
+    def _done_cb(self, box, user_profile):
         self.hide()
-        GLib.idle_add(self._create_profile_cb, name, color)
+        GLib.idle_add(self._create_profile_cb, user_profile)
 
-    def _create_profile_cb(self, name, color):
-        create_profile(name, color)
+    def _create_profile_cb(self, user_profile):
+        create_profile(user_profile)
         self.emit("done")
 
         return False

--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -62,6 +62,7 @@ from jarabe import config
 from jarabe.model import sound
 from jarabe import intro
 from jarabe.intro.window import IntroWindow
+from jarabe.intro.window import UserProfile
 from jarabe.intro.window import create_profile
 from jarabe import frame
 from jarabe.view.service import UIService
@@ -268,7 +269,9 @@ def _check_profile():
 
     profile_name = os.environ.get("SUGAR_PROFILE_NAME", None)
     if profile_name is not None:
-        create_profile(profile_name)
+        user_profile = UserProfile()
+        user_profile.props.nick = profile_name
+        create_profile(user_profile)
         return True
 
     return False


### PR DESCRIPTION
As per [1], this patch adds support for gender and age attributes to
the user's profile. There are modifications to both the intro screens
(gender and age selection are included after the user selects a color)
and the AboutMe section of the Control Panel, which includes
mechanisms for adjusting gender and age. The artwork used on these
screens is added by [2]. Approved by the design team [3]. A change to
main.py is also included since there is now a UserProfile class.

The gender and birth timestamp are stored gsettings as:

/org/sugarlabs/user/gender
/org/sugarlabs/user/birth-timestamp

A unit test is included in a separate pull request [4].
This request replaces pull requests 170, 199 and 200.

[1] http://wiki.sugarlabs.org/go/Features/About_Me
[2] https://github.com/sugarlabs/sugar-artwork/pull/23
[3] http://meeting.sugarlabs.org/sugar-meeting/meetings/2014-01-07T22:18:04
[4] https://github.com/sugarlabs/sugar/pull/201
