### PR TITLE
GConf to GSetitngs port, tier 2

### DIFF
--- a/data/org.sugarlabs.gschema.xml
+++ b/data/org.sugarlabs.gschema.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
     <schema id="org.sugarlabs" path="/org/sugarlabs/">
+        <key name="gsettings-migrated" type="b">
+            <default>false</default>
+            <summary>Migrated to GSettings</summary>
+            <description>This key shows whether or not GConf values were migrated to GSettings</description>
+        </key>
         <key name="backup-url" type="s">
             <default>''</default>
             <summary>Backup URL</summary>
@@ -37,6 +42,7 @@
             <description>This int is used to set a limit to the number of open activities. By default (0), there is no limit.</description>
         </key>
         <child name="user" schema="org.sugarlabs.user" />
+        <child name="journal" schema="org.sugarlabs.journal" />
         <child name="sound" schema="org.sugarlabs.sound" />
         <child name="date" schema="org.sugarlabs.date" />
         <child name="desktop" schema="org.sugarlabs.desktop" />
@@ -80,6 +86,13 @@
             <description>The opacity of the background image.</description>
         </key>
     </schema>
+    <schema id="org.sugarlabs.journal" path="/org/sugarlabs/journal/">
+        <key name="mime-registry" type="a{ss}">
+            <default>{}</default>
+            <summary>Mimetype registry</summary>
+            <description>Consists of key-value pairs mimetypes and their corresponding activity</description>
+        </key>
+    </schema>
     <schema id="org.sugarlabs.sound" path="/org/sugarlabs/sound/">
         <key name="volume" type="i">
             <default>80</default>
@@ -100,25 +113,10 @@
         </key>
     </schema>
     <schema id="org.sugarlabs.desktop" path="/org/sugarlabs/desktop/">
-        <key name="favorites-layout" type="s">
-            <default>'ring-layout'</default>
-            <summary>Favorites Layout</summary>
-            <description>Layout of the favorites view.</description>
-        </key>
-        <key name="favorites-mode" type="b">
-            <default>false</default>
-            <summary>Favorites resume mode</summary>
-            <description>When in resume mode, clicking on a favorite icon will cause the last entry for that activity to be resumed.</description>
-        </key>
-        <key name="favorite-icons" type="as">
-            <default>[]</default>
-            <summary>TODO: add summary</summary>
-            <description>TODO: add description</description>
-        </key>
-        <key name="view-icons" type="as">
-            <default>[]</default>
-            <summary>TODO: add summary</summary>
-            <description>TODO: add description</description>
+        <key name="homeviews" type="aa{ss}">
+            <default>[{'layout': 'ring-layout', 'view-icon': 'view-radial', 'favorite-icon': 'emblem-favorite'}]</default>
+            <summary>Home views</summary>
+            <description>List of home views, including the view icon, the favorite icon and the layout</description>
         </key>
     </schema>
     <schema id="org.sugarlabs.frame" path="/org/sugarlabs/frame/">

--- a/data/sugar-schemas.convert
+++ b/data/sugar-schemas.convert
@@ -23,10 +23,6 @@ mute = /desktop/sugar/sound/mute
 [org.sugarlabs.date]
 timezone = /desktop/sugar/date/timezone
 
-[org.sugarlabs.desktop]
-favorites-layout = /desktop/sugar/desktop/favorites-layout
-favorites-mode = /desktop/sugar/desktop/favorites-mode
-
 [org.sugarlabs.frame]
 edge-delay = /desktop/sugar/frame/edge_delay
 corner-delay = /desktop/sugar/frame/corner_delay

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -22,7 +22,6 @@ import logging
 from gettext import gettext as _
 
 from gi.repository import GObject
-from gi.repository import GConf
 from gi.repository import Gio
 from gi.repository import GLib
 from gi.repository import Gtk
@@ -683,23 +682,17 @@ class OwnerIcon(BuddyIcon):
 
 class FavoritesSetting(object):
 
-    # FIXME: find a way to port this to GSettings
-    # FIXME: maybe make favorites_layout a list of strings?
-
-    _FAVORITES_KEY = '/desktop/sugar/desktop/favorites_layout'
+    _DESKTOP_DIR = 'org.sugarlabs.desktop'
+    _HOMEVIEWS_KEY = 'homeviews'
 
     def __init__(self, favorite_view):
-        client = GConf.Client.get_default()
-        # Special-case 0 for backward compatibility
-        if favorite_view == 0:
-            self._client_string = self._FAVORITES_KEY
-        else:
-            self._client_string = '%s_%d' % (self._FAVORITES_KEY,
-                                             favorite_view)
+        self._favorite_view = int(favorite_view)
 
-        self._layout = client.get_string(self._client_string)
-        if self._layout is None:
-            self._layout = favoriteslayout.RingLayout.key
+        settings = Gio.Settings(self._DESKTOP_DIR)
+        homeviews = settings.get_value(self._HOMEVIEWS_KEY).unpack()
+
+        self._layout = homeviews[self._favorite_view]['layout']
+
         logging.debug('FavoritesSetting layout %r', self._layout)
 
         self._mode = None
@@ -714,8 +707,13 @@ class FavoritesSetting(object):
         if layout != self._layout:
             self._layout = layout
 
-            client = GConf.Client.get_default()
-            client.set_string(self._client_string, layout)
+            settings = Gio.Settings(self._DESKTOP_DIR)
+            homeviews = settings.get_value(self._FAVORITES_KEY).unpack()
+
+            homeviews[self._favorite_view]['layout'] = layout
+
+            variant = GLib.Variant('aa{ss}', homeviews)
+            settings.set_value(self._HOMEVIEWS_KEY, variant)
 
             self.changed.send(self)
 

--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -214,11 +214,107 @@ def cleanup_temporary_files():
         print 'temporary files cleanup failed: %s' % e
 
 
-def _gconf_to_gsettings_data_convert():
+def _migrate_journal_mimeregistry():
+    from gi.repository import GConf
+    client = GConf.Client.get_default()
+
+    # Now this isn't good
+    # keys in /desktop/sugar/journal/defaults are mime types
+    # which are of the sort text/plain
+    # so, GConf is thinking test is a directory and the key is plain
+    # while the key should be 'text/plain'
+
+    gconf_defaults_dir = '/desktop/sugar/journal/defaults'
+
+    entries = client.all_entries(gconf_defaults_dir)
+    for directory in client.all_dirs(gconf_defaults_dir):
+        entries.extend(client.all_entries(directory))
+
+    prefix = gconf_defaults_dir + '/'
+    prefix_length = len(prefix)
+
+    gconf_defaults = {}
+    for entry in entries:
+        key = entry.get_key()
+        key = key[prefix_length:]
+
+        # entry.get_value().get_string() causes sugar to crash later
+        # not on the call, but after some random time
+        # was impossible to debug (almost impossible)
+        value = entry.value.get_string()
+        gconf_defaults[key] = value
+
+    variant = GLib.Variant('a{ss}', gconf_defaults)
+
+    settings = Gio.Settings('org.sugarlabs.journal')
+    settings.set_value('mime-registry', variant)
+
+
+def _migrate_homeviews_settings():
+    from gi.repository import GConf
+    client = GConf.Client.get_default()
+
+    # Merge several keys into one... yay!
+    options = client.get('/desktop/sugar/desktop/view-icons')
+    gconf_view_icons = []
+    if options:
+        gconf_view_icons = [gval.get_string() for gval in options.get_list()]
+
+    # assume view-icons is the leading key
+    number_of_views = len(gconf_view_icons)
+
+    layouts = []
+    prefix = '/desktop/sugar/desktop/favorites_layout'
+
+    entries = client.all_entries('/desktop/sugar/desktop')
+    for entry in entries:
+        key = entry.get_key()
+        if key.startswith(prefix):
+            # entry.get_value().get_string() causes sugar to crash later
+            # not on the call, but after some random time
+            # was impossible to debug (almost impossible)
+            value = entry.value.get_string()
+            layouts.append((key, value))
+
+    layouts.sort()
+    gconf_layouts = [layout[1] for layout in layouts][:number_of_views]
+
+    while len(gconf_layouts) < number_of_views:
+        gconf_layouts.append('ring-layout')
+
+    options = client.get('/desktop/sugar/desktop/favorite-icons')
+    gconf_fav_icons = []
+    if options:
+        gconf_fav_icons = [gval.get_string() for gval in options.get_list()]
+        gconf_fav_icons = gconf_fav_icons[:number_of_views]
+
+    while len(gconf_fav_icons) < number_of_views:
+        gconf_fav_icons.append('emblem-favorite')
+
+    homeviews = []
+    for i, view_icon in enumerate(gconf_view_icons):
+        homeviews.append({'view-icon': view_icon, 'layout': gconf_layouts[i],
+                          'favorite-icon': gconf_fav_icons[i]})
+
+    variant = GLib.Variant('aa{ss}', homeviews)
+    settings = Gio.Settings('org.sugarlabs.desktop')
+    settings.set_value('homeviews', variant)
+
+
+def _migrate_gconf_to_gsettings():
     try:
         subprocess.call('gsettings-data-convert')
     except subprocess.CalledProcessError:
         logging.error('Unable to convert data.')
+
+    settings = Gio.Settings('org.sugarlabs')
+    migrated = settings.get_boolean('gsettings-migrated')
+
+    if not migrated:
+        _migrate_journal_mimeregistry()
+        _migrate_homeviews_settings()
+
+        settings.set_boolean('gsettings-migrated', True)
 
 
 def setup_locale():
@@ -281,7 +377,7 @@ def main():
 
     Gst.init(sys.argv)
 
-    _gconf_to_gsettings_data_convert()
+    _migrate_gconf_to_gsettings()
 
     cleanup_temporary_files()
 

--- a/src/jarabe/model/desktop.py
+++ b/src/jarabe/model/desktop.py
@@ -20,12 +20,8 @@ from gi.repository import Gio
 
 _desktop_view_instance = None
 
-_VIEW_ICONS = ['view-radial']
-_FAVORITE_ICONS = ['emblem-favorite']
-
 _DESKTOP_CONF_DIR = 'org.sugarlabs.desktop'
-_VIEW_KEY = 'view-icons'
-_FAVORITE_KEY = 'favorite-icons'
+_HOMEVIEWS_KEY = 'homeviews'
 
 
 class DesktopViewModel(GObject.GObject):
@@ -45,7 +41,7 @@ class DesktopViewModel(GObject.GObject):
         self._settings = Gio.Settings(_DESKTOP_CONF_DIR)
         self._ensure_view_icons()
         self._settings.connect(
-            'changed::%s' % _VIEW_KEY, self.__conf_changed_cb, None)
+            'changed::%s' % _HOMEVIEWS_KEY, self.__conf_changed_cb, None)
 
     def get_view_icons(self):
         return self._view_icons
@@ -63,21 +59,18 @@ class DesktopViewModel(GObject.GObject):
     favorite_icons = GObject.property(type=object, getter=get_favorite_icons)
 
     def _ensure_view_icons(self, update=False):
-        if self._view_icons is not None and not update:
+        if self._view_icons and not update:
             return
 
-        self._view_icons = self._settings.get_strv(_VIEW_KEY)
-        if not self._view_icons:
-            self._view_icons = _VIEW_ICONS[:]
-        self._number_of_views = len(self._view_icons)
+        homeviews = self._settings.get_value(_HOMEVIEWS_KEY).unpack()
+        if not homeviews:
+            # there should always be atleast one homeview
+            self._settings.reset(_HOMEVIEWS_KEY)
+            homeviews = self._settings.get_value(_HOMEVIEWS_KEY).unpack()
 
-        self._favorite_icons = self._settings.get_strv(_FAVORITE_KEY)
-        if not self._favorite_icons:
-            self._favorite_icons = _FAVORITE_ICONS[:]
-
-        if len(self._favorite_icons) < self._number_of_views:
-            for i in range(self._number_of_views - len(self._favorite_icons)):
-                self._favorite_icons.append(_FAVORITE_ICONS[0])
+        self._number_of_views = len(homeviews)
+        self._view_icons = [view['view-icon'] for view in homeviews]
+        self._favorite_icons = [view['favorite-icon'] for view in homeviews]
 
         self.emit('desktop-view-icons-changed')
 

--- a/src/jarabe/model/mimeregistry.py
+++ b/src/jarabe/model/mimeregistry.py
@@ -14,14 +14,11 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-import re
+from gi.repository import GLib
+from gi.repository import Gio
 
-# FIXME: find a way to port this to GSettings
-from gi.repository import GConf
-
-
-_DEFAULTS_KEY = '/desktop/sugar/journal/defaults'
-_GCONF_INVALID_CHARS = re.compile('[^a-zA-Z0-9-_/.]')
+_JOURNAL_DIR = 'org.sugarlabs.journal'
+_REGISTRY_KEY = 'mime-registry'
 
 _instance = None
 
@@ -30,13 +27,18 @@ class MimeRegistry(object):
 
     def __init__(self):
         # TODO move here all mime_type related code from jarabe modules
-        self._gconf = GConf.Client.get_default()
+        self._settings = Gio.Settings(_JOURNAL_DIR)
 
     def get_default_activity(self, mime_type):
-        return self._gconf.get_string(_key_name(mime_type))
+        dictionary = self._settings.get_value(_REGISTRY_KEY).unpack()
+        return dictionary.get(mime_type)
 
     def set_default_activity(self, mime_type, bundle_id):
-        self._gconf.set_string(_key_name(mime_type), bundle_id)
+        dictionary = self._settings.get_value(_REGISTRY_KEY).unpack()
+        dictionary[mime_type] = bundle_id
+
+        variant = GLib.Variant('a{ss}', dictionary)
+        self._settings.set_value(_REGISTRY_KEY, variant)
 
 
 def get_registry():
@@ -44,8 +46,3 @@ def get_registry():
     if _instance is None:
         _instance = MimeRegistry()
     return _instance
-
-
-def _key_name(mime_type):
-    mime_type = _GCONF_INVALID_CHARS.sub('_', mime_type)
-    return '%s/%s' % (_DEFAULTS_KEY, mime_type)

--- a/tests/test_desktop_config.py
+++ b/tests/test_desktop_config.py
@@ -17,15 +17,19 @@
 from sugar3.test import unittest
 
 from gi.repository import Gio
+from gi.repository import GLib
 
 from jarabe.model import desktop
 
 _DESKTOP_CONF_DIR = 'org.sugarlabs.desktop'
-_VIEW_KEY = 'view-icons'
-_FAVORITE_KEY = 'favorite-icons'
+_HOMEVIEWS_KEY = 'homeviews'
 
-_VIEW_ICONS = ['view-radial']
-_MOCK_LIST = ['view-radial', 'view-random']
+_VIEW_ICONS = [{'layout': 'box-layout', 'view-icon': 'view-radial',
+               'favorite-icon': 'emblem-locked'}]
+_MOCK_LIST = [{'layout': 'box-layout', 'view-icon': 'view-radial',
+               'favorite-icon': 'emblem-locked'},
+              {'layout': 'ring-layout', 'view-icon': 'view-box',
+               'favorite-icon': 'emblem-favorite'}]
 
 
 class TestDesktopConfig(unittest.UITestCase):
@@ -34,22 +38,22 @@ class TestDesktopConfig(unittest.UITestCase):
         self.target = []
 
         settings = Gio.Settings(_DESKTOP_CONF_DIR)
-        self._save_view_icons = settings.get_strv(_VIEW_KEY)
-        self._save_favorite_icons = settings.get_strv(_FAVORITE_KEY)
+        self._save_homeviews = settings.get_value(_HOMEVIEWS_KEY)
 
         self.model = desktop.get_model()
         self.model.connect('desktop-view-icons-changed',
                            self.__desktop_view_icons_changed_cb)
 
-    def __desktop_view_icons_changed_cb(self):
+    def __desktop_view_icons_changed_cb(self, model):
         number_of_views = desktop.get_number_of_views()
         self.assertTrue(number_of_views == len(self.target))
 
         view_icons = desktop.get_view_icons()
         self.assertTrue(len(view_icons) == len(self.target))
 
+        right_view_icons = [view['view-icon'] for view in self.target]
         for i in range(len(view_icons)):
-            self.assertTrue(view_icons[i] in self.target)
+            self.assertTrue(view_icons[i] in right_view_icons)
 
         favorite_icons = desktop.get_favorite_icons()
         self.assertTrue(len(favorite_icons) >= len(self.target))
@@ -58,22 +62,17 @@ class TestDesktopConfig(unittest.UITestCase):
         self.target = _VIEW_ICONS
         with self.run_view("gtk_main"):
             settings = Gio.Settings(_DESKTOP_CONF_DIR)
-            settings.set_strv(_VIEW_KEY, [])
+            variant = GLib.Variant('aa{ss}', self.target)
+            settings.set_value(_HOMEVIEWS_KEY, variant)
 
     def test_set_views(self):
         self.target = _MOCK_LIST
         with self.run_view("gtk_main"):
             settings = Gio.Settings(_DESKTOP_CONF_DIR)
-            settings.set_strv(_VIEW_KEY, _MOCK_LIST)
+            variant = GLib.Variant('aa{ss}', self.target)
+            settings.set_value(_HOMEVIEWS_KEY, variant)
 
     def tearDown(self):
+        self.target = self._save_homeviews.unpack()
         settings = Gio.Settings(_DESKTOP_CONF_DIR)
-        if self._save_view_icons is None:
-            settings.set_strv(_VIEW_KEY, [])
-        else:
-            settings.set_strv(_VIEW_KEY, self._save_view_icons)
-
-        if self._save_favorite_icons is None:
-            settings.set_strv(_FAVORITE_KEY, [])
-        else:
-            settings.set_strv(_FAVORITE_KEY, self._save_favorite_icons)
+        settings.set_value(_HOMEVIEWS_KEY, self._save_homeviews)


### PR DESCRIPTION
The patch converts the last 2 GConf keys to GSettings
It also merges several homeview keys from being parallel arrays to a single array of dictionaries
It has code to migrate the GConf values of those keys to the new GSettings variant
Also, the patch fixes a bug in one of the tests (and the test is rewritten to suit the new GSettings scheme)
