### PR TITLE
Icon API change: use pixel_size

### DIFF
--- a/extensions/cpsection/updater/view.py
+++ b/extensions/cpsection/updater/view.py
@@ -264,8 +264,9 @@ class UpdateBox(Gtk.VBox):
         self.refresh_button.show()
 
         self.install_button = Gtk.Button(_('Install selected'))
-        self.install_button.props.image = Icon(icon_name='emblem-downloads',
-                                               icon_size=Gtk.IconSize.BUTTON)
+        self.install_button.props.image = Icon(
+            icon_name='emblem-downloads',
+            pixel_size=style.SMALL_ICON_SIZE)
         bottom_box.pack_start(self.install_button, False, True, 0)
         self.install_button.show()
 

--- a/extensions/deviceicon/network.py
+++ b/extensions/deviceicon/network.py
@@ -79,7 +79,8 @@ class WirelessPalette(Palette):
         self._info = Gtk.VBox()
 
         self._disconnect_item = PaletteMenuItem(_('Disconnect'))
-        icon = Icon(icon_size=Gtk.IconSize.MENU, icon_name='media-eject')
+        icon = Icon(pixel_size=style.SMALL_ICON_SIZE,
+                    icon_name='media-eject')
         self._disconnect_item.set_image(icon)
         self._disconnect_item.connect('activate',
                                       self.__disconnect_activate_cb)
@@ -232,7 +233,8 @@ class GsmPalette(Palette):
         self.info_box.pack_start(self.error_description_label, True, True, 0)
 
         self.connection_info_box = Gtk.HBox()
-        icon = Icon(icon_name='data-upload', icon_size=Gtk.IconSize.MENU)
+        icon = Icon(icon_name='data-upload',
+                    pixel_size=style.SMALL_ICON_SIZE)
         self.connection_info_box.pack_start(icon, True, True, 0)
         icon.show()
 
@@ -243,7 +245,8 @@ class GsmPalette(Palette):
         self._data_label_up.show()
         label_alignment.show()
 
-        icon = Icon(icon_name='data-download', icon_size=Gtk.IconSize.MENU)
+        icon = Icon(icon_name='data-download',
+                    pixel_size=style.SMALL_ICON_SIZE)
         self.connection_info_box.pack_start(icon, True, True, 0)
         icon.show()
         self._data_label_down = Gtk.Label()
@@ -286,7 +289,7 @@ class GsmPalette(Palette):
             label = GLib.markup_escape_text(_('Disconnected'))
             self.props.secondary_text = label
             icon = Icon(icon_name='dialog-ok',
-                        icon_size=Gtk.IconSize.MENU)
+                        pixel_size=style.SMALL_ICON_SIZE)
             self._toggle_state_item.set_image(icon)
 
         elif self._current_state == _GSM_STATE_CONNECTING:
@@ -294,7 +297,7 @@ class GsmPalette(Palette):
             label = GLib.markup_escape_text(_('Connecting...'))
             self.props.secondary_text = label
             icon = Icon(icon_name='dialog-cancel',
-                        icon_size=Gtk.IconSize.MENU)
+                        pixel_size=style.SMALL_ICON_SIZE)
             self._toggle_state_item.set_image(icon)
 
         elif self._current_state == _GSM_STATE_CONNECTED:
@@ -302,7 +305,7 @@ class GsmPalette(Palette):
             self._toggle_state_item.set_label(_('Disconnect'))
             self.update_connection_time()
             icon = Icon(icon_name='media-eject',
-                        icon_size=Gtk.IconSize.MENU)
+                        pixel_size=style.SMALL_ICON_SIZE)
             self._toggle_state_item.set_image(icon)
 
         elif self._current_state == _GSM_STATE_FAILED:

--- a/extensions/deviceicon/speaker.py
+++ b/extensions/deviceicon/speaker.py
@@ -95,7 +95,7 @@ class SpeakerPalette(Palette):
         box.show()
 
         self._mute_item = PaletteMenuItem('')
-        self._mute_icon = Icon(icon_size=Gtk.IconSize.MENU)
+        self._mute_icon = Icon(pixel_size=style.SMALL_ICON_SIZE)
         self._mute_item.set_image(self._mute_icon)
         box.append_item(self._mute_item)
         self._mute_item.show()

--- a/extensions/deviceicon/volume.py
+++ b/extensions/deviceicon/volume.py
@@ -25,6 +25,7 @@ from sugar3 import profile
 from sugar3.graphics.tray import TrayIcon
 from sugar3.graphics.palettemenu import PaletteMenuItem
 from sugar3.graphics.icon import Icon
+from sugar3.graphics import style
 
 from jarabe.journal import journalactivity
 from jarabe.journal.misc import get_mount_icon_name
@@ -59,7 +60,8 @@ class DeviceView(TrayIcon):
 
         menu_item = PaletteMenuItem(_('Show contents'))
         color = profile.get_color()
-        icon = Icon(icon_name=self._icon_name, icon_size=Gtk.IconSize.MENU,
+        icon = Icon(icon_name=self._icon_name,
+                    pixel_size=style.SMALL_ICON_SIZE,
                     xo_color=color)
         menu_item.set_image(icon)
         icon.show()

--- a/src/jarabe/desktop/activitieslist.py
+++ b/src/jarabe/desktop/activitieslist.py
@@ -384,7 +384,7 @@ class ClearMessageBox(Gtk.EventBox):
         button = Gtk.Button(label=_('Clear search'))
         button.connect('clicked', button_callback)
         button.props.image = Icon(icon_name='dialog-cancel',
-                                  icon_size=Gtk.IconSize.BUTTON)
+                                  pixel_size=style.SMALL_ICON_SIZE)
         button_box.pack_start(button, expand=True, fill=False, padding=0)
         button.show()
 
@@ -552,7 +552,7 @@ class ActivityListPalette(ActivityPalette):
             self._favorite_items.append(PaletteMenuItem())
             self._favorite_icons.append(
                 Icon(icon_name=desktop.get_favorite_icons()[i],
-                     icon_size=Gtk.IconSize.MENU))
+                     pixel_size=style.SMALL_ICON_SIZE))
             self._favorite_items[i].set_image(self._favorite_icons[i])
             self._favorite_icons[i].show()
             self._favorite_items[i].connect(

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -541,7 +541,7 @@ class FavoritePalette(ActivityPalette):
 
         self.props.icon = Icon(file=activity_info.get_icon(),
                                xo_color=xo_color,
-                               icon_size=Gtk.IconSize.LARGE_TOOLBAR)
+                               pixel_size=style.STANDARD_ICON_SIZE)
 
         if journal_entries:
             title = journal_entries[0]['title']

--- a/src/jarabe/desktop/meshbox.py
+++ b/src/jarabe/desktop/meshbox.py
@@ -23,7 +23,6 @@ import logging
 import dbus
 from gi.repository import GLib
 from gi.repository import GObject
-from gi.repository import Gtk
 from gi.repository import Gio
 
 from sugar3.graphics.icon import Icon
@@ -66,8 +65,8 @@ class _ActivityIcon(CanvasIcon):
         primary_text = GLib.markup_escape_text(self._model.bundle.get_name())
         secondary_text = GLib.markup_escape_text(self._model.get_name())
         palette_icon = Icon(file=self._model.bundle.get_icon(),
+                            pixel_size=style.STANDARD_ICON_SIZE,
                             xo_color=self._model.get_color())
-        palette_icon.props.icon_size = Gtk.IconSize.LARGE_TOOLBAR
         palette = Palette(None,
                           primary_text=primary_text,
                           secondary_text=secondary_text,
@@ -81,14 +80,14 @@ class _ActivityIcon(CanvasIcon):
         if joined:
             item = PaletteMenuItem(_('Resume'))
             icon = Icon(
-                icon_size=Gtk.IconSize.MENU, icon_name='activity-start')
+                pixel_size=style.SMALL_ICON_SIZE, icon_name='activity-start')
             item.set_image(icon)
             item.connect('activate', self.__palette_item_clicked_cb)
             menu_box.append_item(item)
         elif not private:
             item = PaletteMenuItem(_('Join'))
             icon = Icon(
-                icon_size=Gtk.IconSize.MENU, icon_name='activity-start')
+                pixel_size=style.SMALL_ICON_SIZE, icon_name='activity-start')
             item.set_image(icon)
             item.connect('activate', self.__palette_item_clicked_cb)
             menu_box.append_item(item)

--- a/src/jarabe/desktop/networkviews.py
+++ b/src/jarabe/desktop/networkviews.py
@@ -127,13 +127,13 @@ class WirelessNetworkView(EventPulsingIcon):
         self.menu_box = Gtk.VBox()
 
         self._connect_item = PaletteMenuItem(_('Connect'))
-        icon = Icon(icon_size=Gtk.IconSize.MENU, icon_name='dialog-ok')
+        icon = Icon(pixel_size=style.SMALL_ICON_SIZE, icon_name='dialog-ok')
         self._connect_item.set_image(icon)
         self._connect_item.connect('activate', self.__connect_activate_cb)
         self.menu_box.add(self._connect_item)
 
         self._disconnect_item = PaletteMenuItem(_('Disconnect'))
-        icon = Icon(icon_size=Gtk.IconSize.MENU, icon_name='media-eject')
+        icon = Icon(pixel_size=style.SMALL_ICON_SIZE, icon_name='media-eject')
         self._disconnect_item.set_image(icon)
         self._disconnect_item.connect(
             'activate', self.__disconnect_activate_cb)
@@ -501,13 +501,13 @@ class SugarAdhocView(EventPulsingIcon):
         self.menu_box = Gtk.VBox()
 
         self._connect_item = PaletteMenuItem(_('Connect'))
-        icon = Icon(icon_size=Gtk.IconSize.MENU, icon_name='dialog-ok')
+        icon = Icon(pixel_size=style.SMALL_ICON_SIZE, icon_name='dialog-ok')
         self._connect_item.set_image(icon)
         self._connect_item.connect('activate', self.__connect_activate_cb)
         self.menu_box.add(self._connect_item)
 
         self._disconnect_item = PaletteMenuItem(_('Disconnect'))
-        icon = Icon(icon_size=Gtk.IconSize.MENU, icon_name='media-eject')
+        icon = Icon(pixel_size=style.SMALL_ICON_SIZE, icon_name='media-eject')
         self._disconnect_item.set_image(icon)
         self._disconnect_item.connect(
             'activate', self.__disconnect_activate_cb)
@@ -642,7 +642,7 @@ class OlpcMeshView(EventPulsingIcon):
         self.menu_box = Gtk.VBox()
 
         self._connect_item = PaletteMenuItem(_('Connect'))
-        icon = Icon(icon_size=Gtk.IconSize.MENU, icon_name='dialog-ok')
+        icon = Icon(pixel_size=style.SMALL_ICON_SIZE, icon_name='dialog-ok')
         self._connect_item.set_image(icon)
         self._connect_item.connect('activate', self.__connect_activate_cb)
         self.menu_box.add(self._connect_item)

--- a/src/jarabe/frame/activitiestray.py
+++ b/src/jarabe/frame/activitiestray.py
@@ -585,7 +585,8 @@ class IncomingTransferPalette(BaseTransferPalette):
         logging.debug('_update state: %r', self.file_transfer.props.state)
         if self.file_transfer.props.state == filetransfer.FT_STATE_PENDING:
             menu_item = PaletteMenuItem(_('Accept'))
-            icon = Icon(icon_name='dialog-ok', icon_size=Gtk.IconSize.MENU)
+            icon = Icon(icon_name='dialog-ok',
+                        pixel_size=style.SMALL_ICON_SIZE)
             menu_item.set_image(icon)
             icon.show()
             menu_item.connect('activate', self.__accept_activate_cb)
@@ -593,7 +594,8 @@ class IncomingTransferPalette(BaseTransferPalette):
             menu_item.show()
 
             menu_item = PaletteMenuItem(_('Decline'))
-            icon = Icon(icon_name='dialog-cancel', icon_size=Gtk.IconSize.MENU)
+            icon = Icon(icon_name='dialog-cancel',
+                        pixel_size=style.SMALL_ICON_SIZE)
             menu_item.set_image(icon)
             icon.show()
             menu_item.connect('activate', self.__decline_activate_cb)
@@ -625,7 +627,8 @@ class IncomingTransferPalette(BaseTransferPalette):
         elif self.file_transfer.props.state in \
                 [filetransfer.FT_STATE_ACCEPTED, filetransfer.FT_STATE_OPEN]:
             menu_item = PaletteMenuItem(_('Cancel'))
-            icon = Icon(icon_name='dialog-cancel', icon_size=Gtk.IconSize.MENU)
+            icon = Icon(icon_name='dialog-cancel',
+                        pixel_size=style.SMALL_ICON_SIZE)
             menu_item.set_image(icon)
             icon.show()
             menu_item.connect('activate', self.__cancel_activate_cb)
@@ -653,7 +656,8 @@ class IncomingTransferPalette(BaseTransferPalette):
 
         elif self.file_transfer.props.state == filetransfer.FT_STATE_COMPLETED:
             menu_item = PaletteMenuItem(_('Dismiss'))
-            icon = Icon(icon_name='dialog-cancel', icon_size=Gtk.IconSize.MENU)
+            icon = Icon(icon_name='dialog-cancel',
+                        pixel_size=style.SMALL_ICON_SIZE)
             menu_item.set_image(icon)
             icon.show()
             menu_item.connect('activate', self.__dismiss_activate_cb)
@@ -667,7 +671,7 @@ class IncomingTransferPalette(BaseTransferPalette):
                     filetransfer.FT_REASON_REMOTE_STOPPED:
                 menu_item = PaletteMenuItem(_('Dismiss'))
                 icon = Icon(icon_name='dialog-cancel',
-                            icon_size=Gtk.IconSize.MENU)
+                            pixel_size=style.SMALL_ICON_SIZE)
                 menu_item.set_image(icon)
                 icon.show()
                 menu_item.connect('activate', self.__dismiss_activate_cb)
@@ -746,7 +750,8 @@ class OutgoingTransferPalette(BaseTransferPalette):
         box.show()
         if new_state == filetransfer.FT_STATE_PENDING:
             menu_item = PaletteMenuItem(_('Cancel'))
-            icon = Icon(icon_name='dialog-cancel', icon_size=Gtk.IconSize.MENU)
+            icon = Icon(icon_name='dialog-cancel',
+                        pixel_size=style.SMALL_ICON_SIZE)
             menu_item.set_image(icon)
             icon.show()
             menu_item.connect('activate', self.__cancel_activate_cb)
@@ -778,7 +783,8 @@ class OutgoingTransferPalette(BaseTransferPalette):
         elif new_state in [filetransfer.FT_STATE_ACCEPTED,
                            filetransfer.FT_STATE_OPEN]:
             menu_item = PaletteMenuItem(_('Cancel'))
-            icon = Icon(icon_name='dialog-cancel', icon_size=Gtk.IconSize.MENU)
+            icon = Icon(icon_name='dialog-cancel',
+                        pixel_size=style.SMALL_ICON_SIZE)
             menu_item.set_image(icon)
             icon.show()
             menu_item.connect('activate', self.__cancel_activate_cb)
@@ -807,7 +813,8 @@ class OutgoingTransferPalette(BaseTransferPalette):
         elif new_state in [filetransfer.FT_STATE_COMPLETED,
                            filetransfer.FT_STATE_CANCELLED]:
             menu_item = PaletteMenuItem(_('Dismiss'))
-            icon = Icon(icon_name='dialog-cancel', icon_size=Gtk.IconSize.MENU)
+            icon = Icon(icon_name='dialog-cancel',
+                        pixel_size=style.SMALL_ICON_SIZE)
             menu_item.set_image(icon)
             icon.show()
             menu_item.connect('activate', self.__dismiss_activate_cb)

--- a/src/jarabe/frame/clipboardmenu.py
+++ b/src/jarabe/frame/clipboardmenu.py
@@ -27,6 +27,7 @@ from gi.repository import Gtk
 from sugar3.graphics.palette import Palette
 from sugar3.graphics.menuitem import MenuItem
 from sugar3.graphics.icon import Icon
+from sugar3.graphics import style
 from sugar3.datastore import datastore
 from sugar3 import mime
 from sugar3 import env
@@ -64,7 +65,8 @@ class ClipboardMenu(Palette):
 
         self._journal_item = MenuItem(_('Keep'))
         color = profile.get_color()
-        icon = Icon(icon_name='document-save', icon_size=Gtk.IconSize.MENU,
+        icon = Icon(icon_name='document-save',
+                    pixel_size=style.SMALL_ICON_SIZE,
                     xo_color=color)
         self._journal_item.set_image(icon)
 

--- a/src/jarabe/journal/detailview.py
+++ b/src/jarabe/journal/detailview.py
@@ -87,7 +87,7 @@ class BackBar(Gtk.EventBox):
                        style.COLOR_PANEL_GREY.get_gdk_color())
         hbox = Gtk.HBox(spacing=style.DEFAULT_PADDING)
         hbox.set_border_width(style.DEFAULT_PADDING)
-        icon = Icon(icon_name='go-previous', icon_size=Gtk.IconSize.MENU,
+        icon = Icon(icon_name='go-previous', pixel_size=style.SMALL_ICON_SIZE,
                     fill_color=style.COLOR_TOOLBAR_GREY.get_svg())
         hbox.pack_start(icon, False, False, 0)
 

--- a/src/jarabe/journal/iconview.py
+++ b/src/jarabe/journal/iconview.py
@@ -299,7 +299,7 @@ class IconView(Gtk.Bin):
             button = Gtk.Button(label=_('Clear search'))
             button.connect('clicked', self.__clear_button_clicked_cb)
             button.props.image = Icon(icon_name='dialog-cancel',
-                                      icon_size=Gtk.IconSize.BUTTON)
+                                      pixel_size=style.SMALL_ICON_SIZE)
             button_box.pack_start(button, expand=True, fill=False, padding=0)
 
         background_box.show_all()

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -36,6 +36,7 @@ from sugar3.graphics.palettemenu import PaletteMenuItem
 from sugar3.graphics.icon import Icon
 from sugar3.graphics.alert import Alert
 from sugar3.graphics import iconentry
+from sugar3.graphics import style
 from sugar3 import mime
 from sugar3 import profile
 from sugar3.graphics.objectchooser import FILTER_TYPE_MIME_BY_ACTIVITY
@@ -611,7 +612,8 @@ class SortingButton(ToolButton):
 
         for property_, icon, label in self._SORT_OPTIONS:
             button = PaletteMenuItem(label)
-            button_icon = Icon(icon_size=Gtk.IconSize.MENU, icon_name=icon)
+            button_icon = Icon(pixel_size=style.SMALL_ICON_SIZE,
+                               icon_name=icon)
             button.set_image(button_icon)
             button_icon.show()
             button.connect('activate',

--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -475,7 +475,7 @@ class BaseListView(Gtk.Bin):
             button = Gtk.Button(label=_('Clear search'))
             button.connect('clicked', self.__clear_button_clicked_cb)
             button.props.image = Icon(icon_name='dialog-cancel',
-                                      icon_size=Gtk.IconSize.BUTTON)
+                                      pixel_size=style.SMALL_ICON_SIZE)
             button_box.pack_start(button, expand=True, fill=False, padding=0)
 
         background_box.show_all()

--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -59,7 +59,7 @@ class ObjectPalette(Palette):
         self._journalactivity = journalactivity
         self._metadata = metadata
 
-        activity_icon = Icon(icon_size=Gtk.IconSize.LARGE_TOOLBAR)
+        activity_icon = Icon(pixel_size=style.STANDARD_ICON_SIZE)
         activity_icon.props.file = misc.get_icon_name(metadata)
         color = misc.get_icon_color(metadata)
         activity_icon.props.xo_color = color
@@ -98,7 +98,7 @@ class ObjectPalette(Palette):
 
         menu_item = MenuItem(_('Copy to'))
         icon = Icon(icon_name='edit-copy', xo_color=color,
-                    icon_size=Gtk.IconSize.MENU)
+                    pixel_size=style.SMALL_ICON_SIZE)
         menu_item.set_image(icon)
         self.menu.append(menu_item)
         menu_item.show()
@@ -109,7 +109,7 @@ class ObjectPalette(Palette):
         if self._metadata['mountpoint'] == '/':
             menu_item = MenuItem(_('Duplicate'))
             icon = Icon(icon_name='edit-duplicate', xo_color=color,
-                        icon_size=Gtk.IconSize.MENU)
+                        pixel_size=style.SMALL_ICON_SIZE)
             menu_item.set_image(icon)
             menu_item.connect('activate', self.__duplicate_activate_cb)
             self.menu.append(menu_item)
@@ -243,7 +243,7 @@ class CopyMenuBuilder():
         if self._add_clipboard_menu:
             clipboard_menu = ClipboardMenu(self._get_uid_list_cb)
             clipboard_menu.set_image(Icon(icon_name='toolbar-edit',
-                                          icon_size=Gtk.IconSize.MENU))
+                                          pixel_size=style.SMALL_ICON_SIZE))
             clipboard_menu.connect('volume-error', self.__volume_error_cb)
             self._menu.append(clipboard_menu)
             clipboard_menu.show()
@@ -254,7 +254,7 @@ class CopyMenuBuilder():
                                       self._get_uid_list_cb, _('Journal'), '/')
             journal_menu.set_image(Icon(icon_name='activity-journal',
                                         xo_color=color,
-                                        icon_size=Gtk.IconSize.MENU))
+                                        pixel_size=style.SMALL_ICON_SIZE))
             journal_menu.connect('volume-error', self.__volume_error_cb)
             self._menu.append(journal_menu)
             journal_menu.show()
@@ -266,7 +266,7 @@ class CopyMenuBuilder():
                                         self._get_uid_list_cb, _('Documents'),
                                         documents_path)
             documents_menu.set_image(Icon(icon_name='user-documents',
-                                          icon_size=Gtk.IconSize.MENU))
+                                          pixel_size=style.SMALL_ICON_SIZE))
             documents_menu.connect('volume-error', self.__volume_error_cb)
             self._menu.append(documents_menu)
             documents_menu.show()
@@ -309,7 +309,7 @@ class CopyMenuBuilder():
                                  self._get_uid_list_cb, mount.get_name(),
                                  mount.get_root().get_path())
         icon_name = misc.get_mount_icon_name(mount, Gtk.IconSize.MENU)
-        volume_menu.set_image(Icon(icon_size=Gtk.IconSize.MENU,
+        volume_menu.set_image(Icon(pixel_size=style.SMALL_ICON_SIZE,
                                    icon_name=icon_name))
         volume_menu.connect('volume-error', self.__volume_error_cb)
         self._menu.append(volume_menu)
@@ -481,7 +481,7 @@ class StartWithMenu(Gtk.Menu):
         for activity_info in misc.get_activities(metadata):
             menu_item = MenuItem(activity_info.get_name())
             menu_item.set_image(Icon(file=activity_info.get_icon(),
-                                     icon_size=Gtk.IconSize.MENU))
+                                     pixel_size=style.SMALL_ICON_SIZE))
             menu_item.connect('activate', self.__item_activate_cb,
                               activity_info.get_bundle_id())
             self.append(menu_item)

--- a/src/jarabe/view/buddymenu.py
+++ b/src/jarabe/view/buddymenu.py
@@ -27,6 +27,7 @@ import dbus
 from sugar3.graphics.palette import Palette
 from sugar3.graphics.palettemenu import PaletteMenuItem
 from sugar3.graphics.icon import Icon
+from sugar3.graphics import style
 
 from jarabe.model import shell
 from jarabe.model import friends
@@ -41,7 +42,7 @@ class BuddyMenu(Palette):
 
         buddy_icon = Icon(icon_name='computer-xo',
                           xo_color=buddy.get_color(),
-                          icon_size=Gtk.IconSize.LARGE_TOOLBAR)
+                          pixel_size=style.STANDARD_ICON_SIZE)
         nick = buddy.get_nick()
         Palette.__init__(self, None,
                          primary_text=GLib.markup_escape_text(nick),
@@ -164,7 +165,7 @@ class BuddyMenu(Palette):
             self._invite_menu.set_label(_('Invite to %s') % title)
 
             icon = Icon(file=activity.get_icon_path(),
-                        icon_size=Gtk.IconSize.SMALL_TOOLBAR)
+                        pixel_size=style.SMALL_ICON_SIZE)
             icon.props.xo_color = activity.get_icon_color()
             self._invite_menu.set_image(icon)
             icon.show()

--- a/src/jarabe/view/palettes.py
+++ b/src/jarabe/view/palettes.py
@@ -140,7 +140,7 @@ class ActivityPalette(Palette):
         color = profile.get_color()
         activity_icon = Icon(file=activity_info.get_icon(),
                              xo_color=color,
-                             icon_size=Gtk.IconSize.LARGE_TOOLBAR)
+                             pixel_size=style.STANDARD_ICON_SIZE)
 
         name = activity_info.get_name()
         Palette.__init__(self, primary_text=GLib.markup_escape_text(name),
@@ -182,7 +182,7 @@ class JournalPalette(BasePalette):
 
         menu_item = PaletteMenuItem(_('Show contents'))
         icon = Icon(file=self._home_activity.get_icon_path(),
-                    icon_size=Gtk.IconSize.MENU,
+                    pixel_size=style.SMALL_ICON_SIZE,
                     xo_color=self._home_activity.get_icon_color())
         menu_item.set_image(icon)
         icon.show()
@@ -239,7 +239,7 @@ class VolumePalette(Palette):
 
         menu_item = PaletteMenuItem(pgettext('Volume', 'Remove'))
 
-        icon = Icon(icon_name='media-eject', icon_size=Gtk.IconSize.MENU)
+        icon = Icon(icon_name='media-eject', pixel_size=style.SMALL_ICON_SIZE)
         menu_item.set_image(icon)
         icon.show()
 

--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -329,7 +329,7 @@ class DocumentButton(RadioToolButton):
         settings = Gio.Settings('org.sugarlabs.user')
         self._color = settings.get_string('color')
         icon = Icon(file=file_name,
-                    icon_size=Gtk.IconSize.LARGE_TOOLBAR,
+                    pixel_size=style.STANDARD_ICON_SIZE,
                     xo_color=XoColor(self._color))
         self.set_icon_widget(icon)
         icon.show()
@@ -337,13 +337,13 @@ class DocumentButton(RadioToolButton):
         if bundle:
             menu_item = MenuItem(_('Duplicate'))
             icon = Icon(icon_name='edit-duplicate',
-                        icon_size=Gtk.IconSize.MENU,
+                        pixel_size=style.SMALL_ICON_SIZE,
                         xo_color=XoColor(self._color))
             menu_item.connect('activate', self.__copy_to_home_cb)
         else:
             menu_item = MenuItem(_('Keep'))
             icon = Icon(icon_name='document-save',
-                        icon_size=Gtk.IconSize.MENU,
+                        pixel_size=style.SMALL_ICON_SIZE,
                         xo_color=XoColor(self._color))
             menu_item.connect('activate', self.__keep_in_journal_cb)
 
@@ -428,7 +428,7 @@ class Toolbar(Gtk.Toolbar):
             activity_button = DocumentButton(file_name, bundle_path, title,
                                              bundle=True)
             icon = Icon(file=file_name,
-                        icon_size=Gtk.IconSize.LARGE_TOOLBAR,
+                        pixel_size=style.STANDARD_ICON_SIZE,
                         fill_color=style.COLOR_TRANSPARENT.get_svg(),
                         stroke_color=style.COLOR_WHITE.get_svg())
             activity_button.set_icon_widget(icon)
@@ -445,7 +445,7 @@ class Toolbar(Gtk.Toolbar):
         if sugar_toolkit_path is not None:
             sugar_button = RadioToolButton()
             icon = Icon(icon_name='computer-xo',
-                        icon_size=Gtk.IconSize.LARGE_TOOLBAR,
+                        pixel_size=style.STANDARD_ICON_SIZE,
                         fill_color=style.COLOR_TRANSPARENT.get_svg(),
                         stroke_color=style.COLOR_WHITE.get_svg())
             sugar_button.set_icon_widget(icon)


### PR DESCRIPTION
Instead of the deprecated icon_size.

There are still places where Gtk.IconSize constants are used, in:
- Gtk.Image.set_from_icon_name - still needs an icon size
- Gtk.IconTheme.lookup_icon - the documentation is not clear in the
  'size' parameter, maybe we can move to pixel_size
