### PR TITLE
Fix error while trying to open journal palette. Fixes #4637

### DIFF
--- a/src/jarabe/journal/listmodel.py
+++ b/src/jarabe/journal/listmodel.py
@@ -208,7 +208,7 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
                     logging.warning('Malformed buddies for %r: %s',
                                     metadata['uid'], exception)
                 else:
-                    self._cached_row.append((nick, XoColor(color)))
+                    self._cached_row.append([nick, XoColor(color)])
                     continue
 
             self._cached_row.append(None)


### PR DESCRIPTION
As explained in [1] pygobject is confused by methods
returning a tuple. Use a array is a workaround.

[1] https://bugzilla.gnome.org/show_bug.cgi?id=689277#c5
