### PR TITLE
Rework the wireless control panel section to respect non-wireless connec...

### DIFF
--- a/extensions/cpsection/network/view.py
+++ b/extensions/cpsection/network/view.py
@@ -43,7 +43,7 @@ class Network(SectionView):
         self._radio_valid = True
         self._jabber_change_handler = None
         self._radio_change_handler = None
-        self._network_configuration_reset_handler = None
+        self._wireless_configuration_reset_handler = None
 
         self.set_border_width(style.DEFAULT_SPACING * 2)
         self.set_spacing(style.DEFAULT_SPACING)
@@ -61,68 +61,74 @@ class Network(SectionView):
         scrolled.add_with_viewport(workspace)
         workspace.show()
 
-        separator_wireless = Gtk.HSeparator()
-        workspace.pack_start(separator_wireless, False, True, 0)
-        separator_wireless.show()
+        self.wireless_hardware_available = \
+            self._model.network.wireless_hardware_available()
+        if self.wireless_hardware_available:
+            separator_wireless = Gtk.HSeparator()
+            workspace.pack_start(separator_wireless, False, True, 0)
+            separator_wireless.show()
 
-        label_wireless = Gtk.Label(label=_('Wireless'))
-        label_wireless.set_alignment(0, 0)
-        workspace.pack_start(label_wireless, False, True, 0)
-        label_wireless.show()
-        box_wireless = Gtk.VBox()
-        box_wireless.set_border_width(style.DEFAULT_SPACING * 2)
-        box_wireless.set_spacing(style.DEFAULT_SPACING)
+            label_wireless = Gtk.Label(label=_('Wireless'))
+            label_wireless.set_alignment(0, 0)
+            workspace.pack_start(label_wireless, False, True, 0)
+            label_wireless.show()
+            box_wireless = Gtk.VBox()
+            box_wireless.set_border_width(style.DEFAULT_SPACING * 2)
+            box_wireless.set_spacing(style.DEFAULT_SPACING)
 
-        radio_info = Gtk.Label(label=
-                               _('Turn off the wireless radio to save battery'
-                                 ' life'))
-        radio_info.set_alignment(0, 0)
-        radio_info.set_line_wrap(True)
-        radio_info.show()
-        box_wireless.pack_start(radio_info, False, True, 0)
+            radio_info = Gtk.Label(label=_('The wireless radio may be turned'
+                                           ' off to save battery life.'))
+            radio_info.set_alignment(0, 0)
+            radio_info.set_line_wrap(True)
+            radio_info.show()
+            box_wireless.pack_start(radio_info, False, True, 0)
 
-        box_radio = Gtk.HBox(spacing=style.DEFAULT_SPACING)
-        self._button = Gtk.CheckButton()
-        self._button.set_alignment(0, 0)
-        box_radio.pack_start(self._button, False, True, 0)
-        self._button.show()
+            box_radio = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+            self._button = Gtk.CheckButton()
+            self._button.set_alignment(0, 0)
+            box_radio.pack_start(self._button, False, True, 0)
+            self._button.show()
 
-        label_radio = Gtk.Label(label=_('Radio'))
-        label_radio.set_alignment(0, 0.5)
-        box_radio.pack_start(label_radio, False, True, 0)
-        label_radio.show()
+            label_radio = Gtk.Label(label=_('Radio'))
+            label_radio.set_alignment(0, 0.5)
+            box_radio.pack_start(label_radio, False, True, 0)
+            label_radio.show()
 
-        box_wireless.pack_start(box_radio, False, True, 0)
-        box_radio.show()
+            box_wireless.pack_start(box_radio, False, True, 0)
+            box_radio.show()
 
-        self._radio_alert = InlineAlert()
-        self._radio_alert_box.pack_start(self._radio_alert, False, True, 0)
-        box_radio.pack_end(self._radio_alert_box, False, True, 0)
-        self._radio_alert_box.show()
-        if 'radio' in self.restart_alerts:
-            self._radio_alert.props.msg = self.restart_msg
-            self._radio_alert.show()
+            self._radio_alert = InlineAlert()
+            self._radio_alert_box.pack_start(self._radio_alert, False, True, 0)
+            box_radio.pack_end(self._radio_alert_box, False, True, 0)
+            self._radio_alert_box.show()
+            if 'radio' in self.restart_alerts:
+                self._radio_alert.props.msg = self.restart_msg
+                self._radio_alert.show()
 
-        history_info = Gtk.Label(label=_('Discard network history if you have'
-                                         ' trouble connecting to the network'))
-        history_info.set_alignment(0, 0)
-        history_info.set_line_wrap(True)
-        history_info.show()
-        box_wireless.pack_start(history_info, False, True, 0)
+            wireless_info = Gtk.Label(label=_('Discard wireless connections if'
+                               ' you have trouble connecting to the network.'))
+            wireless_info.set_alignment(0, 0)
+            wireless_info.set_line_wrap(True)
+            wireless_info.show()
+            box_wireless.pack_start(wireless_info, False, True, 0)
 
-        box_clear_history = Gtk.HBox(spacing=style.DEFAULT_SPACING)
-        self._clear_history_button = Gtk.Button()
-        self._clear_history_button.set_label(_('Discard network history'))
-        box_clear_history.pack_start(
-            self._clear_history_button, False, True, 0)
-        if not self._model.have_networks():
-            self._clear_history_button.set_sensitive(False)
-        self._clear_history_button.show()
-        box_wireless.pack_start(box_clear_history, False, True, 0)
-        box_clear_history.show()
+            box_clear_wireless = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+            self._clear_wireless_button = Gtk.Button()
+            self._clear_wireless_button.set_label(_(
+                                        'Discard wireless connections'))
+            box_clear_wireless.pack_start(self._clear_wireless_button, False,
+                                          True, 0)
+            if not self._model.have_wireless_networks():
+                self._clear_wireless_button.set_sensitive(False)
+            self._clear_wireless_button.show()
+            box_wireless.pack_start(box_clear_wireless, False, True, 0)
+            box_clear_wireless.show()
 
-        workspace.pack_start(box_wireless, False, True, 0)
-        box_wireless.show()
+            workspace.pack_start(box_wireless, False, True, 0)
+            box_wireless.show()
+        else:
+            # Delete radio code objects in memory for this invocation.
+            del self._model._options['radio']
 
         separator_mesh = Gtk.HSeparator()
         workspace.pack_start(separator_mesh, False, False, 0)
@@ -180,31 +186,34 @@ class Network(SectionView):
 
     def setup(self):
         self._entry.set_text(self._model.get_jabber())
-        try:
-            radio_state = self._model.get_radio()
-        except self._model.ReadError, detail:
-            self._radio_alert.props.msg = detail
-            self._radio_alert.show()
-        else:
-            self._button.set_active(radio_state)
+
+        if self.wireless_hardware_available:
+            try:
+                radio_state = self._model.get_radio()
+            except self._model.ReadError, detail:
+                self._radio_alert.props.msg = detail
+                self._radio_alert.show()
+            else:
+                self._button.set_active(radio_state)
+                self._radio_change_handler = self._button.connect(
+                        'toggled', self.__radio_toggled_cb)
+                self._wireless_configuration_reset_handler = \
+                        self._clear_wireless_button.connect(
+                        'clicked', self.__wireless_configuration_reset_cb)
+                self._radio_valid = True
 
         self._jabber_valid = True
-        self._radio_valid = True
         self.needs_restart = False
-        self._radio_change_handler = self._button.connect(
-            'toggled', self.__radio_toggled_cb)
         self._jabber_change_handler = self._entry.connect(
             'changed', self.__jabber_changed_cb)
-        self._network_configuration_reset_handler =  \
-            self._clear_history_button.connect(
-                'clicked', self.__network_configuration_reset_cb)
 
     def undo(self):
-        self._button.disconnect(self._radio_change_handler)
+        if self.wireless_hardware_available:
+            self._button.disconnect(self._radio_change_handler)
+            self._radio_alert.hide()
         self._entry.disconnect(self._jabber_change_handler)
         self._model.undo()
         self._jabber_alert.hide()
-        self._radio_alert.hide()
 
     def _validate(self):
         if self._jabber_valid and self._radio_valid:
@@ -221,8 +230,8 @@ class Network(SectionView):
             self._radio_valid = False
         else:
             self._radio_valid = True
-            if self._model.have_networks():
-                self._clear_history_button.set_sensitive(True)
+            if self._model.have_wireless_networks():
+                self._clear_wireless_button.set_sensitive(True)
 
         self._validate()
         return False
@@ -252,9 +261,8 @@ class Network(SectionView):
         self._validate()
         return False
 
-    def __network_configuration_reset_cb(self, widget):
+    def __wireless_configuration_reset_cb(self, widget):
         # FIXME: takes effect immediately, not after CP is closed with
         # confirmation button
-        self._model.clear_networks()
-        if not self._model.have_networks():
-            self._clear_history_button.set_sensitive(False)
+        self._model.clear_wireless_networks()
+        self._clear_wireless_button.set_sensitive(False)

--- a/src/jarabe/model/network.py
+++ b/src/jarabe/model/network.py
@@ -1056,6 +1056,14 @@ def find_gsm_connection():
     return find_connection_by_id(GSM_CONNECTION_ID)
 
 
+def wireless_hardware_available():
+    """
+    Check for the presence of a wireless adapter.
+    """
+    return any(os.listdir(os.path.join(os.sep,
+                                      'sys', 'module', 'cfg80211', 'holders')))
+
+
 def disconnect_access_points(ap_paths):
     """
     Disconnect all devices connected to any of the given access points.


### PR DESCRIPTION
...tions

Fixes #4410  https://bugs.sugarlabs.org/ticket/4410

The 'Discard network history' button is peculiar to Sugar, and
is destructive to all non-wireless connections, despite being in
the 'Wireless' section of the control panel.

Relabel the code variables and functions to be specific to
wireless connections.

Recode the functions to exclude non-wireless connections.

Relabel the 'Radio' box instructions and 'Discard ...' button
to avoid confusion over their state and actions.

If wireless hardware is not present on the system, the 'Wireless'
section of the control panel is excluded.

The availability of wireless hardware is tested with the kernel's
sys filesystem because, with the radio disabled, wireless devices
are not exposed in the NetworkManager API and it would be
inappropriate to turn the radio on--just to see if one is present.

Wireless hardware present:
![network-withwifi](https://f.cloud.github.com/assets/4335897/1958321/989b620e-8217-11e3-9794-3730cf661d1d.png)

No wireless hardware:
![network-nowifi](https://f.cloud.github.com/assets/4335897/1958343/e288b1f0-8217-11e3-87d4-5aea713cf1eb.png)
