### PR TITLE
Use set_color_xo instead set_color

### DIFF
--- a/extensions/cpsection/aboutme/view.py
+++ b/extensions/cpsection/aboutme/view.py
@@ -473,7 +473,7 @@ class AboutMe(SectionView):
         return False
 
     def __color_changed_cb(self, colorpicker, color):
-        self._model.set_color(color.to_string())
+        self._model.set_color_xo(color.to_string())
         self.needs_restart = True
         self._color_alert.props.msg = self.restart_msg
         self._color_valid = True


### PR DESCRIPTION
set_color needs more arguments, set_color_xo only one str.
WARNING: Deprecated

Just now, the change color in aboutme cp section didn't work. This patch fix a simple typo and now works.
