### PR TITLE
Added a notification system to sugar

### DIFF
--- a/src/jarabe/frame/notification.py
+++ b/src/jarabe/frame/notification.py
@@ -20,6 +20,7 @@ from gi.repository import Gdk
 
 from sugar3.graphics import style
 from sugar3.graphics.xocolor import XoColor
+from sugar3.graphics.icon import get_surface, Icon
 
 from jarabe.view.pulsingicon import PulsingIcon
 
@@ -35,10 +36,13 @@ class NotificationIcon(Gtk.EventBox):
 
     _PULSE_TIMEOUT = 3
 
-    def __init__(self, **kwargs):
+    def __init__(self, draw_little_icon=False, **kwargs):
         self._icon = PulsingIcon(pixel_size=style.STANDARD_ICON_SIZE)
         Gtk.EventBox.__init__(self, **kwargs)
         self.props.visible_window = False
+
+        self._draw_little_icon = draw_little_icon
+        self._notfication_icon = None
 
         self._icon.props.pulse_color = \
             XoColor('%s,%s' % (style.COLOR_BUTTON_GREY.get_svg(),
@@ -60,6 +64,11 @@ class NotificationIcon(Gtk.EventBox):
         if pspec.name == 'xo-color':
             if self._icon.props.base_color != value:
                 self._icon.props.base_color = value
+                self._notfication_icon = get_surface(
+                    icon_name='emblem-notification',
+                    width=22, height=22,
+                    stroke_color=value.get_stroke_color(),
+                    fill_color=value.get_fill_color())
         elif pspec.name == 'icon-name':
             if self._icon.props.icon_name != value:
                 self._icon.props.icon_name = value
@@ -82,6 +91,38 @@ class NotificationIcon(Gtk.EventBox):
         return self._icon.palette
 
     palette = property(_get_palette, _set_palette)
+
+    def do_draw(self, cr):
+        self._icon.do_draw(cr)
+
+        if self._draw_little_icon:
+            cr.set_source_surface(self._notfication_icon, 28, 28)
+            cr.paint()
+
+        return False
+
+
+class NotificationFrameIcon(Icon):
+
+    def __init__(self):
+        Icon.__init__(self)
+        self._notfication_icon = None
+
+    def gen_little_icon(self, xocolor):
+        self._notfication_icon = get_surface(
+            icon_name='emblem-notification',
+            width=21, height=21,
+            stroke_color=xocolor.get_stroke_color(),
+            fill_color=xocolor.get_fill_color())
+
+    def do_draw(self, cr):
+        Icon.do_draw(self, cr)
+
+        if self._notfication_icon:
+            cr.set_source_surface(self._notfication_icon, 19, 19)
+            cr.paint()
+
+        return False
 
 
 class NotificationWindow(Gtk.Window):

--- a/src/jarabe/view/palettes.py
+++ b/src/jarabe/view/palettes.py
@@ -42,9 +42,14 @@ from jarabe.journal import misc
 
 
 class BasePalette(Palette):
+    __gsignals__ = {
+        'notification-removed': (GObject.SignalFlags.RUN_FIRST, None, [int])
+    }
+
     def __init__(self, home_activity):
         Palette.__init__(self)
 
+        self.notifications_by_id = {}
         self._notify_launch_hid = None
 
         if home_activity.props.launch_status == shell.Activity.LAUNCHING:
@@ -70,6 +75,45 @@ class BasePalette(Palette):
             self._on_failed_launch()
         else:
             self.setup_palette()
+
+    def add_notification(self, data):
+        if not self.notifications_by_id:
+            separator = PaletteMenuItemSeparator()
+            self.menu_box.append_item(separator)
+            separator.show()
+
+        markup = '<b>%s</b>\n%s' % (data['summary'], data['body'])
+        menu_item = PaletteMenuItem(None, 'emblem-notification',
+                                    markup_label=markup)
+        self.menu_box.append_item(menu_item)
+        menu_item.connect('activate', self.__notification_clicked)
+        menu_item.data = data
+
+        self.notifications_by_id[data['id']] = menu_item
+
+    def __notification_clicked(self, notification):
+        data = notification.data
+        notification.hide()
+        self.menu_box.remove(notification)
+        self.notifications_by_id[data['id']] = None
+
+        self.emit('notification-removed', data['id'])
+
+        # TODO: use intents to do something when we make intents
+
+    def remove_notification(self, id_):
+        notification = self.notifications_by_id[id_]
+        notification.hide()
+        self.menu_box.remove(notification)
+        self.notifications_by_id[id_] = None
+
+    def remove_all_notifications(self):
+        for button in self.notifications_by_id.values():
+            button.hide()
+            self.menu_box.remove(button)
+
+        self.notifications_by_id = {}
+        self.notification_buttons = []
 
 
 class CurrentActivityPalette(BasePalette):
@@ -188,9 +232,9 @@ class JournalPalette(BasePalette):
         title = self._home_activity.get_title()
         self.set_primary_text(GLib.markup_escape_text(title))
 
-        box = PaletteMenuBox()
-        self.set_content(box)
-        box.show()
+        self.menu_box = PaletteMenuBox()
+        self.set_content(self.menu_box)
+        self.menu_box.show()
 
         menu_item = PaletteMenuItem(_('Show contents'))
         icon = Icon(file=self._home_activity.get_icon_path(),
@@ -200,16 +244,16 @@ class JournalPalette(BasePalette):
         icon.show()
 
         menu_item.connect('activate', self.__open_activate_cb)
-        box.append_item(menu_item)
+        self.menu_box.append_item(menu_item)
         menu_item.show()
 
         separator = PaletteMenuItemSeparator()
-        box.append_item(separator)
+        self.menu_box.append_item(separator)
         separator.show()
 
         inner_box = Gtk.VBox()
         inner_box.set_spacing(style.DEFAULT_PADDING)
-        box.append_item(inner_box, vertical_padding=0)
+        self.menu_box.append_item(inner_box, vertical_padding=0)
         inner_box.show()
 
         self._progress_bar = Gtk.ProgressBar()


### PR DESCRIPTION
This is largely what has been talked about on the mailing lists.This requires https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/107 . Here are some pretty pictures:

![system_notifications](https://f.cloud.github.com/assets/6022042/2114017/2493d620-9036-11e3-8b82-7701882970f7.png)
System notifications can choose their icon and go on the frame

![notifications_main](https://f.cloud.github.com/assets/6022042/2114025/387f8e36-9036-11e3-9d52-7dac023306fa.png)
Notifications
