### PR TITLE
Microformat updater: fix parser

### DIFF
--- a/src/jarabe/model/update/microformat.py
+++ b/src/jarabe/model/update/microformat.py
@@ -118,7 +118,10 @@ class _UpdateHTMLParser(HTMLParser):
             self.group_desc = data.strip()
 
         if self.in_activity_id > 0:
-            self.last_id = data.strip()
+            if self.last_id is None:
+                self.last_id = data.strip()
+            else:
+                self.last_id = self.last_id + data.strip()
 
         if self.in_activity_version > 0:
             try:


### PR DESCRIPTION
The object_id can be retrieved in more than one chunk,
then the parser should take care of that.

Signed-off-by: Gonzalo Odiard godiard@sugarlabs.org
