### PR TITLE
The updater need reset the internal state when finish with error

### DIFF
--- a/src/jarabe/model/update/updater.py
+++ b/src/jarabe/model/update/updater.py
@@ -129,6 +129,7 @@ class Updater(GObject.GObject):
     def _backend_error_cb(self, error):
         _logger.debug("_backend_error_cb %s", error)
         self._finished(True)
+        self._state = STATE_CHECKED
         self.emit('error', error)
 
     def update(self, bundle_ids):


### PR DESCRIPTION
This is needed to allow the next update request to work.

This was missed in the last patch "Show a error message
if the activity updater can't connect to the server"

Signed-off-by: Gonzalo Odiard godiard@sugarlabs.org
