### PR TITLE
Disconnect volume monitor - Fixes # 4736

### DIFF
--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -266,6 +266,7 @@ class JournalActivity(JournalWindow):
         self.__selection_changed_cb(None, selected_items)
 
     def __go_back_clicked_cb(self, detail_view):
+        self._detail_toolbox.cleanup()
         self.show_main_view()
 
     def _query_changed_cb(self, toolbar, query):

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -511,8 +511,13 @@ class DetailToolbox(ToolbarBox):
             palette.menu.remove(menu_item)
             menu_item.destroy()
 
-        CopyMenuBuilder(self._journalactivity, self.__get_uid_list_cb,
-                        self.__volume_error_cb, palette.menu)
+        self._menu_builder = CopyMenuBuilder(
+            self._journalactivity, self.__get_uid_list_cb,
+            self.__volume_error_cb, palette.menu)
+
+    def cleanup(self):
+        if self._menu_builder is not None:
+            self._menu_builder.cleanup()
 
     def __get_uid_list_cb(self):
         return [self._metadata['uid']]
@@ -727,6 +732,7 @@ class BatchCopyButton(ToolButton):
         ToolButton.__init__(self, 'edit-copy')
         self.props.tooltip = _('Copy')
         self.connect('clicked', self.__clicked_cb)
+        self.connect('destroy', self.__destroy_cb)
         self._menu_builder = None
 
     def _refresh_menu_options(self):
@@ -749,6 +755,9 @@ class BatchCopyButton(ToolButton):
     def __get_uid_list_cb(self):
         model = self._journalactivity.get_list_view().get_model()
         return model.get_selected_items()
+
+    def __destroy_cb(self, widget):
+        self._menu_builder.cleanup()
 
 
 class MultiSelectEntriesInfoWidget(Gtk.ToolItem):


### PR DESCRIPTION
We use the same object CopyMenuBuilder to populate the CopyMenu
in the ObjectPalette, in the BatchCopyMenu and in the palette
in the copy button in the detail view.
This object have callback methods for mount/unmount device events,
and need be disconnected.
This patch add a method cleanup() to disconect them, and call it
in the different cases depending on the live of the other objects.

Signed-off-by: Gonzalo Odiard godiard@sugarlabs.org
