### PR TITLE
Updater: disconnect signals when cp view is closed - Fixes #4740

### DIFF
--- a/extensions/cpsection/updater/view.py
+++ b/extensions/cpsection/updater/view.py
@@ -39,10 +39,14 @@ class ActivityUpdater(SectionView):
         SectionView.__init__(self)
 
         self._model = updater.get_instance()
-        self._model.connect('progress', self.__progress_cb)
-        self._model.connect('updates-available', self.__updates_available_cb)
-        self._model.connect('error', self.__error_cb)
-        self._model.connect('finished', self.__finished_cb)
+        self._id_progresss = self._model.connect('progress',
+                                                 self.__progress_cb)
+        self._id_updates = self._model.connect('updates-available',
+                                               self.__updates_available_cb)
+        self._id_error = self._model.connect('error',
+                                             self.__error_cb)
+        self._id_finished = self._model.connect('finished',
+                                                self.__finished_cb)
 
         self.set_spacing(style.DEFAULT_SPACING)
         self.set_border_width(style.DEFAULT_SPACING * 2)
@@ -78,6 +82,12 @@ class ActivityUpdater(SectionView):
                        updater.STATE_UPDATING):
             self._switch_to_progress_pane()
             self._progress_pane.set_message(_('Update in progress...'))
+
+    def cleanup(self):
+        self._model.disconnect(self._id_progresss)
+        self._model.disconnect(self._id_updates)
+        self._model.disconnect(self._id_error)
+        self._model.disconnect(self._id_finished)
 
     def _switch_to_update_box(self, updates):
         if self._update_box in self.get_children():

--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -190,6 +190,10 @@ class ControlPanel(Gtk.Window):
             self._options[option]['button'] = sectionicon
 
     def _show_main_view(self):
+        if self._section_view is not None:
+            self._section_view.cleanup()
+            self._section_view = None
+
         self._set_toolbar(self._main_toolbar)
         self._main_toolbar.show()
         self._set_canvas(self._scrolledwindow)

--- a/src/jarabe/controlpanel/sectionview.py
+++ b/src/jarabe/controlpanel/sectionview.py
@@ -52,3 +52,8 @@ class SectionView(Gtk.VBox):
     def undo(self):
         """Undo here the changes that have been made in this section."""
         pass
+
+    def cleanup(self):
+        """Clean here all when the sectionview is closed,
+        remove temporary files, or disconnect signals if needed."""
+        pass


### PR DESCRIPTION
When the updater cp view is created, connect to updater signals.
The updater is a singleton, and the signals are not disconnected,
then produce the errors detailed in the ticket.

This patch add a method cleanup() to SectionView class,
and execute it when the view is closed.

Signed-off-by: Gonzalo Odiard godiard@sugarlabs.org
