### PR TITLE
Connect to same event once at a time from _Account

### DIFF
--- a/src/jarabe/model/neighborhood.py
+++ b/src/jarabe/model/neighborhood.py
@@ -196,7 +196,16 @@ class _Account(GObject.GObject):
         self._buddies_per_activity = {}
         self._activities_per_buddy = {}
 
+        self._home_changed_hid = None
+
         self._start_listening()
+
+    def _close_connection(self):
+        self._connection = None
+        if self._home_changed_hid is not None:
+            model = shell.get_model()
+            model.disconnect(self._home_changed_hid)
+            self._home_changed_hid = None
 
     def _start_listening(self):
         bus = dbus.Bus()
@@ -249,7 +258,7 @@ class _Account(GObject.GObject):
             return
         if properties['Connection'] == '/':
             self._check_registration_error()
-            self._connection = None
+            self._close_connection()
         elif self._connection is None:
             self._prepare_connection(properties['Connection'])
 
@@ -309,7 +318,7 @@ class _Account(GObject.GObject):
             self.emit('disconnected')
 
         if status == CONNECTION_STATUS_DISCONNECTED:
-            self._connection = None
+            self._close_connection()
 
     def __get_self_handle_cb(self, self_handle):
         self._self_handle = self_handle
@@ -347,9 +356,12 @@ class _Account(GObject.GObject):
 
             connection.connect_to_signal('CurrentActivityChanged',
                                          self.__current_activity_changed_cb)
-            home_model = shell.get_model()
-            home_model.connect('active-activity-changed',
-                               self.__active_activity_changed_cb)
+
+            if self._home_changed_hid is None:
+                home_model = shell.get_model()
+                self._home_changed_hid = home_model.connect(
+                    'active-activity-changed',
+                    self.__active_activity_changed_cb)
         else:
             logging.warning('Connection %s does not support OLPC buddy '
                             'properties', self._connection.object_path)
@@ -669,7 +681,7 @@ class _Account(GObject.GObject):
     def disable(self):
         logging.debug('_Account.disable %s', self.object_path)
         self._set_enabled(False)
-        self._connection = None
+        self._close_connection()
 
     def _set_enabled(self, value):
         bus = dbus.Bus()


### PR DESCRIPTION
After an _Account._connection is set, the _Account connects to
'active-activity-changed' shell event. _Account._connection can
later be drop and set to None. When _Account._connection is re-set,
the _Account will re-connect to the same shell event without
disconnecting from the previous one.

Also, when _Account._connection is set to None, it makes no sense
to continue handling that shell event, as there is no need to update
the current active activity for that _Account.

Therefore, make sure _Account connects to shell event only once at a
time, and that it gets disconnected when _Account._connection is set
to None.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
