### PR TITLE
Replace journal filter combo boxes

### DIFF
--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -74,6 +74,7 @@ _WHITE = style.COLOR_WHITE.get_html()
 _LABEL_MAX_WIDTH = 18
 _MAXIMUM_PALETTE_COLUMNS = 4
 
+
 class MainToolbox(ToolbarBox):
 
     query_changed_signal = GObject.Signal('query-changed',


### PR DESCRIPTION
As per Feature [1], this patch replaces the filter combo boxes on the
Journal toolbar with palettes. The raionale is that combo boxes don't
work well when the option list is large. The palette is multicolumn
(when needed), making selection much easier (especially on a touch screen).

Note: There is a corresponding patch to sugar-artwork that introduces
a change to settings (in order to enable "set_important", which
positions a label next to a button icon on a toolbutton), a new icon
(view-type), and a change to the gtk css definition for scrolled
windows (to make them compatible with palette menu items).

This PR has been revised from [2] in order to address an issue with the
palette menu size as identified by Martin Abente.

[1] http://wiki.sugarlabs.org/go/Features/Replace_combo_box_in_journal_search
[2] https://github.com/sugarlabs/sugar/pull/265
