### PR TITLE
Webcp try2

### DIFF
--- a/extensions/cpsection/webaccount/view.py
+++ b/extensions/cpsection/webaccount/view.py
@@ -14,9 +14,9 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 
-import glib
 from gettext import gettext as _
 
+from gi.repository import Glib
 from gi.repository import Gtk
 from gi.repository import Gdk
 
@@ -61,7 +61,7 @@ class WebServicesConfig(SectionView):
             label.set_markup(
                 '<span foreground="%s" size="large">%s</span>'
                 % (style.COLOR_BUTTON_GREY.get_html(),
-                   glib.markup_escape_text(
+                   Glib.markup_escape_text(
                        _('No web services are installed.\n'
                          'Please visit %s for more details.' %
                          'http://wiki.sugarlabs.org/go/WebServices'))))


### PR DESCRIPTION
This patch adds labels to the icons for the webservices in the control panel. The message displayed when no webservices are installed has also been modified to be in compliance with other such messages as per discussion with the design team.

Try2: using Glib from gi.repository instead of glib
