### PR TITLE
Fix notification GetServerInformation

### DIFF
--- a/src/jarabe/model/notifications.py
+++ b/src/jarabe/model/notifications.py
@@ -103,9 +103,9 @@ class NotificationService(dbus.service.Object):
     def GetCapabilities(self):
         return []
 
-    @dbus.service.method(_DBUS_IFACE, in_signature='', out_signature='sss')
-    def GetServerInformation(self, name, vendor, version):
-        return 'Sugar Shell', 'Sugar', config.version
+    @dbus.service.method(_DBUS_IFACE, in_signature='', out_signature='ssss')
+    def GetServerInformation(self):
+        return 'Sugar Shell', 'Sugar', config.version, '0'
 
     @dbus.service.signal(_DBUS_IFACE, signature='uu')
     def NotificationClosed(self, notification_id, reason):


### PR DESCRIPTION
The method definition does not match its own DBus
signature.

Also, when looking at [1] I see there is no formal
definition for the input parameters, therefore there
is no need for having these parameters in our method
definition.

Update GetServerInformation to match 1.2 spec. We don't
fully support any spec, so I will just using 0 as spec
version.
1. https://developer.gnome.org/notification-spec/

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
