### PR TITLE
Fixed #4686. Small description of activity displayed in palette.

### DIFF
--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -25,6 +25,7 @@ from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import Gio
 from gi.repository import GLib
+from gi.repository import Pango
 
 from sugar3.graphics import style
 from sugar3.graphics.palette import Palette
@@ -73,6 +74,30 @@ class ObjectPalette(Palette):
 
         Palette.__init__(self, primary_text=title,
                          icon=activity_icon)
+
+        if metadata.get('description', ''):
+            label = Gtk.Label()
+            label.set_max_width_chars(style.MENU_WIDTH_CHARS)
+            label.set_line_wrap(True)
+            label.set_ellipsize(Pango.EllipsizeMode.END)
+            label.set_lines(3)
+            label.modify_fg(Gtk.StateType.INSENSITIVE,
+                            Gdk.color_parse('white'))
+            label.set_justify(Gtk.Justification.LEFT)
+            label.set_alignment(0, 0)
+
+            description = str(metadata.get('description', ''))
+            description = description.replace('\n', ' ')
+            label.set_text(description)
+            item = Gtk.MenuItem()
+            item.add(label)
+            item.set_sensitive(False)
+            self.menu.append(item)
+            item.show_all()
+
+            separator = Gtk.SeparatorMenuItem()
+            self.menu.append(separator)
+            separator.show()
 
         if misc.can_resume(metadata):
             if metadata.get('activity_id', ''):


### PR DESCRIPTION
Bug: http://bugs.sugarlabs.org/ticket/4686

Used `Gtk.Label` with Pango based ellipsize for wrapping and ellipsizing.

Please see #259 for the previous version of the patch. I've made the entire wrapping and ellipsization using Gtk and Pango, as suggested in the last version of the patch.

_Large Activity Description_
![sugar_large](https://cloud.githubusercontent.com/assets/2565248/2538545/f7a1f684-b5be-11e3-99d8-b60a1cc52dc9.png)

_Small Activity Description_
![sugar_small](https://cloud.githubusercontent.com/assets/2565248/2538556/13d7b46a-b5bf-11e3-8c4a-adfc3bfe5b16.png)
