### PR TITLE
Require Age

### DIFF
--- a/src/jarabe/intro/agepicker.py
+++ b/src/jarabe/intro/agepicker.py
@@ -31,13 +31,14 @@ AGE_LABELS = [_('0-3'), _('4-5'), _('6-7'), _('8-9'), _('10-11'), _('12'),
 
 class AgePicker(Gtk.Grid):
 
-    def __init__(self, gender):
+    def __init__(self, page, gender):
         Gtk.Grid.__init__(self)
         self.set_row_spacing(style.DEFAULT_SPACING)
         self.set_column_spacing(style.DEFAULT_SPACING)
 
+        self._page = page
         self._gender = gender
-        self._age = 5
+        self._age = None
         self._buttons = []
         self._nocolor = XoColor('#010101,#ffffff')
         self._color = XoColor()
@@ -75,6 +76,7 @@ class AgePicker(Gtk.Grid):
 
     def _set_age(self, age):
         self._age = age
+        self._page.set_valid(True)
 
     def update_color(self, color):
         self._color = color

--- a/src/jarabe/intro/genderpicker.py
+++ b/src/jarabe/intro/genderpicker.py
@@ -27,11 +27,12 @@ GENDERS = ['female', 'male']
 
 
 class GenderPicker(Gtk.Grid):
-    def __init__(self):
+    def __init__(self, page):
         Gtk.Grid.__init__(self)
         self.set_row_spacing(style.DEFAULT_SPACING)
         self.set_column_spacing(style.DEFAULT_SPACING)
 
+        self._page = page
         self._gender = None
         self._buttons = []
         self._nocolor = XoColor('#010101,#ffffff')
@@ -57,6 +58,7 @@ class GenderPicker(Gtk.Grid):
 
     def _set_gender(self, gender):
         self._gender = gender
+        self._page.set_valid(True)
 
     def update_color(self, color):
         self._color = color

--- a/src/jarabe/intro/window.py
+++ b/src/jarabe/intro/window.py
@@ -225,7 +225,7 @@ class _GenderPage(_Page):
         grid.attach(label, 0, 0, 1, 1)
         label.show()
 
-        self._gp = genderpicker.GenderPicker()
+        self._gp = genderpicker.GenderPicker(self)
         grid.attach(self._gp, 0, 1, 1, 1)
         self._gp.show()
 
@@ -233,6 +233,7 @@ class _GenderPage(_Page):
         alignment.show()
 
         self._gender = self._gp.get_gender()
+        # Don't require gender
         self.set_valid(True)
 
     def get_gender(self):
@@ -257,7 +258,7 @@ class _AgePage(_Page):
         grid.attach(label, 0, 0, 1, 1)
         label.show()
 
-        self._ap = agepicker.AgePicker(gender)
+        self._ap = agepicker.AgePicker(self, gender)
         grid.attach(self._ap, 0, 1, 1, 1)
         self._ap.show()
 
@@ -265,7 +266,6 @@ class _AgePage(_Page):
         alignment.show()
 
         self._age = self._ap.get_age()
-        self.set_valid(True)
 
     def update_gender(self, gender):
         self._ap.update_gender(gender)
@@ -420,7 +420,7 @@ class UserProfile():
         self.nickname = None
         self.colors = None
         self.gender = None
-        self.age = 12
+        self.age = 0
 
 
 class IntroWindow(Gtk.Window):


### PR DESCRIPTION
OLPC AU (and other deployments) are gathering statistics based on the
user's age. But the intro pages do not require that the user specify age.

This patch added age as a required field. It also adds glue to enable
gender to be required but does not force it to be required.

There is no SL ticket associated with the patch.
