### PR TITLE
More robust locale matching

### DIFF
--- a/extensions/cpsection/language/view.py
+++ b/extensions/cpsection/language/view.py
@@ -124,8 +124,9 @@ class Language(SectionView):
         locale_language = None
         locale_country = None
 
+        target_locale = locale_code.split('.')[0]
         for language, country, code in self._available_locales:
-            if code == locale_code:
+            if code.split('.')[0] == target_locale:
                 locale_language = language
                 locale_country = country
 


### PR DESCRIPTION
Not sure when this issue crept into the OLPC builds, but the locale
that is set by the manufacturing data is of the format es_UY.UTF-8
where as the format of the locales we get from parsing available
languages is es_UY.utf8

This patch matches based on the country code, ignoring the format of
the formating suffix.
