### PR TITLE
Avoid pulsing icon at startup - Fixes #4767

### DIFF
--- a/src/jarabe/model/shell.py
+++ b/src/jarabe/model/shell.py
@@ -594,7 +594,8 @@ class ShellModel(GObject.GObject):
                     Wnck.WindowType.SPLASHSCREEN and \
                     home_activity.get_launch_status() == Activity.LAUNCHING
 
-            if home_activity is None:
+            if home_activity is None and \
+                    window.get_window_type() != Wnck.WindowType.SPLASHSCREEN:
                 logging.debug('first window registered for %s', activity_id)
                 color = self._shared_activities.get(activity_id, None)
                 home_activity = Activity(activity_info, activity_id,


### PR DESCRIPTION
Check if the window is a splash screen before add it,
in all the cases. This check solves the issue originated
by a race condition between the splash window creation and
the creation of the main activity window.

Signed-off-by: Gonzalo Odiard godiard@sugarlabs.org
