### PR TITLE
Journal docs folder

### DIFF
--- a/src/jarabe/journal/model.py
+++ b/src/jarabe/journal/model.py
@@ -732,6 +732,10 @@ def _write_entry_on_external_device(metadata, file_path, ready_callback=None):
         if ready_callback:
             ready_callback(metadata, file_path, destination_path)
 
+    def _updated_cb(*args):
+        updated.send(None, object_id=destination_path)
+        _ready_cb()
+
     def _splice_cb(*args):
         created.send(None, object_id=destination_path)
         _ready_cb()
@@ -812,7 +816,7 @@ def _write_entry_on_external_device(metadata, file_path, ready_callback=None):
     else:
         _rename_entry_on_external_device(file_path, destination_path,
                                          metadata_dir_path)
-        _ready_cb()
+        _updated_cb()
 
 
 def get_file_name(title, mime_type):


### PR DESCRIPTION
These pr solve the persistence of metadata in external devices and in the Documents folder.
Now is possible change the object title, and set favorite, and the extensions are not lost (SL #2949)

A pr on sugar-toolkit-gtk3 is needed https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/137
