### PR TITLE
Don't offer to join beyond maximum participants

### DIFF
--- a/src/jarabe/journal/misc.py
+++ b/src/jarabe/journal/misc.py
@@ -32,7 +32,7 @@ from sugar3.graphics.xocolor import colors
 from sugar3.graphics.alert import ConfirmationAlert
 from sugar3 import mime
 from sugar3.bundle.bundle import ZipExtractException, RegistrationException
-from sugar3.bundle.activitybundle import ActivityBundle
+from sugar3.bundle.activitybundle import ActivityBundle, get_bundle_instance
 from sugar3.bundle.bundle import AlreadyInstalledException
 from sugar3.bundle.contentbundle import ContentBundle
 from sugar3 import util
@@ -89,7 +89,7 @@ def get_icon_name(metadata):
         file_path = model.get_file(metadata['uid'])
         if file_path is not None and os.path.exists(file_path):
             try:
-                bundle = ActivityBundle(file_path)
+                bundle = get_bundle_instance(file_path)
                 file_name = bundle.get_icon()
             except Exception:
                 logging.exception('Could not read bundle')
@@ -131,7 +131,7 @@ def get_bundle(metadata):
             if not os.path.exists(file_path):
                 logging.warning('Invalid path: %r', file_path)
                 return None
-            return ActivityBundle(file_path)
+            return get_bundle_instance(file_path)
 
         elif is_content_bundle(metadata):
             file_path = model.get_file(metadata['uid'])

--- a/src/jarabe/view/viewhelp.py
+++ b/src/jarabe/view/viewhelp.py
@@ -28,7 +28,7 @@ from gi.repository import GdkX11
 from sugar3 import env
 from sugar3.graphics import style
 from sugar3.graphics.toolbutton import ToolButton
-from sugar3.bundle.activitybundle import ActivityBundle
+from sugar3.bundle.activitybundle import get_bundle_instance
 from jarabe.model import shell
 
 
@@ -69,7 +69,7 @@ def get_help_url_and_title(activity):
             link_id = 'org.laptop.JournalActivity'
     else:
         # get activity name and window id
-        activity_bundle = ActivityBundle(bundle_path)
+        activity_bundle = get_bundle_instance(bundle_path)
         title = activity_bundle.get_name()
         link_id = activity_bundle.get_bundle_id()
 

--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -37,7 +37,7 @@ from sugar3.graphics.xocolor import XoColor
 from sugar3.graphics.menuitem import MenuItem
 from sugar3.graphics.toolbutton import ToolButton
 from sugar3.graphics.radiotoolbutton import RadioToolButton
-from sugar3.bundle.activitybundle import ActivityBundle
+from sugar3.bundle.activitybundle import get_bundle_instance
 from sugar3.datastore import datastore
 from sugar3.env import get_user_activities_path
 from sugar3 import mime
@@ -58,7 +58,7 @@ map_activity_to_window = {}
 
 
 def _is_web_activity(bundle_path):
-    activity_bundle = ActivityBundle(bundle_path)
+    activity_bundle = get_bundle_instance(bundle_path)
     return activity_bundle.get_command() == 'sugar-activity-web'
 
 
@@ -207,7 +207,7 @@ class ViewSource(Gtk.Window):
         self._selected_sugar_file = None
         file_name = ''
 
-        activity_bundle = ActivityBundle(bundle_path)
+        activity_bundle = get_bundle_instance(bundle_path)
         command = activity_bundle.get_command()
 
         if _is_web_activity(bundle_path):
@@ -432,7 +432,7 @@ class Toolbar(Gtk.Toolbar):
 
         self._add_separator()
 
-        activity_bundle = ActivityBundle(bundle_path)
+        activity_bundle = get_bundle_instance(bundle_path)
         file_name = activity_bundle.get_icon()
 
         if document_path is not None and os.path.exists(document_path):


### PR DESCRIPTION
This is patch checks to see how many participants are sharing an
activity. If the maximum has been reached, then the Join palette menu
item is not shown.

This patch depends on two patches to sugar-toolkit-gtk3 (#138) that
enable setting max_participants in activity.info and only impacts
activities where that field has been set.

Also, since we added caching of activity bundles in the toolkit, we
take advantage of that caching in view/viewhelp.py,
view/viewsource.py, and journal/misc.py to reduce file I/O.

Replaces #339
