### PR TITLE
More robust locale matching

### DIFF
--- a/extensions/cpsection/language/model.py
+++ b/extensions/cpsection/language/model.py
@@ -114,9 +114,13 @@ def get_languages():
         if line.startswith('LANGUAGE='):
             lang = line[9:].replace('"', '')
             lang = lang.strip()
+            if lang.endswith('UTF-8'):
+                lang = lang.replace('UTF-8', 'utf8')
             langlist = lang.split(':')
         elif line.startswith('LANG='):
             lang = line[5:].replace('"', '')
+            if lang.endswith('UTF-8'):
+                lang = lang.replace('UTF-8', 'utf8')
 
     # There might be cases where .i18n may not contain a LANGUAGE field
     if langlist is None:


### PR DESCRIPTION
The locale that is set by the manufacturing data can be of the format
es_UY.UTF-8 where as the format of the locales we get from parsing
available languages is es_UY.utf8

This patch converts UTF-8 suffixes to utf8

Note that this problem has only been observed on OLPC XO images. I was
unsuccessful in convincing OLPC to change their rules for generating
manufacturing data.

Replaces PR #338
