### PR TITLE
Fixes #2382, don't star journal entries from the object chooser

### DIFF
--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -79,6 +79,7 @@ class BaseListView(Gtk.Bin):
         self._progress_bar = None
         self._last_progress_bar_pulse = None
         self._scroll_position = 0.
+        self._is_object_chooser = False
 
         Gtk.Bin.__init__(self)
 
@@ -295,6 +296,9 @@ class BaseListView(Gtk.Bin):
             cell.props.xo_color = None
 
     def __favorite_clicked_cb(self, cell, path):
+        if self._is_object_chooser:
+            return
+
         row = self._model[path]
         metadata = model.get(row[ListModel.COLUMN_UID])
         if not model.is_editable(metadata):

--- a/src/jarabe/journal/objectchooser.py
+++ b/src/jarabe/journal/objectchooser.py
@@ -207,6 +207,7 @@ class ChooserListView(BaseListView):
     def __init__(self):
         BaseListView.__init__(self, None)
 
+        self._is_object_chooser = True
         self.cell_icon.props.show_palette = False
         self.tree_view.props.hover_selection = True
 


### PR DESCRIPTION
[Here is the ticket description](http://bugs.sugarlabs.org/ticket/2382)

>  In the objectchooser you can change the 'favorite' (star) property of a Journal entry.
> 
> (don't think this has to be in the 0.90.0 release but might be worth to get in the update release)

It was a very weird bug since you would star the thing but the window would close straight away, leaving the users unaware that they just starred it.

I tried to use overriding callbacks but (a) couldn't get it to work and (b) kinda think that sort of oop can be really confusing.
