### PR TITLE
Fixes #2382, don't star journal entries from the object chooser [Try 3]

### DIFF
--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -163,7 +163,7 @@ class BaseListView(Gtk.Bin):
             self.tree_view.append_column(column)
 
         cell_favorite = CellRendererFavorite(self.tree_view)
-        cell_favorite.connect('clicked', self.__favorite_clicked_cb)
+        cell_favorite.connect('clicked', self._favorite_clicked_cb)
 
         column = Gtk.TreeViewColumn()
         column.props.sizing = Gtk.TreeViewColumnSizing.FIXED
@@ -294,7 +294,7 @@ class BaseListView(Gtk.Bin):
         else:
             cell.props.xo_color = None
 
-    def __favorite_clicked_cb(self, cell, path):
+    def _favorite_clicked_cb(self, cell, path):
         row = self._model[path]
         metadata = model.get(row[ListModel.COLUMN_UID])
         if not model.is_editable(metadata):

--- a/src/jarabe/journal/objectchooser.py
+++ b/src/jarabe/journal/objectchooser.py
@@ -216,6 +216,9 @@ class ChooserListView(BaseListView):
     def __entry_activated_cb(self, entry):
         self.emit('entry-activated', entry)
 
+    def _favorite_clicked_cb(self, cell, path):
+        pass
+
     def __button_release_event_cb(self, tree_view, event):
         if event.window != tree_view.get_bin_window():
             return False


### PR DESCRIPTION
[Here is the ticket description](http://bugs.sugarlabs.org/ticket/2382)

>  In the objectchooser you can change the 'favorite' (star) property of a Journal entry.
> 
> (don't think this has to be in the 0.90.0 release but might be worth to get in the update release)

It was a very weird bug since you would star the thing but the window would close straight away, leaving the users unaware that they just starred it.

Thanks @tchx84 for finding out the weirdness of private python methods!
