### PR TITLE
Stop a null device crashing the journal

### DIFF
--- a/src/jarabe/journal/misc.py
+++ b/src/jarabe/journal/misc.py
@@ -395,6 +395,8 @@ def get_mount_color(mount):
 
     if uuid:
         sha_hash.update(uuid)
+    elif path is None:
+        sha_hash.update(str(time.time()))
     else:
         mount_name = os.path.basename(path)
         sha_hash.update(mount_name)


### PR DESCRIPTION
This was a very weird issue.

I was using sugar build (no devices plugged in) and whenever I clicked on the detail view in the journal it would show it to me without any content. It was because a call to the `get_mount_color` function had a null path, crashing `os.path.basename`.

The random color never shows in the ui, but prevents a crash :smile:
