### PR TITLE
Set keep values as strings

### DIFF
--- a/src/jarabe/journal/expandedentry.py
+++ b/src/jarabe/journal/expandedentry.py
@@ -535,9 +535,9 @@ class ExpandedEntry(Gtk.EventBox):
 
     def _keep_icon_toggled_cb(self, keep_icon):
         if keep_icon.get_active():
-            self._metadata['keep'] = 1
+            self._metadata['keep'] = '1'
         else:
-            self._metadata['keep'] = 0
+            self._metadata['keep'] = '0'
         self._update_entry(needs_update=True)
 
     def _icon_button_release_event_cb(self, button, event):


### PR DESCRIPTION
Setting it as int caused problems with up-coming patches
to support metadata editing for Documents folders and
external devices.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
