### PR TITLE
Adhoc enhacements try2

### DIFF
--- a/data/org.sugarlabs.gschema.xml
+++ b/data/org.sugarlabs.gschema.xml
@@ -203,6 +203,11 @@
             <summary>Show Sugar Ad-hoc networks</summary>
             <description>If TRUE, Sugar will show default Ad-hoc networks for channel 1,6 and 11. If Sugar sees no "known" network when it starts, it does autoconnect to an Ad-hoc network.</description>
         </key>
+        <key name="adhoc-autoconnect" type="b">
+            <default>true</default>
+            <summary>Enable Ad-hoc autoconnect</summary>
+            <description>If TRUE, Sugar will autoconnect to Ad-hoc networks.</description>
+        </key>
         <child name="gsm" schema="org.sugarlabs.network.gsm" />
     </schema>
     <schema id="org.sugarlabs.network.gsm" path="/org/sugarlabs/network/gsm/">


### PR DESCRIPTION
These are two patches I made to ad-hoc networks autoconnect behaviour.

The first change, simplifies the autoconnect logic, from a "connect to the first available network you find, or connect to 1 otherwise" to a "connect to the last network you used during this session, or connect to 1 otherwise". This change was made as a requirement from Australia deployment, as the previous behavior seemed too unpredictable for users.

The second change allow us to disable Ad-hoc auto-connect using a gsettings value. Auto-connect option will be enabled by default. When disabled, Sugar will no longer auto-connect until the user explicitly connects to an Ad-hoc network (this is to cover suspend/resume scenarios). When the user explicitly disconnects from the Ad-hoc network, auto-connect will be disabled again.
