### PR TITLE
Remember last ad-hoc used

### DIFF
--- a/src/jarabe/model/adhoc.py
+++ b/src/jarabe/model/adhoc.py
@@ -64,6 +64,7 @@ class AdHocManager(GObject.GObject):
         self._listening_called = 0
         self._device_state = network.NM_DEVICE_STATE_UNKNOWN
 
+        self._last_channel = None
         self._current_channel = None
         self._networks = {self._CHANNEL_1: None,
                           self._CHANNEL_6: None,
@@ -157,18 +158,9 @@ class AdHocManager(GObject.GObject):
         return False
 
     def _autoconnect_adhoc(self):
-        """First we try if there is an Ad-hoc network that is used by other
-        learners in the area, if not we default to channel 1.
-
+        """Autoconnect to the last network used during the session.
         """
-        if self._networks[self._CHANNEL_1] is not None:
-            self.activate_channel(self._CHANNEL_1)
-        elif self._networks[self._CHANNEL_6] is not None:
-            self.activate_channel(self._CHANNEL_6)
-        elif self._networks[self._CHANNEL_11] is not None:
-            self.activate_channel(self._CHANNEL_11)
-        else:
-            self.activate_channel(self._CHANNEL_1)
+        self.activate_channel(self._last_channel or self._CHANNEL_1)
 
     def activate_channel(self, channel):
         """Activate a sugar Ad-hoc network.
@@ -180,6 +172,7 @@ class AdHocManager(GObject.GObject):
         connection = self._find_connection(channel)
         if connection:
             connection.activate(self._device.object_path)
+            self._last_channel = channel
 
     @staticmethod
     def _get_connection_id(channel):
@@ -227,6 +220,7 @@ class AdHocManager(GObject.GObject):
                         network.NM_SERVICE, network.NM_PATH)
                     netmgr = dbus.Interface(obj, network.NM_IFACE)
                     netmgr.DeactivateConnection(connection_o)
+                    self._last_channel = None
 
     def __get_active_connections_error_cb(self, err):
         logging.error('Error getting the active connections: %s', err)


### PR DESCRIPTION
 Simplifies the autoconnect logic, from a "connect to the first available network you find, or connect to 1 otherwise" to a "connect to the last network you used during this session, or connect to 1 otherwise". This change was made as a requirement from Australia deployment, as the previous behavior seemed too unpredictable for users.
