### PR TITLE
Fix circular import

### DIFF
--- a/src/jarabe/view/buddymenu.py
+++ b/src/jarabe/view/buddymenu.py
@@ -33,7 +33,6 @@ from jarabe.model import shell
 from jarabe.model import friends
 from jarabe.model.session import get_session_manager
 from jarabe.controlpanel.gui import ControlPanel
-import jarabe.desktop.homewindow
 
 
 class BuddyMenu(Palette):
@@ -128,6 +127,8 @@ class BuddyMenu(Palette):
         item.show()
 
     def _quit(self, action):
+        import jarabe.desktop.homewindow
+
         home_window = jarabe.desktop.homewindow.get_instance()
         home_window.busy_during_delayed_action(action)
 


### PR DESCRIPTION
There is a circular import loop in sugar:
buddyicon imports buddymenu imports homewindow imports meshview
imports buddyicon.

This patch breaks the loop by moving the homewindow import into the
one method that uses it.
