### PR TITLE
Use del instead of IconInfo.free

### DIFF
--- a/src/jarabe/frame/clipboardobject.py
+++ b/src/jarabe/frame/clipboardobject.py
@@ -68,7 +68,7 @@ class ClipboardObject(object):
                     icon_theme.lookup_icon(icon_name,
                                            Gtk.IconSize.LARGE_TOOLBAR, 0))
                 if icon_info is not None:
-                    icon_info.free()
+                    del icon_info
                     return icon_name
 
         return 'application-octet-stream'


### PR DESCRIPTION
Relace free method call for the proper python del call. IconInfo
does not have a free method.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
