### PR TITLE
Fix display of multiple alerts in home view - Fixes #4757

### DIFF
--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -81,6 +81,8 @@ class HomeWindow(Gtk.Window):
         self._box.pack_start(self._toolbar, False, True, 0)
         self._toolbar.show()
 
+        self._alerts = []
+
         self._home_box = HomeBox(self._toolbar)
         self._box.pack_start(self._home_box, True, True, 0)
         self._home_box.show()
@@ -101,11 +103,20 @@ class HomeWindow(Gtk.Window):
             self.__zoom_level_changed_cb)
 
     def add_alert(self, alert):
-        self._box.pack_start(alert, False, True, 0)
-        self._box.reorder_child(alert, 1)
+        self._alerts.append(alert)
+        if len(self._alerts) == 1:
+            self._box.pack_start(alert, False, False, 0)
+            self._box.reorder_child(alert, 1)
 
     def remove_alert(self, alert):
-        self._box.remove(alert)
+        if alert in self._alerts:
+            self._alerts.remove(alert)
+            # if the alert is the visible one on top of the queue
+            if alert.get_parent() is not None:
+                self._box.remove(alert)
+                if len(self._alerts) >= 1:
+                    self._box.pack_start(self._alerts[0], False, False, 0)
+                    self._box.reorder_child(self._alerts[0], 1)
 
     def _deactivate_view(self, level):
         group = palettegroup.get_group('default')


### PR DESCRIPTION
Copy the logic on grphics/window.py to avoid display more than one
alert at the same time.

Signed-off-by: Gonzalo Odiard godiard@sugarlabs.org
