### PR TITLE
Show the Join option in the activity palette in neighborhood - Fixes #47...

### DIFF
--- a/src/jarabe/desktop/meshbox.py
+++ b/src/jarabe/desktop/meshbox.py
@@ -127,7 +127,7 @@ class ActivityView(SnowflakeLayout):
 
     def _is_joinable(self):
         max_participants = self._model.bundle.get_max_participants()
-        return max_participants is None or len(self._icons) < max_participants
+        return max_participants is 0 or len(self._icons) < max_participants
 
     def _create_icon(self):
         icon = _ActivityIcon(self._model,


### PR DESCRIPTION
...79

The default value when the activity is not configured is 0, not None
