### PR TITLE
Objectchooser filter try3

### DIFF
--- a/src/jarabe/journal/iconview.py
+++ b/src/jarabe/journal/iconview.py
@@ -92,12 +92,13 @@ class IconView(Gtk.Bin):
                             None, ([str])),
     }
 
-    def __init__(self):
+    def __init__(self, toolbar):
         self._query = {}
         self._model = None
         self._progress_bar = None
         self._last_progress_bar_pulse = None
         self._scroll_position = 0.
+        self._toolbar = toolbar
 
         Gtk.Bin.__init__(self)
 
@@ -215,8 +216,9 @@ class IconView(Gtk.Bin):
                 else:
                     self._show_message(_('The device is empty'))
             else:
-                self._show_message(_('No matching entries'),
-                                   show_clear_query=True)
+                self._show_message(
+                    _('No matching entries'),
+                    show_clear_query=self._toolbar.is_filter_changed())
         else:
             self._clear_message()
 

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -459,6 +459,13 @@ class MainToolbox(ToolbarBox):
     def __favorite_button_toggled_cb(self, favorite_button):
         self._update_if_needed()
 
+    def is_filter_changed(self):
+        return not (self._filter_type == self.default_filter_type and
+                    self._what_filter == self.default_what_filter and
+                    self._when_filter is None and
+                    self._favorite_button.props.active == False and
+                    self.search_entry.props.text == '')
+
     def clear_query(self):
         self.search_entry.props.text = ''
         self._filter_type = self.default_filter_type

--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -390,9 +390,12 @@ class BaseListView(Gtk.Bin):
                     self._show_message(_('The device is empty'))
             else:
                 self._show_message(_('No matching entries'),
-                                   show_clear_query=True)
+                                   show_clear_query=self._can_clear_query())
         else:
             self._clear_message()
+
+    def _can_clear_query(self):
+        return True
 
     def __map_cb(self, widget):
         logging.debug('ListView.__map_cb %r', self._scroll_position)

--- a/src/jarabe/journal/objectchooser.py
+++ b/src/jarabe/journal/objectchooser.py
@@ -96,14 +96,14 @@ class ObjectChooser(Gtk.Window):
         self._toolbar.show()
 
         if not self._show_preview:
-            self._list_view = ChooserListView()
+            self._list_view = ChooserListView(self._toolbar)
             self._list_view.connect('entry-activated',
                                     self.__entry_activated_cb)
             self._list_view.connect('clear-clicked', self.__clear_clicked_cb)
             vbox.pack_start(self._list_view, True, True, 0)
             self._list_view.show()
         else:
-            self._icon_view = IconView()
+            self._icon_view = IconView(self._toolbar)
             self._icon_view.connect('entry-activated',
                                     self.__entry_activated_cb)
             self._icon_view.connect('clear-clicked', self.__clear_clicked_cb)
@@ -208,14 +208,18 @@ class ChooserListView(BaseListView):
                             ([str])),
     }
 
-    def __init__(self):
+    def __init__(self, toolbar):
         BaseListView.__init__(self, None)
+        self._toolbar = toolbar
 
         self.cell_icon.props.show_palette = False
         self.tree_view.props.hover_selection = True
 
         self.tree_view.connect('button-release-event',
                                self.__button_release_event_cb)
+
+    def _can_clear_query(self):
+        return self._toolbar.is_filter_changed()
 
     def __entry_activated_cb(self, entry):
         self.emit('entry-activated', entry)


### PR DESCRIPTION
Replaces https://github.com/sugarlabs/sugar/pull/383 - now actually split properly

On the old version the users are given a button `clear search`
if they don't have objects of the type the activity wanted. This
is confusing as it implies that users can insert whatever they
want as an image for example.

This fix hides the button when the user does not have any of the
requested object type. It also makes the button go back to the
activities original filter

There is probably a ticket about this, but I don't know where it is.
