### PR TITLE
Use show instead of show-all

### DIFF
--- a/src/jarabe/intro/colorpicker.py
+++ b/src/jarabe/intro/colorpicker.py
@@ -32,6 +32,7 @@ class ColorPicker(Gtk.EventBox):
         self._set_random_colors()
         self.connect('button-press-event', self._button_press_cb)
         self.add(self._xo)
+        self._xo.show()
 
     def _button_press_cb(self, widget, event):
         if event.button == 1 and event.type == Gdk.EventType.BUTTON_PRESS:

--- a/src/jarabe/intro/window.py
+++ b/src/jarabe/intro/window.py
@@ -163,6 +163,7 @@ class _NamePage(_Page):
         self._entry.set_size_request(style.zoom(300), -1)
         self._entry.set_max_length(45)
         grid.attach(self._entry, 0, 1, 1, 1)
+        self._entry.show()
 
         grid.show()
         alignment.show()
@@ -375,7 +376,6 @@ class _IntroBox(Gtk.VBox):
                                    self._page_valid_changed_cb)
 
         self.pack_start(button_box, False, True, 0)
-        self.show_all()
 
     def _update_next_button(self):
         self._next_button.set_sensitive(self._current_page.props.valid)


### PR DESCRIPTION
The age selector is selective about which icons are shown depending on
the screen width, therefore, the show_all() used in the IntroBox class
needs to be removed. This then requires the addition of a show in both
the color page and nick page.
