### PR TITLE
ObjectChooser: preserve filter type

### DIFF
--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -83,8 +83,8 @@ class MainToolbox(ToolbarBox):
     def __init__(self, default_what_filter=None, default_filter_type=None):
         ToolbarBox.__init__(self)
         self._mount_point = None
-        self._filter_type = None
-        self._what_filter = None
+        self._filter_type = default_filter_type
+        self._what_filter = default_what_filter
         self._when_filter = None
         self._default_what_filter = default_what_filter
         self._default_filter_type = default_filter_type
@@ -344,7 +344,10 @@ class MainToolbox(ToolbarBox):
                 elif 'file' in item:
                     self._what_search_button.set_widget_icon(
                         file_name=item['file'])
-                    self._filter_type = FILTER_TYPE_ACTIVITY
+                    if self._default_filter_type is not None:
+                        self._filter_type = self._default_filter_type
+                    else:
+                        self._filter_type = FILTER_TYPE_ACTIVITY
                 self._what_filter = what_filter
                 break
 
@@ -369,7 +372,10 @@ class MainToolbox(ToolbarBox):
             self._filter_type = FILTER_TYPE_GENERIC_MIME
         elif 'file' in item:
             self._what_search_button.set_widget_icon(file_name=item['file'])
-            self._filter_type = FILTER_TYPE_ACTIVITY
+            if self._default_filter_type is not None:
+                self._filter_type = self._default_filter_type
+            else:
+                self._filter_type = FILTER_TYPE_ACTIVITY
 
         self._what_filter = item['id']
 


### PR DESCRIPTION
When the ObjectChooser is called with the filter_type=FILTER_TYPE_MIME_BY_ACTIVITY
the filter_type was replaced by FILTER_TYPE_ACTIVITY.
This patch preserve the value used, if not filter type was selected,
use FILTER_TYPE_ACTIVITY.

Signd-off-by: Gonzalo Odiard godiard@sugarlabs.org
