### PR TITLE
Fix MetadataLookup signal definition

### DIFF
--- a/src/jarabe/model/update/microformat.py
+++ b/src/jarabe/model/update/microformat.py
@@ -328,7 +328,8 @@ class MetadataLookup(GObject.GObject):
     and there is no local source of the activity's name.
     """
     __gsignals__ = {
-        'complete': (GObject.SignalFlags.RUN_FIRST, None, (object, int, str)),
+        'complete': (GObject.SignalFlags.RUN_FIRST,
+                     None, (object, object, object)),
     }
 
     def __init__(self, url):


### PR DESCRIPTION
When The updater is looking up remotely for activity metadata
such as size and icon, the bundle can become unavailable because
of network or server issues.

Then, the MetadataLookup size attribute is never set and remains
as a None, therefore when the lookup is completed it emits the
complete signal sending a NoneType when a int type is expected,
crashing the updater.

This commit fixes the signal definition to allow NoneType values,
because these are actually valid cases.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
