### PR TITLE
adding cordova support to apisocket.py

### DIFF
--- a/src/jarabe/apisocket.py
+++ b/src/jarabe/apisocket.py
@@ -27,7 +27,7 @@ from gwebsockets.server import Server
 from gwebsockets.server import Message
 
 from sugar3 import env
-from sugar3.cordova import cordovaSocket
+from sugar3.cordova.cordovaSocket import call_cordova
 
 from jarabe.model import shell
 from jarabe.model import session
@@ -102,6 +102,7 @@ class ActivityAPI(API):
 
         chooser.destroy()
 
+    
     def cordova(self, request):
         plugin_name, service_name, args = request['params']
         call_cordova(plugin_name, service_name, args, self, request)
@@ -111,7 +112,7 @@ class ActivityAPI(API):
 
     def send_error(self, request, obj):
         self._client.send_error(request, obj)
-
+    
 
 class DatastoreAPI(API):
     def __init__(self, client):

--- a/src/jarabe/apisocket.py
+++ b/src/jarabe/apisocket.py
@@ -27,7 +27,7 @@ from gwebsockets.server import Server
 from gwebsockets.server import Message
 
 from sugar3 import env
-from sugar3.cordova.cordovasocket import call_cordova
+from sugar3.cordova import cordovaSocket
 
 from jarabe.model import shell
 from jarabe.model import session

--- a/src/jarabe/apisocket.py
+++ b/src/jarabe/apisocket.py
@@ -27,12 +27,11 @@ from gwebsockets.server import Server
 from gwebsockets.server import Message
 
 from sugar3 import env
+from sugar3.cordova.cordovasocket import call_cordova
 
 from jarabe.model import shell
 from jarabe.model import session
 from jarabe.journal.objectchooser import ObjectChooser
-
-from sugar3.cordova import cordovaSocket
 
 
 class StreamMonitor(object):
@@ -104,12 +103,8 @@ class ActivityAPI(API):
         chooser.destroy()
 
     def cordova(self, request):
-        plugin_name = request['params'][0]
-        service_name = request['params'][1]
-        args = request['params'][2]
-        cordova_class = cordovaSocket.callCordova()
-        cordova_class.call_to_cordova(plugin_name, service_name,
-                                      args, self, request)
+        plugin_name, service_name, args = request['params']
+        call_cordova(plugin_name, service_name, args, self, request)
 
 
 class DatastoreAPI(API):

--- a/src/jarabe/apisocket.py
+++ b/src/jarabe/apisocket.py
@@ -106,6 +106,12 @@ class ActivityAPI(API):
         plugin_name, service_name, args = request['params']
         call_cordova(plugin_name, service_name, args, self, request)
 
+    def send_result(self, request, obj):
+        self._client.send_result(request, obj)
+
+    def send_error(self, request, obj):
+        self._client.send_error(request, obj)
+
 
 class DatastoreAPI(API):
     def __init__(self, client):

--- a/src/jarabe/apisocket.py
+++ b/src/jarabe/apisocket.py
@@ -32,6 +32,8 @@ from jarabe.model import shell
 from jarabe.model import session
 from jarabe.journal.objectchooser import ObjectChooser
 
+from sugar3.cordova import cordovaSocket
+
 
 class StreamMonitor(object):
     def __init__(self):
@@ -100,6 +102,14 @@ class ActivityAPI(API):
             self._client.send_result(request, [None])
 
         chooser.destroy()
+
+    def cordova(self, request):
+        plugin_name = request['params'][0]
+        service_name = request['params'][1]
+        args = request['params'][2]
+        cordova_class = cordovaSocket.callCordova()
+        cordova_class.call_to_cordova(plugin_name, service_name,
+                                      args, self, request)
 
 
 class DatastoreAPI(API):


### PR DESCRIPTION
Added a function named cordova to the ActivityAPI class of the apisocket.py. This would enable the messages from cordova to communicate with the native part lying in the cordova folder under sugar-toolkit.