### PR TITLE
Time zone patches 2

### DIFF
--- a/extensions/cpsection/datetime/model.py
+++ b/extensions/cpsection/datetime/model.py
@@ -71,12 +71,28 @@ def print_timezone():
     print get_timezone()
 
 
+def fix_UTC_time_zone(timezone):
+    # Fixes the issue where the timezones are
+    # wrong when using UTC to set the time.
+    # This works by inverting the +/- and using
+    # the Etc/GMT... to be POSIX compliant.
+    if '+' in timezone:
+        new = timezone.replace('+', '-')
+    elif '-' in timezone:
+        new = timezone.replace('-', '+')
+    else:
+        new = 'UTC'
+    return 'Etc/' + new.replace('UTC', 'GMT')
+
+
 def set_timezone(timezone):
     """Set the system timezone
     timezone : e.g. 'America/Los_Angeles'
     """
     timezones = read_all_timezones()
     if timezone in timezones:
+        if timezone.startswith('UTC'):
+            timezone = fix_UTC_time_zone(timezone)
         os.environ['TZ'] = timezone
         settings = Gio.Settings('org.sugarlabs.date')
         settings.set_string('timezone', timezone)


### PR DESCRIPTION
The handeling of UTC in sugar is like the biggest fail whale in the world right now! Clicking UTC+2 will actually set your time to UTC-2!  This patch fixes the sign flipping.

It also extends the UTC range to include more countries time zones.

The duplication of UTC and GMT is also removed.

Replaces #402 
