### PR TITLE
Add default values for age picker to seed i18n

### DIFF
--- a/src/jarabe/intro/agepicker.py
+++ b/src/jarabe/intro/agepicker.py
@@ -36,7 +36,11 @@ from jarabe.intro.genderpicker import GENDERS
 
 _group_labels = None
 _SECONDS_PER_YEAR = 365 * 24 * 60 * 60.
-
+_DEFAULT_PROMPT = _('Select grade:')
+_DEFAULT_LABELS = [_('Preschool'), _('Kindergarten'), _('1st Grade'),
+                   _('2nd Grade'), _('3rd Grade'), _('4th Grade'),
+                   _('5th Grade'), _('6th Grade'), _('7th Grade'),
+                   _('High School'), _('Adult')]
 
 def calculate_birth_timestamp(age):
     age_in_seconds = age * _SECONDS_PER_YEAR


### PR DESCRIPTION
Since the labels for the age-selection widget are taken from an
environment variable (no longer hard-coded) they are not included in
the strings for i18n. This patch adds default values to agepicker.py
so that they are included in the Sugar POT file.
