### PR TITLE
Use busy cursor when duplicating activities

### DIFF
--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -374,18 +374,35 @@ class DocumentButton(RadioToolButton):
         self.props.palette.menu.append(menu_item)
         menu_item.show()
 
+    def set_busy_cursor(self, busy):
+        cursor = None
+        if busy:
+            cursor = Gdk.Cursor(Gdk.CursorType.WATCH)
+        gdk_window = self.get_root_window()
+        gdk_window.set_cursor(cursor)
+
     def __copy_to_home_cb(self, menu_item):
         """Make a local copy of the activity bundle in user_activities_path"""
         user_activities_path = get_user_activities_path()
         nick = customizebundle.generate_unique_id()
         new_basename = '%s_copy_of_%s' % (
             nick, os.path.basename(self._document_path))
+
         if not os.path.exists(os.path.join(user_activities_path,
                                            new_basename)):
-            shutil.copytree(self._document_path,
-                            os.path.join(user_activities_path, new_basename),
-                            symlinks=True)
-            customizebundle.generate_bundle(nick, new_basename)
+            self.set_busy_cursor(True)
+
+            def async_copy_activity_tree():
+                shutil.copytree(self._document_path,
+                                os.path.join(
+                                    user_activities_path,
+                                    new_basename),
+                                symlinks=True)
+                customizebundle.generate_bundle(nick, new_basename)
+                self.set_busy_cursor(False)
+
+            GObject.idle_add(async_copy_activity_tree)
+
         else:
             _logger.debug('%s already exists', new_basename)
 


### PR DESCRIPTION
This is a possible fix of: SL#3672

[Fix some typos of https://github.com/sugarlabs/sugar/pull/420]