### PR TITLE
Show busy on register to school server

### DIFF
--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -373,6 +373,14 @@ class FavoritesView(ViewContainer):
 
     def __register_activate_cb(self, icon):
         alert = Alert()
+        alert.props.title = _('Registration')
+        alert.props.msg = _('Please wait, searching for your school server.')
+        self._box.add_alert(alert)
+        GObject.idle_add(self.__register)
+
+    def __register(self):
+        self._box.remove_alert()
+        alert = Alert()
         try:
             schoolserver.register_laptop()
         except RegisterError, e:
@@ -388,6 +396,7 @@ class FavoritesView(ViewContainer):
 
         self._box.add_alert(alert)
         alert.connect('response', self.__register_alert_response_cb)
+        return False
 
     def __register_alert_response_cb(self, alert, response_id):
         self._box.remove_alert()


### PR DESCRIPTION
School server registration can take a few seconds, depending on network
activity.  Worst case is when there is no school server on an adhoc
network.

Show the shell is busy.  A busy cursor does not work for touchscreens,
so an alert is used.  This is in keeping with the alert already used
when a register to school server finishes.

Test case: connect to an adhoc network, then try to register.  A busy
message will appear, then some time later a failure message will appear.
