### PR TITLE
Add a viewer for Images in the view source.

### DIFF
--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -684,7 +684,7 @@ class SourceDisplay(Gtk.ScrolledWindow):
         elif 'audio/' in mime_type:
             self._show_image_viewer(icon='audio-x-generic')
         elif 'video/' in mime_type:
-            self._show_image_viewer(video='video-x-generic')
+            self._show_image_viewer(icon='video-x-generic')
         else:
             response = self._show_text_viewer()
             if not response:


### PR DESCRIPTION
How its works:
Select an image on the treeview, and It will show
If the selected file is audio/video, an icon (audio=audio-x-generic,
video=video-x-generic) will be showed.
However if you havent selected a file, a label will be showed.
If the selected file is Unknown for the view source
(no audio, text, image, video)will be show the unknown icon

Possible fix of SL#4273
