### PR TITLE
Brightness in frame try2

### DIFF
--- a/extensions/deviceicon/Makefile.am
+++ b/extensions/deviceicon/Makefile.am
@@ -4,6 +4,7 @@ sugar_PYTHON = 		\
 	__init__.py	\
 	audio.py	\
 	battery.py	\
+	display.py	\
 	frame.py	\
 	network.py	\
 	speech.py	\

--- a/extensions/deviceicon/display.py
+++ b/extensions/deviceicon/display.py
@@ -1,0 +1,206 @@
+# Copyright (C) 2014 Sam Parkinson
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+from gettext import gettext as _
+import math
+
+from gi.repository import Gtk
+from gi.repository import GObject
+
+from sugar3 import profile
+from sugar3.graphics import style
+from sugar3.graphics.icon import Icon
+from sugar3.graphics.tray import TrayIcon
+from sugar3.graphics.palette import Palette
+from sugar3.graphics.palettemenu import PaletteMenuBox
+from sugar3.graphics.palettemenu import PaletteMenuItem
+from sugar3.graphics.palettemenu import PaletteMenuItemSeparator
+from sugar3.graphics.xocolor import XoColor
+
+from jarabe.frame.frameinvoker import FrameWidgetInvoker
+from jarabe.model.brightness import brightness
+from jarabe.model.screenshot import take_screenshot
+from jarabe import frame
+
+_ICON_NAME = 'brightness'
+
+
+class DeviceView(TrayIcon):
+
+    FRAME_POSITION_RELATIVE = 160
+
+    def __init__(self, label):
+        self._color = profile.get_color()
+        self._label = label
+
+        TrayIcon.__init__(self, icon_name=_ICON_NAME, xo_color=self._color)
+
+        self.set_palette_invoker(FrameWidgetInvoker(self))
+        self.palette_invoker.props.toggle_palette = True
+
+        brightness.brightness_changed.connect(self.__brightness_changed_cb)
+
+        self._update_output_info()
+
+    def create_palette(self):
+        palette = DisplayPalette()
+        palette.set_group_id('frame')
+        return palette
+
+    def _update_output_info(self):
+        current_level = brightness.get_brightness()
+        xo_color = self._color
+
+        icon_number = math.ceil(float(brightness.get_brightness()) * 3
+                                / brightness.get_max_brightness()) * 33
+        if icon_number == 99:
+            icon_number = 100
+
+        self.icon.props.icon_name = \
+            'brightness-{:03d}'.format(int(icon_number))
+
+    def __brightness_changed_cb(self, **kwargs):
+        self._update_output_info()
+
+
+class BrightnessManagerWidget(Gtk.VBox):
+
+    def __init__(self, text, icon_name):
+        Gtk.VBox.__init__(self)
+        self._progress_bar = None
+        self._adjustment = None
+
+        icon = Icon(icon_size=Gtk.IconSize.MENU)
+        icon.props.icon_name = icon_name
+        icon.props.xo_color = XoColor('%s,%s' % (style.COLOR_WHITE.get_svg(),
+                                      style.COLOR_BUTTON_GREY.get_svg()))
+        icon.show()
+
+        label = Gtk.Label(text)
+        label.show()
+
+        grid = Gtk.Grid()
+        grid.set_column_spacing(style.DEFAULT_SPACING)
+        grid.attach(icon, 0, 0, 1, 1)
+        grid.attach(label, 1, 0, 1, 1)
+        grid.show()
+
+        alignment = Gtk.Alignment()
+        alignment.set(0.5, 0, 0, 0)
+        alignment.add(grid)
+        alignment.show()
+        self.add(alignment)
+
+        alignment = Gtk.Alignment()
+        alignment.set(0.5, 0, 0, 0)
+        alignment.set_padding(0, 0, style.DEFAULT_SPACING,
+                              style.DEFAULT_SPACING)
+
+        if brightness.can_set_brightness():
+            adjustment = Gtk.Adjustment(
+                value=brightness.get_brightness(),
+                lower=0,
+                upper=brightness.get_max_brightness() + 1,
+                step_incr=1,
+                page_incr=1,
+                page_size=1)
+            self._adjustment = adjustment
+
+            self._adjustment_hid = \
+                self._adjustment.connect('value_changed', self.__adjusted_cb)
+
+            hscale = Gtk.HScale()
+            hscale.props.draw_value = False
+            hscale.set_adjustment(adjustment)
+            hscale.set_digits(0)
+            hscale.set_size_request(style.GRID_CELL_SIZE * 4, -1)
+            alignment.add(hscale)
+            hscale.show()
+        else:
+            self._progress_bar = Gtk.ProgressBar()
+            self._progress_bar.set_size_request(
+                style.zoom(style.GRID_CELL_SIZE * 4), -1)
+            alignment.props.top_padding = style.DEFAULT_PADDING
+            alignment.add(self._progress_bar)
+            self._progress_bar.show()
+
+
+        alignment.show()
+        self.add(alignment)
+
+    def update(self):
+        if self._adjustment:
+            self._adjustment.handler_block(self._adjustment_hid)
+            self._adjustment.props.value = brightness.get_brightness()
+            self._adjustment.handler_unblock(self._adjustment_hid)
+        else:
+            self._progress_bar.props.fraction = \
+                float(brightness.get_brightness()) \
+                / brightness.get_max_brightness()
+
+    def __adjusted_cb(self, device, data=None):
+        value = self._adjustment.props.value
+        brightness.set_brightness(int(value))
+
+
+class DisplayPalette(Palette):
+
+    def __init__(self):
+        Palette.__init__(self, label=_('My Display'))
+
+        self._brightness_manager = BrightnessManagerWidget(_('Brightness'),
+                                                           'brightness-100')
+        self._brightness_manager.show()
+
+        separator = PaletteMenuItemSeparator()
+        separator.show()
+
+        self._screenshot = PaletteMenuItem(_('Take a screenshot'))
+        icon = Icon(icon_name='camera-external',
+                    pixel_size=style.SMALL_ICON_SIZE)
+        self._screenshot.set_image(icon)
+        icon.show()
+        self._screenshot.connect('activate', self.__screenshot_cb)
+        self._screenshot.show()
+
+        self._box = PaletteMenuBox()
+        self._box.append_item(self._brightness_manager, 0, 0)
+        self._box.append_item(separator, 0, 0)
+        self._box.append_item(self._screenshot, 0, 0)
+        self._box.show()
+
+        self.set_content(self._box)
+        self.connect('popup', self.__popup_cb)
+
+    def __popup_cb(self, palette):
+        self._brightness_manager.update()
+
+    def __screenshot_cb(self, palette):
+        frame_ = frame.get_view()
+        frame_.hide()
+        GObject.idle_add(self.__take_screenshot_cb, frame_)
+
+    def __take_screenshot_cb(self, frame_):
+        if frame_.is_visible():
+            return True
+
+        title = take_screenshot()
+        frame_.show()
+        return False
+
+
+def setup(tray):
+    tray.add_device(DeviceView(_('Display')))

--- a/extensions/globalkey/screenshot.py
+++ b/extensions/globalkey/screenshot.py
@@ -15,106 +15,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-import os
-import tempfile
-from gettext import gettext as _
-import StringIO
-import cairo
-
-from gi.repository import Gdk
-from gi.repository import Gio
-import dbus
-
-from sugar3.datastore import datastore
-from sugar3.graphics import style
-from sugar3 import env
-from jarabe.model import shell
+from jarabe.model.screenshot import take_screenshot
 
 BOUND_KEYS = ['<alt>1', 'Print']
 
 
 def handle_key_press(key):
-    tmp_dir = os.path.join(env.get_profile_path(), 'data')
-    fd, file_path = tempfile.mkstemp(dir=tmp_dir)
-    os.close(fd)
-
-    window = Gdk.get_default_root_window()
-    width, height = window.get_width(), window.get_height()
-
-    screenshot_surface = Gdk.Window.create_similar_surface(
-        window, cairo.CONTENT_COLOR, width, height)
-
-    cr = cairo.Context(screenshot_surface)
-    Gdk.cairo_set_source_window(cr, window, 0, 0)
-    cr.paint()
-    screenshot_surface.write_to_png(file_path)
-
-    settings = Gio.Settings('org.sugarlabs.user')
-    color = settings.get_string('color')
-
-    content_title = None
-    shell_model = shell.get_model()
-    zoom_level = shell_model.zoom_level
-
-    # TRANS: Nouns of what a screenshot contains
-    if zoom_level == shell_model.ZOOM_MESH:
-        content_title = _('Mesh')
-    elif zoom_level == shell_model.ZOOM_GROUP:
-        content_title = _('Group')
-    elif zoom_level == shell_model.ZOOM_HOME:
-        content_title = _('Home')
-    elif zoom_level == shell_model.ZOOM_ACTIVITY:
-        activity = shell_model.get_active_activity()
-        if activity is not None:
-            content_title = activity.get_title()
-            if content_title is None:
-                content_title = _('Activity')
-
-    if content_title is None:
-        title = _('Screenshot')
-    else:
-        title = _('Screenshot of \"%s\"') % content_title
-
-    jobject = datastore.create()
-    try:
-        jobject.metadata['title'] = title
-        jobject.metadata['keep'] = '0'
-        jobject.metadata['buddies'] = ''
-        jobject.metadata['preview'] = _get_preview_data(screenshot_surface)
-        jobject.metadata['icon-color'] = color
-        jobject.metadata['mime_type'] = 'image/png'
-        jobject.file_path = file_path
-        datastore.write(jobject, transfer_ownership=True)
-    finally:
-        jobject.destroy()
-        del jobject
-
-
-def _get_preview_data(screenshot_surface):
-    screenshot_width = screenshot_surface.get_width()
-    screenshot_height = screenshot_surface.get_height()
-
-    preview_width, preview_height = style.zoom(300), style.zoom(225)
-    preview_surface = cairo.ImageSurface(cairo.FORMAT_ARGB32,
-                                         preview_width, preview_height)
-    cr = cairo.Context(preview_surface)
-
-    scale_w = preview_width * 1.0 / screenshot_width
-    scale_h = preview_height * 1.0 / screenshot_height
-    scale = min(scale_w, scale_h)
-
-    translate_x = int((preview_width - (screenshot_width * scale)) / 2)
-    translate_y = int((preview_height - (screenshot_height * scale)) / 2)
-
-    cr.translate(translate_x, translate_y)
-    cr.scale(scale, scale)
-
-    cr.set_source_rgba(1, 1, 1, 0)
-    cr.set_operator(cairo.OPERATOR_SOURCE)
-    cr.paint()
-    cr.set_source_surface(screenshot_surface)
-    cr.paint()
-
-    preview_str = StringIO.StringIO()
-    preview_surface.write_to_png(preview_str)
-    return dbus.ByteArray(preview_str.getvalue())
+    take_screenshot()

--- a/src/jarabe/model/Makefile.am
+++ b/src/jarabe/model/Makefile.am
@@ -5,6 +5,7 @@ sugar_PYTHON =			\
 	__init__.py		\
 	buddy.py		\
 	bundleregistry.py	\
+	brightness.py		\
 	desktop.py		\
 	filetransfer.py		\
 	friends.py		\

--- a/src/jarabe/model/Makefile.am
+++ b/src/jarabe/model/Makefile.am
@@ -18,6 +18,7 @@ sugar_PYTHON =			\
         notifications.py        \
 	shell.py		\
 	screen.py		\
+	screenshot.py		\
         session.py		\
 	sound.py		\
 	speech.py		\

--- a/src/jarabe/model/brightness.py
+++ b/src/jarabe/model/brightness.py
@@ -1,0 +1,93 @@
+# Copyright (C) 2014 Sam Parkinson
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+import os
+
+import dbus
+from sugar3 import dispatch
+
+
+_DISPLAYS_DIRECTORY = '/sys/class/backlight/'
+
+_CONTROL_RAW = 0
+_CONTROL_GNOME = 1
+
+_POWER_NAME = 'org.gnome.SettingsDaemon.Power'
+_POWER_PATH = '/org/gnome/SettingsDaemon/Power'
+_SCREEN_IFACE = 'org.gnome.SettingsDaemon.Power.Screen'
+
+class Brightness(object):
+
+    brightness_changed = dispatch.Signal()
+
+    def __init__(self):
+        self._control = _CONTROL_RAW
+        self._bus = dbus.SessionBus()
+
+        display = os.listdir(_DISPLAYS_DIRECTORY)[0]
+        brightness_directory = os.path.join(_DISPLAYS_DIRECTORY, display)
+        self._brightness_path = os.path.join(brightness_directory,
+                                             'brightness')
+        self._can_set_brightness = os.access(self._brightness_path, os.W_OK)
+
+        # GNOME provides a way to change root-writeable brightness values
+        # Use it if avaliable
+        if (not self._can_set_brightness) and \
+            self._bus.name_has_owner(_POWER_NAME):
+            self._control = _CONTROL_GNOME
+            self._can_set_brightness = True
+            self._max_brightness = 100  # Percentages are used
+
+            power = self._bus.get_object(_POWER_NAME, _POWER_PATH)
+            self._dbus_props = dbus.Interface(power, dbus.PROPERTIES_IFACE)
+        else:
+            with open(os.path.join(brightness_directory,
+                      'max_brightness')) as f:
+                self._max_brightness = int(f.read())
+
+    def get_brightness(self):
+        if self._control == _CONTROL_RAW:
+            with open(self._brightness_path) as f:
+                return int(f.read())
+        else:
+            return int(self._dbus_props.Get(_SCREEN_IFACE, 'Brightness'))
+
+    def set_brightness(self, brightness):
+        '''
+        Sets the brightness with an int ranging from 0 to max_brightness.
+        '''
+        if not self._can_set_brightness:
+            return
+
+        if brightness < 0 or brightness > self._max_brightness:
+            return
+
+        if self._control == _CONTROL_RAW:
+            with open(self._brightness_path, 'w') as f:
+                f.write(str(brightness))
+        else:
+            self._dbus_props.Set(_SCREEN_IFACE, 'Brightness', brightness)
+
+        self.brightness_changed.send(None)
+
+    def can_set_brightness(self):
+        return self._can_set_brightness
+
+    def get_max_brightness(self):
+        return self._max_brightness
+
+
+brightness = Brightness()

--- a/src/jarabe/model/screenshot.py
+++ b/src/jarabe/model/screenshot.py
@@ -1,0 +1,120 @@
+# Copyright (C) 2008 One Laptop Per Child
+# Copyright (C) 2009 Simon Schampijer, James Zaki
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+import os
+import tempfile
+from gettext import gettext as _
+import StringIO
+import cairo
+
+from gi.repository import Gdk
+from gi.repository import Gio
+import dbus
+
+from sugar3.datastore import datastore
+from sugar3.graphics import style
+from sugar3 import env
+from jarabe.model import shell
+
+
+def take_screenshot():
+    tmp_dir = os.path.join(env.get_profile_path(), 'data')
+    fd, file_path = tempfile.mkstemp(dir=tmp_dir)
+    os.close(fd)
+
+    window = Gdk.get_default_root_window()
+    width, height = window.get_width(), window.get_height()
+
+    screenshot_surface = Gdk.Window.create_similar_surface(
+        window, cairo.CONTENT_COLOR, width, height)
+
+    cr = cairo.Context(screenshot_surface)
+    Gdk.cairo_set_source_window(cr, window, 0, 0)
+    cr.paint()
+    screenshot_surface.write_to_png(file_path)
+
+    settings = Gio.Settings('org.sugarlabs.user')
+    color = settings.get_string('color')
+
+    content_title = None
+    shell_model = shell.get_model()
+    zoom_level = shell_model.zoom_level
+
+    # TRANS: Nouns of what a screenshot contains
+    if zoom_level == shell_model.ZOOM_MESH:
+        content_title = _('Mesh')
+    elif zoom_level == shell_model.ZOOM_GROUP:
+        content_title = _('Group')
+    elif zoom_level == shell_model.ZOOM_HOME:
+        content_title = _('Home')
+    elif zoom_level == shell_model.ZOOM_ACTIVITY:
+        activity = shell_model.get_active_activity()
+        if activity is not None:
+            content_title = activity.get_title()
+            if content_title is None:
+                content_title = _('Activity')
+
+    if content_title is None:
+        title = _('Screenshot')
+    else:
+        title = _('Screenshot of \"%s\"') % content_title
+
+    jobject = datastore.create()
+    try:
+        jobject.metadata['title'] = title
+        jobject.metadata['keep'] = '0'
+        jobject.metadata['buddies'] = ''
+        jobject.metadata['preview'] = _get_preview_data(screenshot_surface)
+        jobject.metadata['icon-color'] = color
+        jobject.metadata['mime_type'] = 'image/png'
+        jobject.file_path = file_path
+        datastore.write(jobject, transfer_ownership=True)
+    finally:
+        jobject.destroy()
+        del jobject
+
+    return title
+
+
+def _get_preview_data(screenshot_surface):
+    screenshot_width = screenshot_surface.get_width()
+    screenshot_height = screenshot_surface.get_height()
+
+    preview_width, preview_height = style.zoom(300), style.zoom(225)
+    preview_surface = cairo.ImageSurface(cairo.FORMAT_ARGB32,
+                                         preview_width, preview_height)
+    cr = cairo.Context(preview_surface)
+
+    scale_w = preview_width * 1.0 / screenshot_width
+    scale_h = preview_height * 1.0 / screenshot_height
+    scale = min(scale_w, scale_h)
+
+    translate_x = int((preview_width - (screenshot_width * scale)) / 2)
+    translate_y = int((preview_height - (screenshot_height * scale)) / 2)
+
+    cr.translate(translate_x, translate_y)
+    cr.scale(scale, scale)
+
+    cr.set_source_rgba(1, 1, 1, 0)
+    cr.set_operator(cairo.OPERATOR_SOURCE)
+    cr.paint()
+    cr.set_source_surface(screenshot_surface)
+    cr.paint()
+
+    preview_str = StringIO.StringIO()
+    preview_surface.write_to_png(preview_str)
+    return dbus.ByteArray(preview_str.getvalue())


### PR DESCRIPTION
This adds a brightness model and screenshot model (from existing screenshot code).  This is then used to create a display frame icon, which houses the brightness and screenshot.

The brightness thing is a bit weird and has limitations.  It either manipulates the file directly or if uses GNOME SettingsDaemon over dbus.  If none of theses are writable, you get a read only brightness in the frame.