### PR TITLE
Don't use markup_text on activity_title

### DIFF
--- a/src/jarabe/desktop/meshbox.py
+++ b/src/jarabe/desktop/meshbox.py
@@ -64,7 +64,7 @@ class _ActivityIcon(CanvasIcon):
 
     def create_palette(self):
         primary_text = GLib.markup_escape_text(self._model.bundle.get_name())
-        secondary_text = GLib.markup_escape_text(self._model.get_name())
+        secondary_text = self._model.get_name()
         palette_icon = Icon(file=self._model.bundle.get_icon(),
                             pixel_size=style.STANDARD_ICON_SIZE,
                             xo_color=self._model.get_color())


### PR DESCRIPTION
markup_escape_text() changes characters like <,>,', etc, for
non-human-readable html code that is displayed in the palette's
activity.

With this patch, we remove markup_text, so, the characters dont change
anymore. Now if you have " ' " it will show " ' ",after " ' " = &quot;

Fixes SL#4456
