### PR TITLE
Remove markup for palettes.

### DIFF
--- a/extensions/deviceicon/audio.py
+++ b/extensions/deviceicon/audio.py
@@ -20,7 +20,6 @@
 
 from gettext import gettext as _
 
-from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gtk
 
@@ -67,10 +66,9 @@ class DeviceView(TrayIcon):
         self._update_output_info()
 
     def create_palette(self):
-        device_label = GLib.markup_escape_text(_('My Audio'))
-        output_label = GLib.markup_escape_text(self._output_label)
-        input_label = GLib.markup_escape_text(self._input_label)
-        palette = AudioPalette(device_label, output_label, input_label,
+        palette = AudioPalette(_('My Audio'),
+                               self._output_label,
+                               self._input_label,
                                output_model=self._audio_output_model,
                                input_model=self._audio_input_model)
         palette.set_group_id('frame')

--- a/extensions/deviceicon/battery.py
+++ b/extensions/deviceicon/battery.py
@@ -67,7 +67,7 @@ class DeviceView(TrayIcon):
         self.set_palette_invoker(FrameWidgetInvoker(self))
 
         self._model = DeviceModel(battery)
-        self.palette = BatteryPalette(GLib.markup_escape_text(_('My Battery')))
+        self.palette = BatteryPalette(_('My Battery'))
         self.palette.set_group_id('frame')
         self.palette_invoker.props.toggle_palette = True
         self._model.connect('updated',
@@ -168,7 +168,7 @@ class BatteryPalette(Palette):
 
         self.set_content(progress_widget)
 
-        self.props.secondary_text = GLib.markup_escape_text(secondary_text)
+        self.props.secondary_text = secondary_text
         self._status_label.set_text(status_text)
 
 

--- a/extensions/deviceicon/network.py
+++ b/extensions/deviceicon/network.py
@@ -26,7 +26,6 @@ import struct
 import datetime
 import time
 from gi.repository import Gtk
-from gi.repository import GLib
 from gi.repository import GObject
 import dbus
 
@@ -104,12 +103,11 @@ class WirelessPalette(Palette):
         self._info.show_all()
 
     def set_connecting(self):
-        label = GLib.markup_escape_text(_('Connecting...'))
-        self.props.secondary_text = label
+        self.props.secondary_text = _('Connecting...')
 
     def _set_connected(self, iaddress):
         self.set_content(self._info)
-        self.props.secondary_text = GLib.markup_escape_text(_('Connected'))
+        self.props.secondary_text = _('Connected')
         self._set_ip_address(iaddress)
         self._disconnect_item.show()
 
@@ -122,8 +120,7 @@ class WirelessPalette(Palette):
         self._set_channel(channel)
 
     def set_disconnected(self):
-        label = GLib.markup_escape_text(_('No wireless connection'))
-        self.props.primary_text = label
+        self.props.primary_text = _('No wireless connection')
         self.props.secondary_text = ''
         self._disconnect_item.hide()
         self.set_content(None)
@@ -156,8 +153,7 @@ class WiredPalette(Palette):
     __gtype_name__ = 'SugarWiredPalette'
 
     def __init__(self):
-        label = GLib.markup_escape_text(_('Wired Network'))
-        Palette.__init__(self, primary_text=label)
+        Palette.__init__(self, primary_text=_('Wired Network'))
 
         self._speed_label = Gtk.Label()
         self._speed_label.props.xalign = 0.0
@@ -182,7 +178,7 @@ class WiredPalette(Palette):
         self._info.show_all()
 
         self.set_content(self._info)
-        self.props.secondary_text = GLib.markup_escape_text(_('Connected'))
+        self.props.secondary_text = _('Connected')
 
     def set_connected(self, speed, iaddress):
         self._speed_label.set_text('%s: %d Mb/s' % (_('Speed'), speed))
@@ -210,8 +206,7 @@ class GsmPalette(Palette):
     }
 
     def __init__(self):
-        label = GLib.markup_escape_text(_('Wireless modem'))
-        Palette.__init__(self, primary_text=label)
+        Palette.__init__(self, primary_text=_('Wireless modem'))
 
         self._current_state = None
         self._failed_connection = False
@@ -280,22 +275,19 @@ class GsmPalette(Palette):
     def _update_label_and_text(self, reason=0):
         if self._current_state == _GSM_STATE_NOT_READY:
             self._toggle_state_item.set_label('...')
-            label = GLib.markup_escape_text(_('Please wait...'))
-            self.props.secondary_text = label
+            self.props.secondary_text = _('Please wait...')
 
         elif self._current_state == _GSM_STATE_DISCONNECTED:
             if not self._failed_connection:
                 self._toggle_state_item.set_label(_('Connect'))
-            label = GLib.markup_escape_text(_('Disconnected'))
-            self.props.secondary_text = label
+            self.props.secondary_text = _('Disconnected')
             icon = Icon(icon_name='dialog-ok',
                         pixel_size=style.SMALL_ICON_SIZE)
             self._toggle_state_item.set_image(icon)
 
         elif self._current_state == _GSM_STATE_CONNECTING:
             self._toggle_state_item.set_label(_('Cancel'))
-            label = GLib.markup_escape_text(_('Connecting...'))
-            self.props.secondary_text = label
+            self.props.secondary_text = _('Connecting...')
             icon = Icon(icon_name='dialog-cancel',
                         pixel_size=style.SMALL_ICON_SIZE)
             self._toggle_state_item.set_image(icon)
@@ -348,8 +340,8 @@ class GsmPalette(Palette):
             formatted_time = connection_time.strftime('%H:%M:%S')
         else:
             formatted_time = '00:00:00'
-        text = _('Connected for %s') % (formatted_time, )
-        self.props.secondary_text = GLib.markup_escape_text(text)
+
+        self.props.secondary_text = _('Connected for %s') % (formatted_time, )
 
     def update_stats(self, in_bytes, out_bytes):
         in_KBytes = in_bytes / 1024
@@ -533,8 +525,7 @@ class WirelessDeviceView(ToolButton):
         else:
             self._icon.props.badge_name = None
 
-        label = GLib.markup_escape_text(self._display_name)
-        self._palette.props.primary_text = label
+        self._palette.props.primary_text = self._display_name
 
         self._update_state()
         self._update_color()
@@ -626,7 +617,7 @@ class OlpcMeshDeviceView(ToolButton):
         self.palette_invoker.props.toggle_palette = True
 
         title = _('Mesh Network')
-        self._palette = WirelessPalette(GLib.markup_escape_text(title))
+        self._palette = WirelessPalette(title)
         self._palette.connect('deactivate-connection',
                               self.__deactivate_connection)
         self.set_palette(self._palette)
@@ -672,8 +663,7 @@ class OlpcMeshDeviceView(ToolButton):
 
     def _update_text(self):
         channel = str(self._channel)
-        text = GLib.markup_escape_text(_('Mesh Network %s') % (channel, ))
-        self._palette.props.primary_text = text
+        self._palette.props.primary_text = _('Mesh Network %s') % (channel, )
 
     def _update(self):
         state = self._device_state

--- a/extensions/deviceicon/speech.py
+++ b/extensions/deviceicon/speech.py
@@ -16,7 +16,6 @@
 
 from gettext import gettext as _
 
-from gi.repository import GLib
 from gi.repository import Gtk
 
 from sugar3 import profile
@@ -47,8 +46,7 @@ class SpeechDeviceView(TrayIcon):
         self._manager = speech.get_speech_manager()
 
     def create_palette(self):
-        label = GLib.markup_escape_text(_('Speech'))
-        palette = SpeechPalette(label, manager=self._manager)
+        palette = SpeechPalette(_('Speech'), manager=self._manager)
         palette.set_group_id('frame')
         return palette
 

--- a/extensions/deviceicon/touchpad.py
+++ b/extensions/deviceicon/touchpad.py
@@ -19,7 +19,6 @@ from gettext import gettext as _
 import os
 
 from gi.repository import Gtk
-from gi.repository import GLib
 
 import logging
 
@@ -59,8 +58,7 @@ class DeviceView(TrayIcon):
     def create_palette(self):
         """ Create a palette for this icon; called by the Sugar framework
         when a palette needs to be displayed. """
-        label = GLib.markup_escape_text(_('My touchpad'))
-        self.palette = ResourcePalette(label, self.icon)
+        self.palette = ResourcePalette(_('My touchpad'), self.icon)
         self.palette.set_group_id('frame')
         return self.palette
 

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -569,8 +569,7 @@ class FavoritePalette(ActivityPalette):
                                pixel_size=style.STANDARD_ICON_SIZE)
 
         if journal_entries:
-            title = journal_entries[0]['title']
-            self.props.secondary_text = GLib.markup_escape_text(title)
+            self.props.secondary_text = journal_entries[0]['title']
 
             menu_items = []
             for entry in journal_entries:

--- a/src/jarabe/desktop/meshbox.py
+++ b/src/jarabe/desktop/meshbox.py
@@ -21,7 +21,6 @@ from gettext import gettext as _
 import logging
 
 import dbus
-from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gio
 
@@ -63,8 +62,8 @@ class _ActivityIcon(CanvasIcon):
         self.palette_invoker.props.toggle_palette = True
 
     def create_palette(self):
-        primary_text = GLib.markup_escape_text(self._model.bundle.get_name())
-        secondary_text = GLib.markup_escape_text(self._model.get_name())
+        primary_text = self._model.bundle.get_name()
+        secondary_text = self._model.get_name()
         palette_icon = Icon(file=self._model.bundle.get_icon(),
                             pixel_size=style.STANDARD_ICON_SIZE,
                             xo_color=self._model.get_color())

--- a/src/jarabe/desktop/networkviews.py
+++ b/src/jarabe/desktop/networkviews.py
@@ -22,7 +22,6 @@ import hashlib
 import uuid
 
 import dbus
-from gi.repository import GLib
 
 from gi.repository import Gtk
 
@@ -121,8 +120,8 @@ class WirelessNetworkView(EventPulsingIcon):
                                   icon_size=style.STANDARD_ICON_SIZE,
                                   badge_name=self.props.badge_name)
 
-        label = GLib.markup_escape_text(self._display_name)
-        p = palette.Palette(primary_text=label, icon=self._palette_icon)
+        p = palette.Palette(primary_text=self._display_name,
+                            icon=self._palette_icon)
 
         self.menu_box = Gtk.VBox()
 
@@ -494,8 +493,7 @@ class SugarAdhocView(EventPulsingIcon):
             icon_name=self._ICON_NAME + str(self._channel),
             icon_size=style.STANDARD_ICON_SIZE)
 
-        text = _('Ad-hoc Network %d') % (self._channel, )
-        palette_ = palette.Palette(GLib.markup_escape_text(text),
+        palette_ = palette.Palette(_('Ad-hoc Network %d') % (self._channel, ),
                                    icon=self._palette_icon)
 
         self.menu_box = Gtk.VBox()
@@ -636,8 +634,7 @@ class OlpcMeshView(EventPulsingIcon):
         self.set_palette(self._palette)
 
     def _create_palette(self):
-        text = _('Mesh Network %d') % (self._channel, )
-        _palette = palette.Palette(GLib.markup_escape_text(text))
+        _palette = palette.Palette(_('Mesh Network %d') % (self._channel, ))
 
         self.menu_box = Gtk.VBox()
 

--- a/src/jarabe/frame/activitiestray.py
+++ b/src/jarabe/frame/activitiestray.py
@@ -23,7 +23,6 @@ import os
 
 from gi.repository import GObject
 from gi.repository import Gio
-from gi.repository import GLib
 from gi.repository import Gtk
 from gi.repository import Pango
 
@@ -223,7 +222,7 @@ class InvitePalette(Palette):
         else:
             name = bundle_id
 
-        self.set_primary_text(GLib.markup_escape_text(name))
+        self.set_primary_text(name)
 
     def __join_activate_cb(self, menu_item):
         self._invite.join()
@@ -566,7 +565,7 @@ class BaseTransferPalette(Palette):
     }
 
     def __init__(self, file_transfer):
-        Palette.__init__(self, GLib.markup_escape_text(file_transfer.title))
+        Palette.__init__(self, file_transfer.title)
 
         self.file_transfer = file_transfer
 
@@ -630,8 +629,7 @@ class IncomingTransferPalette(BaseTransferPalette):
         self.file_transfer.connect('notify::state', self.__notify_state_cb)
 
         nick = str(self.file_transfer.buddy.props.nick)
-        label = GLib.markup_escape_text(_('Transfer from %s') % (nick,))
-        self.props.secondary_text = label
+        self.props.secondary_text = _('Transfer from %s') % (nick,)
 
         self._update()
 
@@ -797,8 +795,7 @@ class OutgoingTransferPalette(BaseTransferPalette):
         self.file_transfer.connect('notify::state', self.__notify_state_cb)
 
         nick = str(file_transfer.buddy.props.nick)
-        label = GLib.markup_escape_text(_('Transfer to %s') % (nick,))
-        self.props.secondary_text = label
+        self.props.secondary_text = _('Transfer to %s') % (nick,)
 
         self._update()
 

--- a/src/jarabe/frame/clipboardmenu.py
+++ b/src/jarabe/frame/clipboardmenu.py
@@ -20,7 +20,6 @@ import urlparse
 import os
 import logging
 from gi.repository import Gio
-from gi.repository import GLib
 
 from gi.repository import Gtk
 
@@ -145,11 +144,10 @@ class ClipboardMenu(Palette):
         self._update()
 
     def _update(self):
-        name = self._cb_object.get_name()
-        self.props.primary_text = GLib.markup_escape_text(name)
+        self.props.primary_text = self._cb_object.get_name()
         preview = self._cb_object.get_preview()
         if preview:
-            self.props.secondary_text = GLib.markup_escape_text(preview)
+            self.props.secondary_text = preview
         self._update_items_visibility()
         self._update_open_submenu()
 

--- a/src/jarabe/journal/expandedentry.py
+++ b/src/jarabe/journal/expandedentry.py
@@ -21,7 +21,6 @@ import time
 import os
 
 from gi.repository import GObject
-from gi.repository import GLib
 from gi.repository import Gtk
 import json
 
@@ -494,8 +493,7 @@ class ExpandedEntry(Gtk.EventBox):
         old_title = self._metadata.get('title', None)
         new_title = self._title.get_text()
         if old_title != new_title:
-            label = GLib.markup_escape_text(new_title)
-            self._icon.palette.props.primary_text = label
+            self._icon.palette.props.primary_text = new_title
             self._metadata['title'] = new_title
             self._metadata['title_set_by_user'] = '1'
             needs_update = True

--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -24,7 +24,6 @@ from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import Gio
-from gi.repository import GLib
 
 from sugar3.graphics import style
 from sugar3.graphics.palette import Palette
@@ -67,9 +66,9 @@ class ObjectPalette(Palette):
         activity_icon.props.xo_color = color
 
         if 'title' in metadata:
-            title = GObject.markup_escape_text(metadata['title'])
+            title = metadata['title']
         else:
-            title = GLib.markup_escape_text(_('Untitled'))
+            title = _('Untitled')
 
         Palette.__init__(self, primary_text=title,
                          icon=activity_icon)
@@ -524,8 +523,7 @@ class BuddyPalette(Palette):
                           icon_size=style.STANDARD_ICON_SIZE,
                           xo_color=XoColor(colors))
 
-        Palette.__init__(self, primary_text=GLib.markup_escape_text(nick),
-                         icon=buddy_icon)
+        Palette.__init__(self, primary_text=nick, icon=buddy_icon)
 
         # TODO: Support actions on buddies, like make friend, invite, etc.
 

--- a/src/jarabe/journal/volumestoolbar.py
+++ b/src/jarabe/journal/volumestoolbar.py
@@ -211,8 +211,7 @@ class VolumesToolbar(Gtk.Toolbar):
         if documents_path is not None:
             button = DocumentsButton(documents_path)
             button.props.group = self._volume_buttons[0]
-            label = GLib.markup_escape_text(_('Documents'))
-            button.set_palette(Palette(label))
+            button.set_palette(Palette(_('Documents')))
             button.connect('toggled', self._button_toggled_cb)
             button.show()
 
@@ -347,7 +346,7 @@ class JournalButton(BaseButton):
 class JournalButtonPalette(Palette):
 
     def __init__(self, mount):
-        Palette.__init__(self, GLib.markup_escape_text(_('Journal')))
+        Palette.__init__(self, _('Journal'))
 
         grid = Gtk.Grid(orientation=Gtk.Orientation.VERTICAL,
                         margin=style.DEFAULT_SPACING,

--- a/src/jarabe/view/buddymenu.py
+++ b/src/jarabe/view/buddymenu.py
@@ -21,7 +21,6 @@ from gettext import gettext as _
 
 from gi.repository import Gtk
 from gi.repository import Gio
-from gi.repository import GLib
 import dbus
 
 from sugar3.graphics.palette import Palette
@@ -43,9 +42,7 @@ class BuddyMenu(Palette):
                           xo_color=buddy.get_color(),
                           pixel_size=style.STANDARD_ICON_SIZE)
         nick = buddy.get_nick()
-        Palette.__init__(self, None,
-                         primary_text=GLib.markup_escape_text(nick),
-                         icon=buddy_icon)
+        Palette.__init__(self, None, primary_text=nick, icon=buddy_icon)
         self.menu_box = Gtk.VBox()
         self.set_content(self.menu_box)
         self.menu_box.show_all()
@@ -177,7 +174,7 @@ class BuddyMenu(Palette):
         self._update_invite_menu(activity_model)
 
     def __buddy_notify_nick_cb(self, buddy, pspec):
-        self.set_primary_text(GLib.markup_escape_text(buddy.props.nick))
+        self.set_primary_text(buddy.props.nick)
 
     def _make_friend_cb(self, menuitem):
         friends.get_model().make_friend(self._buddy)

--- a/src/jarabe/view/palettes.py
+++ b/src/jarabe/view/palettes.py
@@ -19,7 +19,6 @@ import statvfs
 from gettext import gettext as _
 import logging
 
-from gi.repository import GLib
 from gi.repository import Gtk
 from gi.repository import GObject
 
@@ -50,7 +49,7 @@ class BasePalette(Palette):
         if home_activity.props.launch_status == shell.Activity.LAUNCHING:
             self._notify_launch_hid = home_activity.connect(
                 'notify::launch-status', self.__notify_launch_status_cb)
-            self.set_primary_text(GLib.markup_escape_text(_('Starting...')))
+            self.set_primary_text(_('Starting...'))
         elif home_activity.props.launch_status == shell.Activity.LAUNCH_FAILED:
             self._on_failed_launch()
         else:
@@ -61,7 +60,7 @@ class BasePalette(Palette):
 
     def _on_failed_launch(self):
         message = _('Activity failed to start')
-        self.set_primary_text(GLib.markup_escape_text(message))
+        self.set_primary_text(message)
 
     def __notify_launch_status_cb(self, home_activity, pspec):
         home_activity.disconnect(self._notify_launch_hid)
@@ -87,11 +86,11 @@ class CurrentActivityPalette(BasePalette):
     def setup_palette(self):
         activity_name = self._home_activity.get_activity_name()
         if activity_name:
-            self.props.primary_text = GLib.markup_escape_text(activity_name)
+            self.props.primary_text = activity_name
 
         title = self._home_activity.get_title()
         if title and title != activity_name:
-            self.props.secondary_text = GLib.markup_escape_text(title)
+            self.props.secondary_text = title
 
         self.menu_box = PaletteMenuBox()
 
@@ -172,8 +171,7 @@ class ActivityPalette(Palette):
                              pixel_size=style.STANDARD_ICON_SIZE)
 
         name = activity_info.get_name()
-        Palette.__init__(self, primary_text=GLib.markup_escape_text(name),
-                         icon=activity_icon)
+        Palette.__init__(self, primary_text=name, icon=activity_icon)
 
         xo_color = XoColor('%s,%s' % (style.COLOR_WHITE.get_svg(),
                                       style.COLOR_TRANSPARENT.get_svg()))
@@ -202,8 +200,7 @@ class JournalPalette(BasePalette):
         BasePalette.__init__(self, home_activity)
 
     def setup_palette(self):
-        title = self._home_activity.get_title()
-        self.set_primary_text(GLib.markup_escape_text(title))
+        self.set_primary_text(self._home_activity.get_title())
 
         box = PaletteMenuBox()
         self.set_content(box)
@@ -259,8 +256,7 @@ class VolumePalette(Palette):
         Palette.__init__(self, label=mount.get_name())
         self._mount = mount
 
-        path = mount.get_root().get_path()
-        self.props.secondary_text = GLib.markup_escape_text(path)
+        self.props.secondary_text = mount.get_root().get_path()
 
         self.content_box = PaletteMenuBox()
         self.set_content(self.content_box)


### PR DESCRIPTION
Now sugar-toolkit get markup (glib.markup_escape_text) as default.
This prevent non-human-readable html code showed in palettes.

This fixes SL#4456

Requires: https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/176
