### PR TITLE
Use the bundle registry in sugar-install-bundle; fixes #4722

### DIFF
--- a/bin/sugar-install-bundle
+++ b/bin/sugar-install-bundle
@@ -2,6 +2,7 @@
 import sys
 
 from sugar3.bundle.activitybundle import ActivityBundle
+from jarabe.model.bundleregistry import get_registry
 
 from dbus.mainloop.glib import DBusGMainLoop
 DBusGMainLoop(set_as_default=True)
@@ -15,7 +16,8 @@ if len(sys.argv) != 2:
     cmd_help()
     sys.exit(2)
 
+registry = get_registry()
 bundle = ActivityBundle(sys.argv[1])
-bundle.install()
+registry.install(bundle, force_downgrade=True)
 
 print "%s: '%s' installed." % (sys.argv[0], sys.argv[1])


### PR DESCRIPTION
The bundle registry properly signals the activity list to update its entries,
whereas directly installing the bundle does not emit any signals (unless it is
an install or uninstall).

[GCI task](https://www.google-melange.com/gci/task/view/google/gci2014/5866507338776576)
