### PR TITLE
Use 'sugar' icons and no 'gnome' icons.

### DIFF
--- a/src/jarabe/journal/misc.py
+++ b/src/jarabe/journal/misc.py
@@ -60,6 +60,8 @@ def _get_icon_for_mime(mime_type):
     for icon_name in icons.props.names:
         file_name = get_icon_file_name(icon_name)
         if file_name is not None:
+            if not '/icons/sugar/' in file_name:
+                continue
             return file_name
 
 
@@ -68,7 +70,11 @@ def get_mount_icon_name(mount, size):
     if isinstance(icon, Gio.ThemedIcon):
         icon_theme = Gtk.IconTheme.get_default()
         for icon_name in icon.props.names:
-            if icon_theme.lookup_icon(icon_name, size, 0) is not None:
+            lookup = icon_theme.lookup_icon(icon_name, size, 0)
+            if lookup is not None:
+                file_name = lookup.get_filename()
+                if not '/icons/sugar/' in file_name:
+                    continue
                 return icon_name
     logging.error('Cannot find icon name for %s, %s', icon, mount)
     return 'drive'


### PR DESCRIPTION
Right now IconTheme return the icons of the gnome theme,
with this patch, its compare the paths..

If the icons contain some text of the normal sugar icons path,
its uses it. (/icons/sugar/)

Before this patch, the journal show gnome icons in mime_types

Fixes SL#4791
