### PR TITLE
Don't save jabber without user confirmation.

### DIFF
--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -323,6 +323,9 @@ class ControlPanel(Gtk.Window):
         self._show_main_view()
 
     def __accept_clicked_cb(self, widget):
+        if hasattr(self._section_view, "apply"):
+            self._section_view.apply()
+
         if self._section_view.needs_restart:
             self._section_toolbar.accept_button.set_sensitive(False)
             self._section_toolbar.cancel_button.set_sensitive(False)


### PR DESCRIPTION
Right now the jabber server entry autosaves when the user presses enter.
With this patch, that no longer happens. The user must click the accept
button in the control panel in order to save a new jabber server entry.

The timeout has been removed because we need now reset the server immediately
when the accept button is pressed.

The change-signal handler has been removed because we only want to change the
server name when the user clicks on accept button.

An apply flag has been added so if the user clicks on accept, we know
whether or not the server should be updated.