### PR TITLE
Use the bundle registry in sugar-install-bundle (when sugar is running)

### DIFF
--- a/bin/sugar-install-bundle
+++ b/bin/sugar-install-bundle
@@ -1,8 +1,8 @@
 #!/usr/bin/env python2
+import os
 import sys
 
 from sugar3.bundle.activitybundle import ActivityBundle
-from jarabe.model.bundleregistry import get_registry
 
 from dbus.mainloop.glib import DBusGMainLoop
 DBusGMainLoop(set_as_default=True)
@@ -16,8 +16,15 @@ if len(sys.argv) != 2:
     cmd_help()
     sys.exit(2)
 
-registry = get_registry()
-bundle = ActivityBundle(sys.argv[1])
-registry.install(bundle, force_downgrade=True)
+if 'SUGAR_PROFILE' in os.environ:
+    # We are in sugar, so use the bundle registry so the correct signals
+    # are sent to the activity list
+    from jarabe.model.bundleregistry import get_registry
+    registry = get_registry()
+    bundle = ActivityBundle(sys.argv[1])
+    registry.install(bundle, force_downgrade=True)
+else:
+    bundle = ActivityBundle(sys.argv[1])
+    bundle.install()
 
 print "%s: '%s' installed." % (sys.argv[0], sys.argv[1])


### PR DESCRIPTION
Fixes #4722, while remaining compatiable with non-sugar users of the installer
