### PR TITLE
Elipsize view source title to prevent toolbar overflow, fixes #4755

### DIFF
--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -489,10 +489,11 @@ class Toolbar(Gtk.Toolbar):
         self.sugar_toolkit_title_text = _('View source: %r') % 'Sugar Toolkit'
         self.label = Gtk.Label()
         self.label.set_markup('<b>%s</b>' % self.activity_title_text)
+        self.label.set_ellipsize(style.ELLIPSIZE_MODE_DEFAULT)
         self.label.set_alignment(0, 0.5)
-        self._add_widget(self.label)
+        self._add_widget(self.label, expand=True)
 
-        self._add_separator(True)
+        self._add_separator(False)
 
         stop = ToolButton(icon_name='dialog-cancel')
         stop.set_tooltip(_('Close'))


### PR DESCRIPTION
This also fixes on of the dot points in #4397

> ## Browse show source - close is off RHS of toolbar
> 
> XO-4 Sugar 0.100 13.4.0 build 1 Browse156
> The close button does not fit on the toolbar of show source, document source and activity source but toolkit source is ok

http://bugs.sugarlabs.org/ticket/4755
