### PR TITLE
Show activity name in the search entry when one activity is selected

### DIFF
--- a/src/jarabe/desktop/activitieslist.py
+++ b/src/jarabe/desktop/activitieslist.py
@@ -35,6 +35,7 @@ from sugar3.graphics.icon import Icon, CellRendererIcon
 from sugar3.graphics.xocolor import XoColor
 from sugar3.graphics.alert import Alert
 from sugar3.graphics.palettemenu import PaletteMenuItem
+from sugar3.datastore import datastore
 
 from jarabe.model import bundleregistry
 from jarabe.model import desktop
@@ -133,6 +134,7 @@ class ActivitiesTreeView(Gtk.TreeView):
 
         self.set_search_column(self._model.column_title)
         self.set_enable_search(False)
+        self._activity_selected = None
 
     def __erase_activated_cb(self, cell_renderer, bundle_id):
         self.emit('erase-activated', bundle_id)
@@ -185,6 +187,41 @@ class ActivitiesTreeView(Gtk.TreeView):
         if column == self._icon_column:
             self._start_activity(path)
 
+    def get_activities_selected(self):
+        activities = []
+        for row in self.get_model():
+            activities.append(
+                {'name': row[self.get_model().column_activity_name],
+                 'bundle_id': row[self.get_model().column_bundle_id]})
+        return activities
+
+    def run_activity(self, bundle_id, resume_mode):
+        if not resume_mode:
+            registry = bundleregistry.get_registry()
+            bundle = registry.get_bundle(bundle_id)
+            misc.launch(bundle)
+            return
+
+        self._activity_selected = bundle_id
+        query = {'activity': bundle_id}
+        properties = ['uid', 'title', 'icon-color', 'activity', 'activity_id',
+                      'mime_type', 'mountpoint']
+        datastore.find(query, sorting=['+timestamp'],
+                       limit=1, properties=properties,
+                       reply_handler=self.__get_last_activity_reply_handler_cb,
+                       error_handler=self.__get_last_activity_error_handler_cb)
+
+    def __get_last_activity_reply_handler_cb(self, entries, total_count):
+        registry = bundleregistry.get_registry()
+        if entries:
+            misc.resume(entries[0], entries[0]['activity'])
+        else:
+            bundle = registry.get_bundle(self._activity_selected)
+            misc.launch(bundle)
+
+    def __get_last_activity_error_handler_cb(self, entries, total_count):
+        pass
+
 
 class ListModel(Gtk.TreeModelSort):
     __gtype_name__ = 'SugarListModel'
@@ -200,8 +237,9 @@ class ListModel(Gtk.TreeModelSort):
         self.column_version_text = self.column_version + 1
         self.column_date = self.column_version_text + 1
         self.column_date_text = self.column_date + 1
+        self.column_activity_name = self.column_date_text + 1
 
-        column_types = [str, str, str, str, str, int, str]
+        column_types = [str, str, str, str, str, int, str, str]
         for i in range(desktop.get_number_of_views()):
             column_types.insert(1, bool)
 
@@ -283,6 +321,7 @@ class ListModel(Gtk.TreeModelSort):
         model_list.append(_('Version %s') % version)
         model_list.append(int(timestamp))
         model_list.append(util.timestamp_to_elapsed_string(timestamp))
+        model_list.append(activity_info.get_name())
         self._model.append(model_list)
 
     def set_visible_func(self, func):
@@ -524,6 +563,12 @@ class ActivitiesList(Gtk.VBox):
             registry = bundleregistry.get_registry()
             bundle = registry.get_bundle(bundle_id)
             registry.uninstall(bundle, delete_profile=True)
+
+    def get_activities_selected(self):
+        return self._tree_view.get_activities_selected()
+
+    def run_activity(self, bundle_id, resume_mode):
+        self._tree_view.run_activity(bundle_id, resume_mode)
 
 
 class ActivityListPalette(ActivityPalette):

--- a/src/jarabe/desktop/homebox.py
+++ b/src/jarabe/desktop/homebox.py
@@ -59,6 +59,7 @@ class HomeBox(Gtk.VBox):
 
         self._set_view(self._favorites_views_indicies[0])
         self._query = ''
+        self._resume_mode = True
 
     def __desktop_view_icons_changed_cb(self, model):
         number_of_views = desktop.get_number_of_views()
@@ -87,8 +88,21 @@ class HomeBox(Gtk.VBox):
         self._list_view.set_filter(self._query)
         for i in range(desktop.get_number_of_views()):
             self._favorites_boxes[i].set_filter(self._query)
-        toolbar.search_entry._icon_selected = self._favorites_boxes[
-            i]._get_selected(self._query)
+        toolbar.search_entry._icon_selected = \
+            self._list_view.get_activities_selected()
+
+        # verify if one off the selected names is a perfect match
+        # this is needed by th case of activities with names contained
+        # in other activities like 'Paint' and 'MusicPainter'
+        for activity in self._list_view.get_activities_selected():
+            if activity['name'].upper() == query.upper():
+                toolbar.search_entry._icon_selected = [activity]
+                break
+
+        if len(toolbar.search_entry._icon_selected) == 1:
+            toolbar.search_entry.set_text(
+                toolbar.search_entry._icon_selected[0]['name'])
+            toolbar.search_entry.set_position(-1)
 
     def __toolbar_view_changed_cb(self, toolbar, view):
         self._set_view(view)
@@ -97,8 +111,10 @@ class HomeBox(Gtk.VBox):
         # wherever a single item is selected in a desktop view,
         # launch the activity on pressing return
         if event.keyval == Gdk.KEY_Return and len(entry._icon_selected) == 1:
-            entry._icon_selected[0].run_activity()
+            self._list_view.run_activity(entry._icon_selected[0]['bundle_id'],
+                                         self._resume_mode)
             entry._icon_selected = []
+            self.set_resume_mode(True)
 
     def __activitylist_clear_clicked_cb(self, widget, toolbar):
         toolbar.clear_query()
@@ -160,6 +176,7 @@ class HomeBox(Gtk.VBox):
         return False
 
     def set_resume_mode(self, resume_mode, favorite_view=0):
+        self._resume_mode = resume_mode
         self._favorites_boxes[favorite_view].set_resume_mode(resume_mode)
         if resume_mode and self._query != '':
             self._list_view.set_filter(self._query)


### PR DESCRIPTION
This patch complete the activity name in the filter, even for
activities not present in the favorites view.
The activity can be started pressing Enter, by default the activity
will start the last instance, if the user want start a new instance
can press Alt+Enter. This behaviour is the same in all the views.
