### PR TITLE
Use SugarExt.clipboard_set_with_data

### DIFF
--- a/src/jarabe/frame/clipboardicon.py
+++ b/src/jarabe/frame/clipboardicon.py
@@ -19,6 +19,7 @@ import logging
 
 from gi.repository import Gtk
 from gi.repository import Gdk
+from gi.repository import SugarExt
 
 from sugar3.graphics.radiotoolbutton import RadioToolButton
 from sugar3.graphics.icon import Icon
@@ -90,10 +91,23 @@ class ClipboardIcon(RadioToolButton):
         targets = self._get_targets()
         if targets:
             x_clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
-            if not x_clipboard.set_with_data(targets,
-                                             self._clipboard_data_get_cb,
-                                             self._clipboard_clear_cb,
-                                             targets):
+
+            # XXX SL#4307 - until set_with_data bindings are fixed upstream
+            if hasattr(x_clipboard, 'set_with_data'):
+                stored = x_clipboard.set_with_data(
+                    targets,
+                    self._clipboard_data_get_cb,
+                    self._clipboard_clear_cb,
+                    targets)
+            else:
+                stored = SugarExt.clipboard_set_with_data(
+                    x_clipboard,
+                    targets,
+                    self._clipboard_data_get_cb,
+                    self._clipboard_clear_cb,
+                    targets)
+
+            if not stored:
                 logging.error('GtkClipboard.set_with_data failed!')
             else:
                 self.owns_clipboard = True

--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -24,6 +24,7 @@ from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import Gio
+from gi.repository import SugarExt
 
 from sugar3.graphics import style
 from sugar3.graphics.palette import Palette
@@ -423,10 +424,20 @@ class ClipboardMenu(MenuItem):
                           _('Warning'))
                 return
 
-            clipboard.set_with_data(
-                [Gtk.TargetEntry.new('text/uri-list', 0, 0)],
-                self.__clipboard_get_func_cb,
-                self.__clipboard_clear_func_cb, None)
+            # XXX SL#4307 - until set_with_data bindings are fixed upstream
+            if hasattr(clipboard, 'set_with_data'):
+                clipboard.set_with_data(
+                    [Gtk.TargetEntry.new('text/uri-list', 0, 0)],
+                    self.__clipboard_get_func_cb,
+                    self.__clipboard_clear_func_cb,
+                    None)
+            else:
+                SugarExt.clipboard_set_with_data(
+                    clipboard,
+                    [Gtk.TargetEntry.new('text/uri-list', 0, 0)],
+                    self.__clipboard_get_func_cb,
+                    self.__clipboard_clear_func_cb,
+                    None)
 
     def __clipboard_get_func_cb(self, clipboard, selection_data, info, data):
         # Get hold of a reference so the temp file doesn't get deleted


### PR DESCRIPTION
As described in SL#4307, Gtk.Clipboard.set_with_data is not
introspectable, use SugarExt.clipboard_set_with_data to access
it. Use Gtk.Clipboard.set_with_data if available.

Fixes SL#4307.

Requires https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/182 before merge.

Signed-off-by: Martin Abente Lahaye <tch@sugarlabs.org>