### PR TITLE
Hide the Speech TrayIcon if GST or the espeak module isn't installed

### DIFF
--- a/extensions/deviceicon/speech.py
+++ b/extensions/deviceicon/speech.py
@@ -154,4 +154,5 @@ class SpeechPalette(Palette):
 
 
 def setup(tray):
-    tray.add_device(SpeechDeviceView())
+    if speech.get_speech_manager():
+        tray.add_device(SpeechDeviceView())

--- a/extensions/globalkey/speech.py
+++ b/extensions/globalkey/speech.py
@@ -21,6 +21,9 @@ BOUND_KEYS = ['<alt><shift>s']
 
 def handle_key_press(key):
     manager = speech.get_speech_manager()
+    if not manager:
+        return
+
     if manager.is_paused:
         manager.restart()
     elif not manager.is_playing:

--- a/src/jarabe/model/speech.py
+++ b/src/jarabe/model/speech.py
@@ -25,4 +25,6 @@ def get_speech_manager():
 
     if _speech_manager is None:
         _speech_manager = SpeechManager()
+        if not _speech_manager.enabled():
+            _speech_manager = None
     return _speech_manager


### PR DESCRIPTION
This patch disable speech trayicon, in case gst or espeak module
isn't installed