### PR TITLE
Select autocompleted activity search text

### DIFF
--- a/src/jarabe/desktop/homebox.py
+++ b/src/jarabe/desktop/homebox.py
@@ -99,10 +99,13 @@ class HomeBox(Gtk.VBox):
                 toolbar.search_entry._icon_selected = [activity]
                 break
 
-        if len(toolbar.search_entry._icon_selected) == 1:
+        # Don't change the selection if the entry has been autocompleted
+        if len(toolbar.search_entry._icon_selected) == 1 \
+           and not toolbar.search_entry.get_text() == activity['name']:
+            pos = toolbar.search_entry.get_position()
             toolbar.search_entry.set_text(
                 toolbar.search_entry._icon_selected[0]['name'])
-            toolbar.search_entry.set_position(-1)
+            toolbar.search_entry.select_region(pos, -1)
 
     def __toolbar_view_changed_cb(self, toolbar, view):
         self._set_view(view)


### PR DESCRIPTION
This means that slow typers who are not looking at the screen will
will overwrite the autocomplete, instead of adding to it.

Thanks to @quozl for reporting and suggesting the solution.