### PR TITLE
Avoid "Cannot unfreeze the DCON"

### DIFF
--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -74,9 +74,9 @@ _window_manager_started = False
 _starting_desktop = False
 
 
-def unfreeze_dcon_cb():
-    logging.debug('STARTUP: unfreeze_dcon_cb')
-    screen.set_dcon_freeze(0)
+def unfreeze_screen_cb():
+    logging.debug('STARTUP: unfreeze_screen_cb')
+    screen.unfreeze(0)
 
 
 def setup_frame_cb():
@@ -393,7 +393,7 @@ def main():
 
     # this must be added early, so that it executes and unfreezes the screen
     # even when we initially get blocked on the intro screen
-    GLib.idle_add(unfreeze_dcon_cb)
+    GLib.idle_add(unfreeze_screen_cb)
 
     GLib.idle_add(setup_cursortracker_cb)
     sound.restore()

--- a/src/jarabe/model/screen.py
+++ b/src/jarabe/model/screen.py
@@ -23,23 +23,26 @@ _HARDWARE_MANAGER_INTERFACE = 'org.freedesktop.ohm.Keystore'
 _HARDWARE_MANAGER_SERVICE = 'org.freedesktop.ohm'
 _HARDWARE_MANAGER_OBJECT_PATH = '/org/freedesktop/ohm/Keystore'
 
-_ohm_service = None
+POWERD_FLAG_DIR = '/etc/powerd/flags'
+
+
+def using_powerd():
+    return os.access(POWERD_FLAG_DIR, os.W_OK)
 
 
 def _get_ohm():
-    global _ohm_service
-    if _ohm_service is None:
-        bus = dbus.SystemBus()
-        proxy = bus.get_object(_HARDWARE_MANAGER_SERVICE,
-                               _HARDWARE_MANAGER_OBJECT_PATH,
-                               follow_name_owner_changes=True)
-        _ohm_service = dbus.Interface(proxy, _HARDWARE_MANAGER_INTERFACE)
-
-    return _ohm_service
+    bus = dbus.SystemBus()
+    proxy = bus.get_object(_HARDWARE_MANAGER_SERVICE,
+                           _HARDWARE_MANAGER_OBJECT_PATH,
+                           follow_name_owner_changes=True)
+    return dbus.Interface(proxy, _HARDWARE_MANAGER_INTERFACE)
 
 
-def set_dcon_freeze(frozen):
+def unfreeze():
+    if not using_powerd():
+        return
+
     try:
-        _get_ohm().SetKey('display.dcon_freeze', frozen)
+        _get_ohm().SetKey('display.dcon_freeze', 0)
     except dbus.DBusException:
-        logging.error('Cannot unfreeze the DCON')
+        pass


### PR DESCRIPTION
Sugar asks olpc-powerd to unfreeze the display once startup is
complete.  On platforms without olpc-powerd, this causes:

	ERROR dbus.proxies: Introspect error on
	org.freedesktop.ohm:/org/freedesktop/ohm/Keystore:
	dbus.exceptions.DBusException:
	org.freedesktop.DBus.Error.ServiceUnknown: The name
	org.freedesktop.ohm was not provided by any .service files
	ERROR root: Cannot unfreeze the DCON

Remove this logging, by detecting powerd before resolving the interface.

Remove the DCON concept from main.py, by changing method names, so that
the implementation details are hidden in model/screen.py