### PR TITLE
Fix broken background section

### DIFF
--- a/extensions/cpsection/background/view.py
+++ b/extensions/cpsection/background/view.py
@@ -122,7 +122,7 @@ class Background(SectionView):
                 pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(
                     file_path, style.XLARGE_ICON_SIZE,
                     style.XLARGE_ICON_SIZE)
-            except gi._glib._glib.GError:
+            except GObject.GError:
                 pass
             else:
                 self._store.append([pixbuf, file_path])


### PR DESCRIPTION
Fix GError namespace in backgrounds, by changing from
"gi._glib._glib.GError" to "GObject.GError", as is being
used in journaltoolbox.py.

Signed-off-by: Martin Abente Lahaye <tch@sugarlabs.org>