### PR TITLE
fix for #2974

### DIFF
--- a/src/jarabe/model/neighborhood.py
+++ b/src/jarabe/model/neighborhood.py
@@ -417,7 +417,7 @@ class _Account(GObject.GObject):
             error_handler=self.__set_current_activity_error_cb)
 
     def __set_current_activity_cb(self):
-        logging.warning('_Account.__set_current_activity_cb')
+        logging.debug('_Account.__set_current_activity_cb')
 
     def __set_current_activity_error_cb(self, error):
         logging.debug('_Account.__set_current_activity__error_cb %r', error)

--- a/src/jarabe/model/shell.py
+++ b/src/jarabe/model/shell.py
@@ -429,6 +429,8 @@ class ShellModel(GObject.GObject):
         self._maximum_open_activities = settings.get_int(
             'maximum-number-of-open-activities')
 
+        self._launch_timers = {}
+
     def get_launcher(self, activity_id):
         return self._launchers.get(str(activity_id))
 
@@ -732,10 +734,13 @@ class ShellModel(GObject.GObject):
 
         self.emit('launch-started', home_activity)
 
-        # FIXME: better learn about finishing processes by receiving a signal.
-        # Now just check whether an activity has a window after ~90sec
-        GObject.timeout_add_seconds(90, self._check_activity_launched,
+        if activity_id in self._launch_timers:
+            GObject.source_remove(self._launch_timers[activity_id])
+            del self._launch_timers[activity_id]
+
+        timer = GObject.timeout_add_seconds(90, self._check_activity_launched,
                                     activity_id)
+        self._launch_timers[activity_id] = timer
 
     def notify_launch_failed(self, activity_id):
         home_activity = self.get_activity_by_id(activity_id)
@@ -752,6 +757,7 @@ class ShellModel(GObject.GObject):
                           activity_id)
 
     def _check_activity_launched(self, activity_id):
+        del self._launch_timers[activity_id]
         home_activity = self.get_activity_by_id(activity_id)
 
         if not home_activity:


### PR DESCRIPTION
Fix for spurious "failed to start" message, solved while testing repeated Write-96 resume from journal on Fedora 18.

http://bugs.sugarlabs.org/ticket/2974