### PR TITLE
fix language control panel on XO es_UY keyboards

### DIFF
--- a/extensions/cpsection/language/model.py
+++ b/extensions/cpsection/language/model.py
@@ -119,6 +119,7 @@ def get_languages():
             langlist = lang.split(':')
         elif line.startswith('LANG='):
             lang = line[5:].replace('"', '')
+            lang = lang.strip()
             if lang.endswith('UTF-8'):
                 lang = lang.replace('UTF-8', 'utf8')
 


### PR DESCRIPTION
My Settings Language showed English USA on XO-4 laptops with LO tag set
to es_UY.UTF-8 and Spanish keyboards.  It should show Spanish Uruguay.

Workaround is to ignore what is shown and change it.

Cause was unhandled newline when reading $HOME/.i18n file.  As a result,
following code to convert UTF-8 to utf8 did not run, and so the language
setting could not be found in "locale -av" output.  The default language
setting was used.

Fix is to strip the whitespace from the end of the line.

Reported-by: Walter Bender <walter.bender@gmail.com>
Reported-by: Samuel Greenfeld <samuel@greenfeld.org>
Signed-off-by: James Cameron <quozl@laptop.org>