### PR TITLE
Social Help

### DIFF
--- a/data/org.sugarlabs.gschema.xml
+++ b/data/org.sugarlabs.gschema.xml
@@ -157,6 +157,11 @@
             <summary>Publish to Gadget</summary>
             <description>If TRUE, Sugar will make us searchable for the other users of the Jabber server.</description>
         </key>
+        <key name="social-help-server" type="s">
+            <default>'https://use-socialhelp.sugarlabs.org'</default>
+            <summary>Social Help Server</summary>
+            <description>URL of the social help server to use with protocol.</description>
+        </key>
     </schema>
     <schema id="org.sugarlabs.power" path="/org/sugarlabs/power/">
         <key name="automatic" type="b">

--- a/extensions/cpsection/network/model.py
+++ b/extensions/cpsection/network/model.py
@@ -26,7 +26,7 @@ from gi.repository import NMClient
 from jarabe.model import network
 
 
-KEYWORDS = ['network', 'jabber', 'radio', 'server']
+KEYWORDS = ['network', 'jabber', 'radio', 'server', 'social', 'help']
 
 
 class ReadError(Exception):
@@ -35,6 +35,29 @@ class ReadError(Exception):
 
     def __str__(self):
         return repr(self.value)
+
+
+def get_social_help():
+    settings = Gio.Settings('org.sugarlabs.collaboration')
+    return settings.get_string('social-help-server')
+
+
+def print_social_help():
+    print get_social()
+
+
+def set_social_help(server):
+    """
+    Set the social-help server
+
+    e.g. 'https://use-socialhelp.sugarlabs.org'
+    """
+    if server:
+        settings = Gio.Settings('org.sugarlabs.collaboration')
+        server.rstrip('/')
+        if '://' not in server:
+            server = 'http://' + server
+        settings.set_string('social-help-server', server)
 
 
 def get_jabber():

--- a/extensions/cpsection/network/view.py
+++ b/extensions/cpsection/network/view.py
@@ -39,9 +39,11 @@ class Network(SectionView):
 
         self._model = model
         self.restart_alerts = alerts
+        self._social_help_sid = 0
         self._jabber_sid = 0
         self._jabber_valid = True
         self._radio_valid = True
+        self._social_help_change_handler = None
         self._jabber_change_handler = None
         self._radio_change_handler = None
         self._wireless_configuration_reset_handler = None
@@ -175,6 +177,34 @@ class Network(SectionView):
             self._jabber_alert.props.msg = self.restart_msg
             self._jabber_alert.show()
 
+        social_help_info = Gtk.Label(
+            _("Social Help is a fourm that lets you connect with developers"
+              " and discuss Sugar Activities.  Changing servers means"
+              " discussions will happen in a different place with"
+              " different people."))
+        social_help_info.set_alignment(0, 0)
+        social_help_info.set_line_wrap(True)
+        box_mesh.pack_start(social_help_info, False, True, 0)
+        social_help_info.show()
+
+        social_help_box = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        social_help_label = Gtk.Label(label=_('Social Help Server:'))
+        social_help_label.set_alignment(1, 0.5)
+        social_help_label.modify_fg(Gtk.StateType.NORMAL,
+                                    style.COLOR_SELECTION_GREY.get_gdk_color())
+        social_help_box.pack_start(social_help_label, False, True, 0)
+        group.add_widget(social_help_label)
+        social_help_label.show()
+
+        self._social_help_entry = Gtk.Entry()
+        self._social_help_entry.set_alignment(0)
+        self._social_help_entry.set_size_request(
+            int(Gdk.Screen.width() / 3), -1)
+        social_help_box.pack_start(self._social_help_entry, False, True, 0)
+        self._social_help_entry.show()
+        box_mesh.pack_start(social_help_box, False, True, 0)
+        social_help_box.show()
+
         workspace.pack_start(box_mesh, False, True, 0)
         box_mesh.show()
 
@@ -182,9 +212,10 @@ class Network(SectionView):
 
     def setup(self):
         self._entry.set_text(self._model.get_jabber())
+        self._social_help_entry.set_text(self._model.get_social_help())
         try:
             radio_state = self._model.get_radio()
-        except self._model.ReadError, detail:
+        except self._model.ReadError as detail:
             self._radio_alert.props.msg = detail
             self._radio_alert.show()
         else:
@@ -197,6 +228,8 @@ class Network(SectionView):
             'toggled', self.__radio_toggled_cb)
         self._jabber_change_handler = self._entry.connect(
             'changed', self.__jabber_changed_cb)
+        self._social_help_change_handler = self._social_help_entry.connect(
+            'changed', self.__social_help_changed_cb)
         self._wireless_configuration_reset_handler =  \
             self._clear_wireless_button.connect(
                 'clicked', self.__wireless_configuration_reset_cb)
@@ -204,6 +237,7 @@ class Network(SectionView):
     def undo(self):
         self._button.disconnect(self._radio_change_handler)
         self._entry.disconnect(self._jabber_change_handler)
+        self._social_help_entry.disconnect(self._social_help_change_handler)
         self._model.undo()
         self._jabber_alert.hide()
         self._radio_alert.hide()
@@ -218,7 +252,7 @@ class Network(SectionView):
         radio_state = widget.get_active()
         try:
             self._model.set_radio(radio_state)
-        except self._model.ReadError, detail:
+        except self._model.ReadError as detail:
             self._radio_alert.props.msg = detail
             self._radio_valid = False
         else:
@@ -242,7 +276,7 @@ class Network(SectionView):
             return
         try:
             self._model.set_jabber(widget.get_text())
-        except self._model.ReadError, detail:
+        except self._model.ReadError as detail:
             self._jabber_alert.props.msg = detail
             self._jabber_valid = False
             self._jabber_alert.show()
@@ -252,6 +286,19 @@ class Network(SectionView):
             self._jabber_alert.hide()
 
         self._validate()
+        return False
+
+    def __social_help_changed_cb(self, widget, data=None):
+        if self._social_help_sid:
+            GObject.source_remove(self._social_help_sid)
+        self._social_help_sid = GObject.timeout_add(
+            _APPLY_TIMEOUT, self.__social_help_timeout_cb, widget)
+
+    def __social_help_timeout_cb(self, widget):
+        self._social_help_sid = 0
+        if widget.get_text() == self._model.get_social_help():
+            return
+        self._model.set_social_help(widget.get_text())
         return False
 
     def __wireless_configuration_reset_cb(self, widget):

--- a/extensions/globalkey/Makefile.am
+++ b/extensions/globalkey/Makefile.am
@@ -5,4 +5,5 @@ sugar_PYTHON = 		\
 	screenshot.py	\
 	speech.py	\
 	viewsource.py	\
-	viewhelp.py
+	viewhelp.py	\
+	viewsocialhelp.py

--- a/extensions/globalkey/viewsocialhelp.py
+++ b/extensions/globalkey/viewsocialhelp.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2015 Sam Parkinson
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+from jarabe.view.viewsocialhelp import setup_view_social_help
+from jarabe.model import shell
+
+BOUND_KEYS = ['<alt><shift>c']
+
+
+def handle_key_press(key):
+    shell_model = shell.get_model()
+    activity = shell_model.get_active_activity()
+
+    setup_view_social_help(activity)

--- a/src/jarabe/view/Makefile.am
+++ b/src/jarabe/view/Makefile.am
@@ -14,4 +14,5 @@ sugar_PYTHON =				\
 	service.py			\
 	tabbinghandler.py		\
 	viewsource.py			\
+	viewsocialhelp.py		\
 	viewhelp.py

--- a/src/jarabe/view/palettes.py
+++ b/src/jarabe/view/palettes.py
@@ -120,7 +120,7 @@ class CurrentActivityPalette(BasePalette):
         menu_item = PaletteMenuItem(_('View Social Help'),
                                     'toolbar-social-help')
         menu_item.connect('activate', self.__view_social_help__cb)
-        menu_item.set_accelerator('Shift+Alt+S')
+        menu_item.set_accelerator('Shift+Alt+C')
         self.menu_box.append_item(menu_item)
         menu_item.show()
 

--- a/src/jarabe/view/palettes.py
+++ b/src/jarabe/view/palettes.py
@@ -38,6 +38,7 @@ from jarabe.model import shell
 from jarabe.view.viewsource import setup_view_source
 from jarabe.view.viewhelp import setup_view_help
 from jarabe.view.viewhelp import get_help_url_and_title
+from jarabe.view.viewsocialhelp import setup_view_social_help
 from jarabe.journal import misc
 
 
@@ -116,6 +117,13 @@ class CurrentActivityPalette(BasePalette):
             self.menu_box.append_item(menu_item)
             menu_item.show()
 
+        menu_item = PaletteMenuItem(_('View Social Help'),
+                                    'toolbar-social-help')
+        menu_item.connect('activate', self.__view_social_help__cb)
+        menu_item.set_accelerator('Shift+Alt+S')
+        self.menu_box.append_item(menu_item)
+        menu_item.show()
+
         # avoid circular importing reference
         from jarabe.frame.notification import NotificationBox
 
@@ -153,6 +161,10 @@ class CurrentActivityPalette(BasePalette):
 
     def __view_help__cb(self, menu_item):
         setup_view_help(self._home_activity)
+        self.emit('done')
+
+    def __view_social_help__cb(self, menu_item):
+        setup_view_social_help(self._home_activity)
         self.emit('done')
 
     def __stop_activate_cb(self, menu_item):

--- a/src/jarabe/view/viewsocialhelp.py
+++ b/src/jarabe/view/viewsocialhelp.py
@@ -1,0 +1,128 @@
+# Copyright (C) 2015 Sam Parkinson
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+from gettext import gettext as _
+import logging
+import os
+import json
+
+from gi.repository import Gtk
+from gi.repository import GObject
+from gi.repository import Gdk
+from gi.repository import WebKit2
+from gi.repository import Gio
+from gi.repository import GdkX11
+
+from sugar3 import env
+from sugar3.graphics import style
+from sugar3.graphics.icon import get_icon_file_name
+from sugar3.graphics.toolbutton import ToolButton
+from sugar3.bundle.activitybundle import get_bundle_instance
+from jarabe.model import shell
+
+
+_logger = logging.getLogger('ViewSocialHelp')
+
+
+def setup_view_social_help(activity):
+    if shell.get_model().has_modal():
+        return
+    # check whether the execution was from an activity
+    bundle_path = activity.get_bundle_path()
+    if bundle_path is None:
+        return
+    else:
+        # get activity name and window id
+        window_xid = activity.get_xid()
+
+    activity_bundle = get_bundle_instance(bundle_path)
+    bundle_id = activity_bundle.get_bundle_id()
+
+    viewsocialhelp = ViewSocialHelp(bundle_id, window_xid)
+    activity.push_shell_window(viewsocialhelp)
+    viewsocialhelp.connect('hide', activity.pop_shell_window)
+    viewsocialhelp.show()
+
+
+class ViewSocialHelp(Gtk.Window):
+    parent_window_xid = None
+
+    def __init__(self, bundle_id, window_xid):
+        self.parent_window_xid = window_xid
+
+        Gtk.Window.__init__(self)
+        overlay = Gtk.Overlay()
+        self.add(overlay)
+        overlay.show()
+
+        self.set_decorated(False)
+        self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
+        self.set_border_width(style.LINE_WIDTH)
+        self.set_has_resize_grip(False)
+
+        tb = Gtk.Toolbar()
+        tb.props.valign = Gtk.Align.START
+        tb.props.halign = Gtk.Align.END
+        overlay.add_overlay(tb)
+        tb.show()
+
+        stop = ToolButton(icon_name='dialog-cancel')
+        stop.set_tooltip(_('Close'))
+        stop.connect('clicked', self.__stop_clicked_cb)
+        tb.insert(stop, -1)
+        stop.show()
+
+        width = Gdk.Screen.width() - style.GRID_CELL_SIZE * 2
+        height = Gdk.Screen.height() - style.GRID_CELL_SIZE * 2
+        self.set_size_request(width, height)
+
+        self.connect('realize', self.__realize_cb)
+
+        webview = WebKit2.WebView()
+        webview.connect('load-changed', self.__load_status_changed_cb)
+
+        context = WebKit2.WebContext.get_default()
+        cookies = context.get_cookie_manager()
+        cookies.set_persistent_storage(
+            os.path.join(env.get_profile_path(), 'social-help.cookies'),
+            WebKit2.CookiePersistentStorage.SQLITE)
+
+        overlay.add(webview)
+
+        webview.show()
+        webview.load_uri('https://use-socialhelp.sugarlabs.org/goto/'
+                         + bundle_id)
+
+    def __load_status_changed_cb(self, web_view, load_event):
+        if load_event == WebKit2.LoadEvent.FINISHED:
+            web_view.run_javascript('document.body.classList.add("sugar");',
+                                    None, None, None)
+
+    def __stop_clicked_cb(self, widget):
+        self.destroy()
+        shell.get_model().pop_modal()
+
+    def __realize_cb(self, widget):
+        self.set_type_hint(Gdk.WindowTypeHint.DIALOG)
+        window = self.get_window()
+        window.set_accept_focus(True)
+
+        display = Gdk.Display.get_default()
+        parent = GdkX11.X11Window.foreign_new_for_display(
+            display, self.parent_window_xid)
+        window.set_transient_for(parent)
+
+        shell.get_model().push_modal()

--- a/src/jarabe/view/viewsocialhelp.py
+++ b/src/jarabe/view/viewsocialhelp.py
@@ -101,10 +101,11 @@ class ViewSocialHelp(Gtk.Window):
             WebKit2.CookiePersistentStorage.SQLITE)
 
         overlay.add(webview)
-
         webview.show()
-        webview.load_uri('https://use-socialhelp.sugarlabs.org/goto/'
-                         + bundle_id)
+
+        settings = Gio.Settings('org.sugarlabs.collaboration')
+        server = settings.get_string('social-help-server')
+        webview.load_uri('{}/goto/{}'.format(server, bundle_id))
 
     def __load_status_changed_cb(self, web_view, load_event):
         if load_event == WebKit2.LoadEvent.FINISHED:


### PR DESCRIPTION
WebKit2 is the new version of GtkWebKit that has all the cool new stuff.  It
has a slightly different api, but it is basically the same.

Migrating to WebKit2 is needed because there can only be 1 version of WebKit
per process, meaning if the help view uses the old version everything else
is forced to as well.