### PR TITLE
Search for alternative copies after deleting a bundle, fixes #4836

### DIFF
--- a/src/jarabe/model/bundleregistry.py
+++ b/src/jarabe/model/bundleregistry.py
@@ -548,6 +548,39 @@ class BundleRegistry(GObject.GObject):
         bundle.uninstall(force, delete_profile)
         self.remove_bundle(install_path)
 
+        alt_bundles = self.get_system_bundles(act.get_bundle_id())
+        if alt_bundles:
+            alt_bundles.sort(
+                key=lambda b: NormalizedVersion(b.get_activity_version()))
+            alt_bundles.reverse()
+            new_bundle = alt_bundles[0]
+            self.add_bundle(new_bundle.get_path())
+
+    def get_system_bundles(self, bundle_id):
+        """
+        Searches for system bundles (eg. those in /usr/share/sugar/activities)
+        with a given bundle id.
+
+        Prams:
+            * bundle_id (string):  the bundle id to look for
+
+        Returns a list of ActivityBundle or ContentBundle objects, or an empty
+        list if there are none found.
+        """
+        bundles = []
+        for root in GLib.get_system_data_dirs():
+            root = os.path.join(root, 'sugar', 'activities')
+
+            for activity_dir in os.listdir(root):
+                try:
+                    bundle = bundle_from_dir(os.path.join(root, activity_dir))
+                except MalformedBundleException:
+                    continue
+
+                if bundle.get_bundle_id() == bundle_id:
+                    bundles.append(bundle)
+        return bundles
+
 
 class _InstallQueue(object):
     """


### PR DESCRIPTION
Replaces #487 

If the user removes a $HOME activity, sugar should fall back to
displaying a `/usr/share` copy of the same activity.  This patch
searches through the system paths after removing an activity in
order to add it back if needed.

Steps to reproduce can be found in the ticket.

Ticket URL:  <http://bugs.sugarlabs.org/ticket/4836>