### PR TITLE
Add accelerators for control panel open and close

### DIFF
--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -207,6 +207,16 @@ class ControlPanel(Gtk.Window):
         self.grab_focus()
 
     def __key_press_event_cb(self, window, event):
+        if (event.keyval == Gdk.KEY_Escape) or \
+           ((event.keyval == Gdk.KEY_q or event.keyval == Gdk.KEY_Q) and \
+           (event.state & Gdk.ModifierType.CONTROL_MASK)):
+            if self._toolbar == self._main_toolbar:
+                self.__stop_clicked_cb(None)
+                self.destroy()
+            else:
+                self.__cancel_clicked_cb(None)
+            return True
+
         # if the user clicked out of the window - fix SL #3188
         if not self.is_active():
             self.present()

--- a/src/jarabe/view/keyhandler.py
+++ b/src/jarabe/view/keyhandler.py
@@ -30,6 +30,7 @@ from jarabe.view.tabbinghandler import TabbingHandler
 from jarabe.model.shell import ShellModel
 from jarabe import config
 from jarabe.journal import journalactivity
+from jarabe.controlpanel.gui import ControlPanel
 
 
 _VOLUME_STEP = sound.VOLUME_STEP
@@ -58,6 +59,7 @@ _actions_table = {
     'XF86WebCam': 'open_search',
     '<alt><shift>f': 'frame',
     'XF86Search': 'open_search',
+    '<alt><shift>m': 'open_controlpanel',
     '<alt><shift>o': 'open_search',
     '<alt><shift>q': 'logout',
     '<alt><shift>d': 'dump_ui_tree'
@@ -163,6 +165,10 @@ class KeyHandler(object):
 
     def handle_open_search(self, event_time):
         journalactivity.get_journal().show_journal()
+
+    def handle_open_controlpanel(self, event_time):
+        panel = ControlPanel()
+        panel.show()
 
     def handle_dump_ui_tree(self, event_time):
         print uitree.get_root().dump()


### PR DESCRIPTION
There is no accelerator for opening or closing control panel.  This hinders use, requiring mouse or touchscreen.  See #4660.

View Source has *Alt+Shift+V* for open, and *Escape* for close.  Activities have *Ctrl+q* for close.  Wireless Key Required dialog has *Escape* for close.

Patch adds accelerators:

1. *Alt+Shift+M* to open control panel, valid in any Sugar screen or activity, and;
1. *Escape*, *Ctrl+q* or *Ctrl+Shift+q* to close control panel or sections.

Close accelerator is added in the key event callback, rather than using ToolButton accelerators, because they do not work in the control panel.

Test case: use *Alt+Shift+M* to open control panel, verify *q* alone, and *Shift+Q* do insert into search box, select a section, verify *Ctrl+q*, *Ctrl+Shift+Q* and *Escape* closes section, and closes control panel.

References:
* [HotKeys](http://wiki.sugarlabs.org/go/Hotkeys) page on Wiki,
* [Ticket #4660](http://bugs.sugarlabs.org/ticket/4660) (keyboard navigation of Sugar), and;
* [Pull Request #443](https://github.com/sugarlabs/sugar/pull/443) (keyboard navigation of control panel).