### PR TITLE
Add accelerator for control panel close

### DIFF
--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -207,6 +207,14 @@ class ControlPanel(Gtk.Window):
         self.grab_focus()
 
     def __key_press_event_cb(self, window, event):
+        if event.keyval == Gdk.KEY_Escape:
+            if self._toolbar == self._main_toolbar:
+                self.__stop_clicked_cb(None)
+                self.destroy()
+            else:
+                self.__cancel_clicked_cb(None)
+            return True
+
         # if the user clicked out of the window - fix SL #3188
         if not self.is_active():
             self.present()


### PR DESCRIPTION
There is no accelerator for closing control panel.  This hinders use, requiring mouse or touchscreen.  See #4660.

View Source has Escape for close.  Wireless Key Required dialog has Escape for close.

Patch adds an accelerator Escape, to close control panel or sections.

Accelerator is added in the key event callback, rather than using ToolButton accelerators, because they do not work in the control panel.

Test case: open control panel, select a section, verify "Escape" closes section, and closes control panel.

References:

http://wiki.sugarlabs.org/go/Hotkeys
http://bugs.sugarlabs.org/ticket/4660