### PR TITLE
Add BundleLauncher

### DIFF
--- a/src/jarabe/journal/Makefile.am
+++ b/src/jarabe/journal/Makefile.am
@@ -1,6 +1,7 @@
 sugardir = $(pythondir)/jarabe/journal
 sugar_PYTHON =				\
 	__init__.py			\
+	bundlelauncher.py		\
 	detailview.py			\
 	expandedentry.py		\
 	iconview.py			\

--- a/src/jarabe/journal/bundlelauncher.py
+++ b/src/jarabe/journal/bundlelauncher.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2014, Sugarlabs (Manuel Quinones)
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+import logging
+
+from sugar3.activity import activityfactory
+from sugar3.activity.activityhandle import ActivityHandle
+from sugar3.datastore import datastore
+from jarabe.model import bundleregistry
+
+def get_bundle(bundle_id=None, object_id=None):
+    if bundle_id is None:
+        obj = datastore.get(object_id)
+        mime_type = str(obj.metadata['mime_type'])
+
+        activities = bundleregistry.get_registry() \
+            .get_activities_for_type(mime_type, with_parents=True)
+
+        if not activities:
+            logging.warning('No activity can start object with type, %s.',
+                            mime_type)
+            return None
+
+        return activities[0]
+    else:
+        bundle = bundleregistry.get_registry().get_bundle(bundle_id)
+        if bundle is None:
+            logging.warning('Activity with the bundle_id %s was not found',
+                            mime_type)
+            return None
+        return bundle
+
+
+def launch_bundle(bundle_id=None, object_id=None):
+    '''
+    Launch a bundle with the given parameters.
+
+    If an object_id is given, the bundle will be launched with the
+    object that has that id.  Otherwise, the bundle with the given
+    bundle_id will be launched.
+
+    Note: this function should not be used out side of the sugar
+    shell process.  The `JournalActivityDBusService` makes this
+    avaliable over DBus.
+    '''
+    if bundle_id is None and object_id is None:
+        logging.error('At least one parameter has to be passed')
+        return False
+
+    bundle = get_bundle(bundle_id, object_id)
+    if bundle is None:
+        return False
+
+    activity_handle = ActivityHandle(activity_id=None,
+                                     object_id=object_id,
+                                     uri=None,
+                                     invited=False)
+    activityfactory.create(bundle, activity_handle)
+    return True
+

--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -44,6 +44,7 @@ from jarabe.journal.objectchooser import ObjectChooser
 from jarabe.journal.modalalert import ModalAlert
 from jarabe.journal import model
 from jarabe.journal.journalwindow import JournalWindow
+from jarabe.journal.bundlelauncher import launch_bundle
 
 from jarabe.model import session
 
@@ -68,6 +69,24 @@ class JournalActivityDBusService(dbus.service.Object):
                                         allow_replacement=False)
         logging.debug('bus_name: %r', bus_name)
         dbus.service.Object.__init__(self, bus_name, J_DBUS_PATH)
+
+    @dbus.service.method(J_DBUS_INTERFACE, in_signature='ss',
+                         out_signature='b')
+    def LaunchBundle(self, bundle_id, object_id):
+        '''
+        Launch an activity with a given object_id and/or bundle_id.
+
+        See `jarabe.journal.bundlelauncher.launch_bundle` for
+        further documentation
+        '''
+        # Convert dbus empty strings to None, is the only way to pass
+        # optional parameters with dbus.
+        if bundle_id == "":
+            bundle_id = None
+        if object_id == "":
+            object_id = None
+
+        return launch_bundle(bundle_id, object_id)
 
     @dbus.service.method(J_DBUS_INTERFACE,
                          in_signature='s', out_signature='')

--- a/src/jarabe/model/bundleregistry.py
+++ b/src/jarabe/model/bundleregistry.py
@@ -31,6 +31,7 @@ from sugar3.bundle.bundleversion import NormalizedVersion
 from sugar3.bundle.bundle import MalformedBundleException, \
     AlreadyInstalledException, RegistrationException
 from sugar3 import env
+from sugar3.mime import get_mime_parents
 
 from jarabe.model import desktop
 from jarabe.model import mimeregistry
@@ -330,7 +331,7 @@ class BundleRegistry(GObject.GObject):
             self.emit('bundle-removed', removed)
         return removed is not None
 
-    def get_activities_for_type(self, mime_type):
+    def get_activities_for_type(self, mime_type, with_parents=False):
         result = []
 
         mime = mimeregistry.get_registry()
@@ -351,6 +352,12 @@ class BundleRegistry(GObject.GObject):
 
         if default_bundle is not None:
             result.insert(0, default_bundle)
+
+        if with_parents:
+            for parent_mime in get_mime_parents(mime_type):
+                for activity in registry.get_activities_for_type(parent_mime):
+                    if activity not in result:
+                        result.append(activity)
 
         return result
 


### PR DESCRIPTION
Replaces #501 

Requires https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/211

Changes:

* Alphabetize makefile
* Remove unneeded bundlelauncher code

The BundleLauncher is a dbus service served from within the sugar
shell process.  The BundleLauncher service lets activities launch
other activities, with a given bundle_id, mime_type or object_id.