### PR TITLE
Age picker: check if is in a valid state - Fixes #4850

### DIFF
--- a/src/jarabe/intro/window.py
+++ b/src/jarabe/intro/window.py
@@ -382,9 +382,9 @@ class _IntroBox(Gtk.VBox):
         self.next()
 
     def next(self):
-        if self._page == self.PAGE_LAST:
-            self.done()
         if self._current_page.props.valid:
+            if self._page == self.PAGE_LAST:
+                self.done()
             self._page += 1
             self._setup_page()
 


### PR DESCRIPTION
When the user press Return, we need check if the page is in a valid state
before checking if is the last page.