### PR TITLE
Avoid "Cannot unfreeze the DCON"

### DIFF
--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -74,9 +74,9 @@ _window_manager_started = False
 _starting_desktop = False
 
 
-def unfreeze_dcon_cb():
-    logging.debug('STARTUP: unfreeze_dcon_cb')
-    screen.set_dcon_freeze(0)
+def unfreeze_screen_cb():
+    logging.debug('STARTUP: unfreeze_screen_cb')
+    screen.unfreeze()
 
 
 def setup_frame_cb():
@@ -393,7 +393,7 @@ def main():
 
     # this must be added early, so that it executes and unfreezes the screen
     # even when we initially get blocked on the intro screen
-    GLib.idle_add(unfreeze_dcon_cb)
+    GLib.idle_add(unfreeze_screen_cb)
 
     GLib.idle_add(setup_cursortracker_cb)
     sound.restore()


### PR DESCRIPTION
Rework of previous https://github.com/sugarlabs/sugar/pull/478

Sugar asks olpc-powerd to unfreeze the display once startup is complete.  On platforms without olpc-powerd, this causes:
```
ERROR dbus.proxies: Introspect error on org.freedesktop.ohm:/org/freedesktop/ohm/Keystore:
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.ServiceUnknown: The name
org.freedesktop.ohm was not provided by any .service files
ERROR root: Cannot unfreeze the DCON
```
Remove this logging, by detecting powerd before resolving the interface.

Remove the DCON concept from main.py, by changing method names, so that the implementation details are hidden in model/screen.py

Tested on XO-1 with Fedora 18.

Tested on commodity hardware with Ubuntu 14.04.2 LTS (Trusty).