### PR TITLE
Brightness controls try9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ data/sugar.gtkrc
 data/sugar.xml
 data/sugar-xo.gtkrc
 data/sugar-emulator.desktop
+data/org.sugar.brightness.policy

--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -1,4 +1,6 @@
 python_scripts =		\
+	sugar-backlight-helper	\
+	sugar-backlight-setup	\
 	sugar-control-panel	\
 	sugar-install-bundle	\
 	sugar-launch

--- a/bin/sugar-backlight-helper
+++ b/bin/sugar-backlight-helper
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+device=/var/run/sugar-backlight
+
+case "$1" in
+    "--set-brightness")
+        echo "$2" > $device/brightness
+        ;;
+    "--get-brightness")
+        read value < $device/brightness
+        echo "$value"
+        ;;
+    "--get-max-brightness")
+        read value < $device/max_brightness
+        echo "$value"
+        ;;
+esac

--- a/bin/sugar-backlight-setup
+++ b/bin/sugar-backlight-setup
@@ -1,0 +1,68 @@
+#!/usr/bin/env python2
+
+# Copyright (C) 2015 Martin Abente Lahaye <tch@sugarlabs.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+import os
+import sys
+from functools import cmp_to_key
+
+from gi.repository import GUdev
+
+
+class SugarBacklightSetup:
+
+    SUGAR_LINK = '/var/run/sugar-backlight'
+
+    def __init__(self):
+        self._path = None
+        self._get_best_backlight()
+        self._create_link()
+
+    def _get_best_backlight(self):
+        client = GUdev.Client()
+        devices = client.query_by_subsystem('backlight')
+
+        if not devices:
+            raise LookupError('No backlight devices present')
+
+        devices.sort(key=cmp_to_key(SugarBacklightSetup._sort_criteria))
+        self._path = devices[0].get_sysfs_path()
+
+    @staticmethod
+    def _sort_criteria(ldevice, rdevice):
+        if ldevice.get_sysfs_attr('type') == 'firmware':
+            return 1
+        if ldevice.get_sysfs_attr('type') == 'platform' and \
+           rdevice.get_sysfs_attr('type') == 'raw':
+            return 1
+        return -1
+
+    def _create_link(self):
+        if os.path.exists(self.SUGAR_LINK):
+            os.unlink(self.SUGAR_LINK)
+        os.symlink(self._path, self.SUGAR_LINK)
+
+
+def _main():
+    try:
+        SugarBacklightSetup()
+    except Exception as err:
+        print 'Could not create device link: %s' % str(err)
+        sys.exit(1)
+
+if __name__ == '__main__':
+    _main()

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -66,5 +66,12 @@ gsettings_SCHEMAS = org.sugarlabs.gschema.xml
 convertdir = $(datarootdir)/GConf/gsettings
 convert_DATA = sugar-schemas.convert
 
-EXTRA_DIST = $(sugar_DATA) $(xsessions_DATA) $(nmservice_DATA) $(mime_xml_in_files) em.py gtkrc.em $(schema_in_files) $(icon_DATA) $(gsettings_SCHEMAS) $(convert_DATA)
-CLEANFILES = $(GTKRC_FILES) $(mime_xml_files) $(schema_DATA)
+org.sugar.brightness.policy: org.sugar.brightness.policy.in
+	sed -e "s|\@bindir\@|$(bindir)|g" $< > $@
+
+polkit_policydir = $(datadir)/polkit-1/actions
+polkit_in_files = org.sugar.brightness.policy.in
+polkit_policy_DATA = $(polkit_in_files:.policy.in=.policy)
+
+EXTRA_DIST = $(sugar_DATA) $(xsessions_DATA) $(nmservice_DATA) $(mime_xml_in_files) em.py gtkrc.em $(schema_in_files) $(icon_DATA) $(gsettings_SCHEMAS) $(convert_DATA) $(polkit_in_files)
+CLEANFILES = $(GTKRC_FILES) $(mime_xml_files) $(schema_DATA) $(polkit_policy_DATA)

--- a/data/org.sugar.brightness.policy.in
+++ b/data/org.sugar.brightness.policy.in
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+
+  <vendor>Sugar</vendor>
+  <vendor_url>https://www.sugarlabs.org</vendor_url>
+  <icon_name>battery</icon_name>
+
+  <action id="org.sugar.backlight-helper">
+    <_description>Adjust brightness</_description>
+    <_message>Adjusting the brightness of the screen requires authentication</_message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">@bindir@/sugar-backlight-helper</annotate>
+  </action>
+
+  <action id="org.sugar.backlight-setup">
+    <_description>Setup backlight device</_description>
+    <_message>Setup the backlight device symlink requires authentication</_message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">@bindir@/sugar-backlight-setup</annotate>
+  </action>
+
+</policyconfig>

--- a/data/org.sugarlabs.gschema.xml
+++ b/data/org.sugarlabs.gschema.xml
@@ -120,6 +120,13 @@
             <description>Setting for muting the sound device.</description>
         </key>
     </schema>
+    <schema id="org.sugarlabs.screen" path="/org/sugarlabs/screen/">
+        <key name="brightness" type="i">
+            <default>-1</default>
+            <summary>Brightness Level</summary>
+            <description>Brightness level for the computer screen.</description>
+        </key>
+    </schema>
     <schema id="org.sugarlabs.date" path="/org/sugarlabs/date/">
         <key name="timezone" type="s">
             <default>''</default>

--- a/extensions/deviceicon/Makefile.am
+++ b/extensions/deviceicon/Makefile.am
@@ -4,6 +4,7 @@ sugar_PYTHON = 		\
 	__init__.py	\
 	audio.py	\
 	battery.py	\
+	display.py	\
 	frame.py	\
 	network.py	\
 	speech.py	\

--- a/extensions/deviceicon/display.py
+++ b/extensions/deviceicon/display.py
@@ -186,13 +186,6 @@ class DisplayPalette(Palette):
     def __init__(self):
         Palette.__init__(self, label=_('My Display'))
 
-        self._brightness_manager = BrightnessManagerWidget(_('Brightness'),
-                                                           'brightness-100')
-        self._brightness_manager.show()
-
-        separator = PaletteMenuItemSeparator()
-        separator.show()
-
         self._screenshot = PaletteMenuItem(_('Take a screenshot'))
         icon = Icon(icon_name='camera-external',
                     pixel_size=style.SMALL_ICON_SIZE)
@@ -202,16 +195,32 @@ class DisplayPalette(Palette):
         self._screenshot.show()
 
         self._box = PaletteMenuBox()
-        self._box.append_item(self._brightness_manager, 0, 0)
-        self._box.append_item(separator, 0, 0)
+
+        self._brightness_manager = None
+        # only add this widget if device available
+        if brightness.get_instance().get_path():
+            self._add_brightness_manager()
+
         self._box.append_item(self._screenshot, 0, 0)
         self._box.show()
 
         self.set_content(self._box)
         self.connect('popup', self.__popup_cb)
 
+    def _add_brightness_manager(self):
+        self._brightness_manager = BrightnessManagerWidget(_('Brightness'),
+                                                           'brightness-100')
+        self._brightness_manager.show()
+
+        separator = PaletteMenuItemSeparator()
+        separator.show()
+
+        self._box.append_item(self._brightness_manager, 0, 0)
+        self._box.append_item(separator, 0, 0)
+
     def __popup_cb(self, palette):
-        self._brightness_manager.update()
+        if self._brightness_manager is not None:
+            self._brightness_manager.update()
 
     def __screenshot_cb(self, palette):
         frame_ = frame.get_view()
@@ -227,5 +236,4 @@ class DisplayPalette(Palette):
 
 
 def setup(tray):
-    if brightness.get_instance().get_path():
-        tray.add_device(DeviceView(_('Display')))
+    tray.add_device(DeviceView(_('Display')))

--- a/extensions/deviceicon/display.py
+++ b/extensions/deviceicon/display.py
@@ -18,6 +18,7 @@
 from gettext import gettext as _
 import math
 
+from gi.repository import GLib
 from gi.repository import Gtk
 from gi.repository import GObject
 
@@ -81,6 +82,8 @@ class DeviceView(TrayIcon):
 
 class BrightnessManagerWidget(Gtk.VBox):
 
+    TIMEOUT_DELAY = 100
+
     def __init__(self, text, icon_name):
         Gtk.VBox.__init__(self)
         self._progress_bar = None
@@ -125,6 +128,7 @@ class BrightnessManagerWidget(Gtk.VBox):
                 page_size=self._model.get_step_amount())
             self._adjustment = adjustment
 
+            self._adjustment_timeout_id = None
             self._adjustment_hid = \
                 self._adjustment.connect('value_changed', self.__adjusted_cb)
 
@@ -157,8 +161,16 @@ class BrightnessManagerWidget(Gtk.VBox):
                 / self._model.get_max_brightness()
 
     def __adjusted_cb(self, device, data=None):
+        if self._adjustment_timeout_id is not None:
+            GLib.source_remove(self._adjustment_timeout_id)
+        self._adjustment_timeout_id = GLib.timeout_add(
+            self.TIMEOUT_DELAY,  self._adjust_brightness)
+
+    def _adjust_brightness(self):
         value = self._adjustment.props.value
         self._model.set_brightness(int(value))
+        self._adjustment_timeout_id = None
+        return False
 
 
 class DisplayPalette(Palette):

--- a/extensions/deviceicon/display.py
+++ b/extensions/deviceicon/display.py
@@ -37,8 +37,6 @@ from jarabe.model import brightness
 from jarabe.model.screenshot import take_screenshot
 from jarabe import frame
 
-_ICON_NAME = 'brightness'
-
 
 class DeviceView(TrayIcon):
 
@@ -48,15 +46,17 @@ class DeviceView(TrayIcon):
         self._color = profile.get_color()
         self._label = label
 
-        TrayIcon.__init__(self, icon_name=_ICON_NAME, xo_color=self._color)
+        TrayIcon.__init__(self, icon_name='brightness-100',
+                          xo_color=self._color)
 
         self.set_palette_invoker(FrameWidgetInvoker(self))
         self.palette_invoker.props.toggle_palette = True
 
-        self._model = brightness.get_instance()
-        self._model.changed_signal.connect(self.__brightness_changed_cb)
-
-        self._update_output_info()
+        model = brightness.get_instance()
+        if model.get_path():
+            self._model = model
+            self._model.changed_signal.connect(self.__brightness_changed_cb)
+            self._update_output_info()
 
     def create_palette(self):
         palette = DisplayPalette()

--- a/extensions/deviceicon/display.py
+++ b/extensions/deviceicon/display.py
@@ -1,0 +1,211 @@
+# Copyright (C) 2014 Sam Parkinson
+# Copyright (C) 2015 Martin Abente Lahaye
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+from gettext import gettext as _
+import math
+
+from gi.repository import Gtk
+from gi.repository import GObject
+
+from sugar3 import profile
+from sugar3.graphics import style
+from sugar3.graphics.icon import Icon
+from sugar3.graphics.tray import TrayIcon
+from sugar3.graphics.palette import Palette
+from sugar3.graphics.palettemenu import PaletteMenuBox
+from sugar3.graphics.palettemenu import PaletteMenuItem
+from sugar3.graphics.palettemenu import PaletteMenuItemSeparator
+from sugar3.graphics.xocolor import XoColor
+
+from jarabe.frame.frameinvoker import FrameWidgetInvoker
+from jarabe.model import brightness
+from jarabe.model.screenshot import take_screenshot
+from jarabe import frame
+
+_ICON_NAME = 'brightness'
+
+
+class DeviceView(TrayIcon):
+
+    FRAME_POSITION_RELATIVE = 160
+
+    def __init__(self, label):
+        self._color = profile.get_color()
+        self._label = label
+
+        TrayIcon.__init__(self, icon_name=_ICON_NAME, xo_color=self._color)
+
+        self.set_palette_invoker(FrameWidgetInvoker(self))
+        self.palette_invoker.props.toggle_palette = True
+
+        self._model = brightness.get_instance()
+        self._model.changed_signal.connect(self.__brightness_changed_cb)
+
+        self._update_output_info()
+
+    def create_palette(self):
+        palette = DisplayPalette()
+        palette.set_group_id('frame')
+        return palette
+
+    def _update_output_info(self, value=None):
+        if value is None:
+            value = self._model.get_brightness()
+
+        icon_number = math.ceil(
+            float(value) * 3 / self._model.get_max_brightness()) * 33
+
+        if icon_number == 99:
+            icon_number = 100
+
+        self.icon.props.icon_name = \
+            'brightness-{:03d}'.format(int(icon_number))
+
+    def __brightness_changed_cb(self, model, value):
+        self._update_output_info(value)
+
+
+class BrightnessManagerWidget(Gtk.VBox):
+
+    def __init__(self, text, icon_name):
+        Gtk.VBox.__init__(self)
+        self._progress_bar = None
+        self._adjustment = None
+
+        icon = Icon(icon_size=Gtk.IconSize.MENU)
+        icon.props.icon_name = icon_name
+        icon.props.xo_color = XoColor('%s,%s' % (style.COLOR_WHITE.get_svg(),
+                                      style.COLOR_BUTTON_GREY.get_svg()))
+        icon.show()
+
+        label = Gtk.Label(text)
+        label.show()
+
+        grid = Gtk.Grid()
+        grid.set_column_spacing(style.DEFAULT_SPACING)
+        grid.attach(icon, 0, 0, 1, 1)
+        grid.attach(label, 1, 0, 1, 1)
+        grid.show()
+
+        alignment = Gtk.Alignment()
+        alignment.set(0.5, 0, 0, 0)
+        alignment.add(grid)
+        alignment.show()
+        self.add(alignment)
+
+        alignment = Gtk.Alignment()
+        alignment.set(0.5, 0, 0, 0)
+        alignment.set_padding(0, 0, style.DEFAULT_SPACING,
+                              style.DEFAULT_SPACING)
+
+        self._model = brightness.get_instance()
+
+        # if sugar-backlight-helper finds the device
+        if self._model.get_path():
+            adjustment = Gtk.Adjustment(
+                value=self._model.get_brightness(),
+                lower=0,
+                upper=self._model.get_max_brightness() + 1,
+                step_incr=self._model.get_step_amount(),
+                page_incr=self._model.get_step_amount(),
+                page_size=self._model.get_step_amount())
+            self._adjustment = adjustment
+
+            self._adjustment_hid = \
+                self._adjustment.connect('value_changed', self.__adjusted_cb)
+
+            hscale = Gtk.HScale()
+            hscale.props.draw_value = False
+            hscale.set_adjustment(adjustment)
+            hscale.set_digits(0)
+            hscale.set_size_request(style.GRID_CELL_SIZE * 4, -1)
+            alignment.add(hscale)
+            hscale.show()
+        else:
+            self._progress_bar = Gtk.ProgressBar()
+            self._progress_bar.set_size_request(
+                style.zoom(style.GRID_CELL_SIZE * 4), -1)
+            alignment.props.top_padding = style.DEFAULT_PADDING
+            alignment.add(self._progress_bar)
+            self._progress_bar.show()
+
+        alignment.show()
+        self.add(alignment)
+
+    def update(self):
+        if self._adjustment:
+            self._adjustment.handler_block(self._adjustment_hid)
+            self._adjustment.props.value = self._model.get_brightness()
+            self._adjustment.handler_unblock(self._adjustment_hid)
+        else:
+            self._progress_bar.props.fraction = \
+                float(self._model.get_brightness()) \
+                / self._model.get_max_brightness()
+
+    def __adjusted_cb(self, device, data=None):
+        value = self._adjustment.props.value
+        self._model.set_brightness(int(value))
+
+
+class DisplayPalette(Palette):
+
+    def __init__(self):
+        Palette.__init__(self, label=_('My Display'))
+
+        self._brightness_manager = BrightnessManagerWidget(_('Brightness'),
+                                                           'brightness-100')
+        self._brightness_manager.show()
+
+        separator = PaletteMenuItemSeparator()
+        separator.show()
+
+        self._screenshot = PaletteMenuItem(_('Take a screenshot'))
+        icon = Icon(icon_name='camera-external',
+                    pixel_size=style.SMALL_ICON_SIZE)
+        self._screenshot.set_image(icon)
+        icon.show()
+        self._screenshot.connect('activate', self.__screenshot_cb)
+        self._screenshot.show()
+
+        self._box = PaletteMenuBox()
+        self._box.append_item(self._brightness_manager, 0, 0)
+        self._box.append_item(separator, 0, 0)
+        self._box.append_item(self._screenshot, 0, 0)
+        self._box.show()
+
+        self.set_content(self._box)
+        self.connect('popup', self.__popup_cb)
+
+    def __popup_cb(self, palette):
+        self._brightness_manager.update()
+
+    def __screenshot_cb(self, palette):
+        frame_ = frame.get_view()
+        frame_.hide()
+        GObject.idle_add(self.__take_screenshot_cb, frame_)
+
+    def __take_screenshot_cb(self, frame_):
+        if frame_.is_visible():
+            return True
+        take_screenshot()
+        frame_.show()
+        return False
+
+
+def setup(tray):
+    if brightness.get_instance().get_path():
+        tray.add_device(DeviceView(_('Display')))

--- a/extensions/globalkey/Makefile.am
+++ b/extensions/globalkey/Makefile.am
@@ -2,6 +2,7 @@ sugardir = $(pkgdatadir)/extensions/globalkey
 
 sugar_PYTHON = 		\
 	__init__.py	\
+	brightness.py	\
 	screenshot.py	\
 	speech.py	\
 	viewsource.py	\

--- a/extensions/globalkey/brightness.py
+++ b/extensions/globalkey/brightness.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2015 Martin Abente Lahaye <tch@sugarlabs.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+from jarabe.model import brightness
+
+BOUND_KEYS = ['XF86MonBrightnessUp', 'XF86MonBrightnessDown']
+
+
+def handle_key_press(key):
+    model = brightness.get_instance()
+    if not model.get_path():
+        return
+
+    value = model.get_brightness()
+    if key == 'XF86MonBrightnessUp':
+        new_value = value + model.get_step_amount()
+        if new_value > model.get_max_brightness():
+            new_value = model.get_max_brightness()
+    else:
+        new_value = value - model.get_step_amount()
+        if new_value < 0:
+            new_value = 0
+
+    # don't write to the device unnecessarily
+    if new_value == value:
+        return
+
+    model.set_brightness(new_value)

--- a/extensions/globalkey/screenshot.py
+++ b/extensions/globalkey/screenshot.py
@@ -15,106 +15,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-import os
-import tempfile
-from gettext import gettext as _
-import StringIO
-import cairo
-
-from gi.repository import Gdk
-from gi.repository import Gio
-import dbus
-
-from sugar3.datastore import datastore
-from sugar3.graphics import style
-from sugar3 import env
-from jarabe.model import shell
+from jarabe.model.screenshot import take_screenshot
 
 BOUND_KEYS = ['<alt>1', 'Print']
 
 
 def handle_key_press(key):
-    tmp_dir = os.path.join(env.get_profile_path(), 'data')
-    fd, file_path = tempfile.mkstemp(dir=tmp_dir)
-    os.close(fd)
-
-    window = Gdk.get_default_root_window()
-    width, height = window.get_width(), window.get_height()
-
-    screenshot_surface = Gdk.Window.create_similar_surface(
-        window, cairo.CONTENT_COLOR, width, height)
-
-    cr = cairo.Context(screenshot_surface)
-    Gdk.cairo_set_source_window(cr, window, 0, 0)
-    cr.paint()
-    screenshot_surface.write_to_png(file_path)
-
-    settings = Gio.Settings('org.sugarlabs.user')
-    color = settings.get_string('color')
-
-    content_title = None
-    shell_model = shell.get_model()
-    zoom_level = shell_model.zoom_level
-
-    # TRANS: Nouns of what a screenshot contains
-    if zoom_level == shell_model.ZOOM_MESH:
-        content_title = _('Mesh')
-    elif zoom_level == shell_model.ZOOM_GROUP:
-        content_title = _('Group')
-    elif zoom_level == shell_model.ZOOM_HOME:
-        content_title = _('Home')
-    elif zoom_level == shell_model.ZOOM_ACTIVITY:
-        activity = shell_model.get_active_activity()
-        if activity is not None:
-            content_title = activity.get_title()
-            if content_title is None:
-                content_title = _('Activity')
-
-    if content_title is None:
-        title = _('Screenshot')
-    else:
-        title = _('Screenshot of \"%s\"') % content_title
-
-    jobject = datastore.create()
-    try:
-        jobject.metadata['title'] = title
-        jobject.metadata['keep'] = '0'
-        jobject.metadata['buddies'] = ''
-        jobject.metadata['preview'] = _get_preview_data(screenshot_surface)
-        jobject.metadata['icon-color'] = color
-        jobject.metadata['mime_type'] = 'image/png'
-        jobject.file_path = file_path
-        datastore.write(jobject, transfer_ownership=True)
-    finally:
-        jobject.destroy()
-        del jobject
-
-
-def _get_preview_data(screenshot_surface):
-    screenshot_width = screenshot_surface.get_width()
-    screenshot_height = screenshot_surface.get_height()
-
-    preview_width, preview_height = style.zoom(300), style.zoom(225)
-    preview_surface = cairo.ImageSurface(cairo.FORMAT_ARGB32,
-                                         preview_width, preview_height)
-    cr = cairo.Context(preview_surface)
-
-    scale_w = preview_width * 1.0 / screenshot_width
-    scale_h = preview_height * 1.0 / screenshot_height
-    scale = min(scale_w, scale_h)
-
-    translate_x = int((preview_width - (screenshot_width * scale)) / 2)
-    translate_y = int((preview_height - (screenshot_height * scale)) / 2)
-
-    cr.translate(translate_x, translate_y)
-    cr.scale(scale, scale)
-
-    cr.set_source_rgba(1, 1, 1, 0)
-    cr.set_operator(cairo.OPERATOR_SOURCE)
-    cr.paint()
-    cr.set_source_surface(screenshot_surface)
-    cr.paint()
-
-    preview_str = StringIO.StringIO()
-    preview_surface.write_to_png(preview_str)
-    return dbus.ByteArray(preview_str.getvalue())
+    take_screenshot()

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -33,6 +33,7 @@ extensions/cpsection/webaccount/__init__.py
 extensions/cpsection/webaccount/view.py
 extensions/deviceicon/audio.py
 extensions/deviceicon/battery.py
+extensions/deviceicon/display.py
 extensions/deviceicon/frame.py
 extensions/deviceicon/network.py
 extensions/deviceicon/speech.py
@@ -76,6 +77,7 @@ src/jarabe/journal/volumestoolbar.py
 src/jarabe/journal/iconmodel.py
 src/jarabe/journal/iconview.py
 src/jarabe/model/network.py
+src/jarabe/model/screenshot.py
 src/jarabe/view/alerts.py
 src/jarabe/view/buddymenu.py
 src/jarabe/view/keyhandler.py

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,1 +1,2 @@
 data/sugar.xml.in
+data/org.sugar.brightness.policy.in

--- a/src/jarabe/model/Makefile.am
+++ b/src/jarabe/model/Makefile.am
@@ -5,6 +5,7 @@ sugar_PYTHON =			\
 	__init__.py		\
 	buddy.py		\
 	bundleregistry.py	\
+	brightness.py		\
 	desktop.py		\
 	filetransfer.py		\
 	friends.py		\

--- a/src/jarabe/model/Makefile.am
+++ b/src/jarabe/model/Makefile.am
@@ -18,6 +18,7 @@ sugar_PYTHON =			\
         notifications.py        \
 	shell.py		\
 	screen.py		\
+	screenshot.py		\
         session.py		\
 	sound.py		\
 	speech.py		\

--- a/src/jarabe/model/brightness.py
+++ b/src/jarabe/model/brightness.py
@@ -17,6 +17,7 @@
 import os
 
 from gi.repository import GLib
+from gi.repository import Gio
 from gi.repository import GObject
 
 
@@ -34,6 +35,7 @@ class Brightness(GObject.GObject):
 
     _STEPS = 20
     _SUGAR_LINK = '/var/run/sugar-backlight'
+    _SAVE_DELAY = 1000
     changed_signal = GObject.Signal('changed', arg_types=([int]))
 
     def __init__(self):
@@ -41,11 +43,23 @@ class Brightness(GObject.GObject):
         self._path = None
         self._helper_path = None
         self._max_brightness = None
+        self._save_timeout_id = None
         self._setup()
+        self._restore()
 
     def _setup(self):
         cmd = 'pkexec %s' % self._find_binary('sugar-backlight-setup')
         GLib.spawn_command_line_sync(cmd)
+
+    def _save(self, value):
+        settings = Gio.Settings('org.sugarlabs.screen')
+        settings.set_int('brightness', value)
+
+    def _restore(self):
+        settings = Gio.Settings('org.sugarlabs.screen')
+        value = settings.get_int('brightness')
+        if value != -1:
+            self.set_brightness(value)
 
     def _get_helper(self):
         if self._helper_path is None:
@@ -70,9 +84,20 @@ class Brightness(GObject.GObject):
         cmd = 'pkexec %s --%s %d' % (self._get_helper(), option, value)
         GLib.spawn_command_line_sync(cmd)
 
+    def __save_timeout_cb(self, value):
+        self._save_timeout_id = None
+        self._save(value)
+        return False
+
     def set_brightness(self, value):
         self._helper_write('set-brightness', value)
         self.changed_signal.emit(value)
+
+        # do not store every change while is still changing
+        if self._save_timeout_id is not None:
+            GLib.source_remove(self._save_timeout_id)
+        self._save_timeout_id = GLib.timeout_add(
+            self._SAVE_DELAY, self.__save_timeout_cb, value)
 
     def get_path(self):
         if self._path is None:

--- a/src/jarabe/model/brightness.py
+++ b/src/jarabe/model/brightness.py
@@ -1,0 +1,95 @@
+# Copyright (C) 2015 Martin Abente Lahaye <tch@sugarlabs.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+import os
+
+from gi.repository import GLib
+from gi.repository import GObject
+
+
+_instance = None
+
+
+def get_instance():
+    global _instance
+    if _instance is None:
+        _instance = Brightness()
+    return _instance
+
+
+class Brightness(GObject.GObject):
+
+    _STEPS = 20
+    _SUGAR_LINK = '/var/run/sugar-backlight'
+    changed_signal = GObject.Signal('changed', arg_types=([int]))
+
+    def __init__(self):
+        GObject.GObject.__init__(self)
+        self._path = None
+        self._helper_path = None
+        self._max_brightness = None
+        self._setup()
+
+    def _setup(self):
+        cmd = 'pkexec %s' % self._find_binary('sugar-backlight-setup')
+        GLib.spawn_command_line_sync(cmd)
+
+    def _get_helper(self):
+        if self._helper_path is None:
+            self._helper_path = self._find_binary('sugar-backlight-helper')
+        return self._helper_path
+
+    def _find_binary(self, binary):
+        for path in os.environ['PATH'].split(os.pathsep):
+            binary_path = os.path.join(path, binary)
+            if os.path.exists(binary_path):
+                return binary_path
+        return None
+
+    def _helper_read(self, option):
+        cmd = '%s --%s' % (self._get_helper(), option)
+        result, output, error, status = GLib.spawn_command_line_sync(cmd)
+        if status != 0:
+            return None
+        return output.rstrip('\0\n')
+
+    def _helper_write(self, option, value):
+        cmd = 'pkexec %s --%s %d' % (self._get_helper(), option, value)
+        GLib.spawn_command_line_sync(cmd)
+
+    def set_brightness(self, value):
+        self._helper_write('set-brightness', value)
+        self.changed_signal.emit(value)
+
+    def get_path(self):
+        if self._path is None:
+            if os.path.exists(self._SUGAR_LINK):
+                self._path = self._SUGAR_LINK
+        return self._path
+
+    def get_brightness(self):
+        return int(self._helper_read('get-brightness'))
+
+    def get_max_brightness(self):
+        if self._max_brightness is None:
+            self._max_brightness = int(self._helper_read('get-max-brightness'))
+        return self._max_brightness
+
+    def get_step_amount(self):
+        if self.get_max_brightness() < self._STEPS:
+            return 1
+        else:
+            return self.get_max_brightness() / self._STEPS

--- a/src/jarabe/model/brightness.py
+++ b/src/jarabe/model/brightness.py
@@ -36,6 +36,7 @@ class Brightness(GObject.GObject):
     _STEPS = 20
     _SUGAR_LINK = '/var/run/sugar-backlight'
     _SAVE_DELAY = 1000
+    _MONITOR_RATE = 1000
     changed_signal = GObject.Signal('changed', arg_types=([int]))
 
     def __init__(self):
@@ -44,7 +45,11 @@ class Brightness(GObject.GObject):
         self._helper_path = None
         self._max_brightness = None
         self._save_timeout_id = None
+        self._monitor = None
+        self._monitor_timeout_id = None
+        self._monitor_changed_hid = None
         self._setup()
+        self._start_monitoring()
         self._restore()
 
     def _setup(self):
@@ -60,6 +65,16 @@ class Brightness(GObject.GObject):
         value = settings.get_int('brightness')
         if value != -1:
             self.set_brightness(value)
+
+    def _start_monitoring(self):
+        if not self.get_path():
+            return
+
+        self._monitor = Gio.File.new_for_path(self.get_path()) \
+            .monitor_file(Gio.FileMonitorFlags.WATCH_HARD_LINKS, None)
+        self._monitor.set_rate_limit(self._MONITOR_RATE)
+        self._monitor_changed_hid = \
+            self._monitor.connect('changed', self.__monitor_changed_cb)
 
     def _get_helper(self):
         if self._helper_path is None:
@@ -84,14 +99,33 @@ class Brightness(GObject.GObject):
         cmd = 'pkexec %s --%s %d' % (self._get_helper(), option, value)
         GLib.spawn_command_line_sync(cmd)
 
+    def __monitor_changed_cb(self, monitor, child, other_file, event):
+        if event == Gio.FileMonitorEvent.CHANGED:
+            self.changed_signal.emit(self.get_brightness())
+
+    def __monitor_timeout_cb(self):
+        self._monitor_timeout_id = None
+        self._monitor.handler_unblock(self._monitor_changed_hid)
+        return False
+
     def __save_timeout_cb(self, value):
         self._save_timeout_id = None
         self._save(value)
         return False
 
     def set_brightness(self, value):
+        # do not monitor the external change we are about to trigger
+        if self._monitor_timeout_id is None:
+            self._monitor.handler_block(self._monitor_changed_hid)
+
         self._helper_write('set-brightness', value)
         self.changed_signal.emit(value)
+
+        # do monitor again only after the rate has passed
+        if self._monitor_timeout_id is not None:
+            GLib.source_remove(self._monitor_timeout_id)
+        self._monitor_timeout_id = GLib.timeout_add(
+            self._MONITOR_RATE * 2, self.__monitor_timeout_cb)
 
         # do not store every change while is still changing
         if self._save_timeout_id is not None:

--- a/src/jarabe/model/screenshot.py
+++ b/src/jarabe/model/screenshot.py
@@ -1,0 +1,120 @@
+# Copyright (C) 2008 One Laptop Per Child
+# Copyright (C) 2009 Simon Schampijer, James Zaki
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+import os
+import tempfile
+from gettext import gettext as _
+import StringIO
+import cairo
+
+from gi.repository import Gdk
+from gi.repository import Gio
+import dbus
+
+from sugar3.datastore import datastore
+from sugar3.graphics import style
+from sugar3 import env
+from jarabe.model import shell
+
+
+def take_screenshot():
+    tmp_dir = os.path.join(env.get_profile_path(), 'data')
+    fd, file_path = tempfile.mkstemp(dir=tmp_dir)
+    os.close(fd)
+
+    window = Gdk.get_default_root_window()
+    width, height = window.get_width(), window.get_height()
+
+    screenshot_surface = Gdk.Window.create_similar_surface(
+        window, cairo.CONTENT_COLOR, width, height)
+
+    cr = cairo.Context(screenshot_surface)
+    Gdk.cairo_set_source_window(cr, window, 0, 0)
+    cr.paint()
+    screenshot_surface.write_to_png(file_path)
+
+    settings = Gio.Settings('org.sugarlabs.user')
+    color = settings.get_string('color')
+
+    content_title = None
+    shell_model = shell.get_model()
+    zoom_level = shell_model.zoom_level
+
+    # TRANS: Nouns of what a screenshot contains
+    if zoom_level == shell_model.ZOOM_MESH:
+        content_title = _('Mesh')
+    elif zoom_level == shell_model.ZOOM_GROUP:
+        content_title = _('Group')
+    elif zoom_level == shell_model.ZOOM_HOME:
+        content_title = _('Home')
+    elif zoom_level == shell_model.ZOOM_ACTIVITY:
+        activity = shell_model.get_active_activity()
+        if activity is not None:
+            content_title = activity.get_title()
+            if content_title is None:
+                content_title = _('Activity')
+
+    if content_title is None:
+        title = _('Screenshot')
+    else:
+        title = _('Screenshot of \"%s\"') % content_title
+
+    jobject = datastore.create()
+    try:
+        jobject.metadata['title'] = title
+        jobject.metadata['keep'] = '0'
+        jobject.metadata['buddies'] = ''
+        jobject.metadata['preview'] = _get_preview_data(screenshot_surface)
+        jobject.metadata['icon-color'] = color
+        jobject.metadata['mime_type'] = 'image/png'
+        jobject.file_path = file_path
+        datastore.write(jobject, transfer_ownership=True)
+    finally:
+        jobject.destroy()
+        del jobject
+
+    return title
+
+
+def _get_preview_data(screenshot_surface):
+    screenshot_width = screenshot_surface.get_width()
+    screenshot_height = screenshot_surface.get_height()
+
+    preview_width, preview_height = style.zoom(300), style.zoom(225)
+    preview_surface = cairo.ImageSurface(cairo.FORMAT_ARGB32,
+                                         preview_width, preview_height)
+    cr = cairo.Context(preview_surface)
+
+    scale_w = preview_width * 1.0 / screenshot_width
+    scale_h = preview_height * 1.0 / screenshot_height
+    scale = min(scale_w, scale_h)
+
+    translate_x = int((preview_width - (screenshot_width * scale)) / 2)
+    translate_y = int((preview_height - (screenshot_height * scale)) / 2)
+
+    cr.translate(translate_x, translate_y)
+    cr.scale(scale, scale)
+
+    cr.set_source_rgba(1, 1, 1, 0)
+    cr.set_operator(cairo.OPERATOR_SOURCE)
+    cr.paint()
+    cr.set_source_surface(screenshot_surface)
+    cr.paint()
+
+    preview_str = StringIO.StringIO()
+    preview_surface.write_to_png(preview_str)
+    return dbus.ByteArray(preview_str.getvalue())


### PR DESCRIPTION
This PR is for adding brightness control capabilities to Sugar. It includes a generic mechanism to interact with backlight devices, a jarabe model that acts as an abstraction for the sugar shell, keyboard control keys and a device frame UI.