### PR TITLE
Don't change star color on hovering - Fixes #3147

### DIFF
--- a/src/jarabe/desktop/activitieslist.py
+++ b/src/jarabe/desktop/activitieslist.py
@@ -367,9 +367,6 @@ class CellRendererFavorite(CellRendererIcon):
         self.props.size = style.SMALL_ICON_SIZE
         self.props.icon_name = desktop.get_favorite_icons()[favorite_view]
         self.props.mode = Gtk.CellRendererMode.ACTIVATABLE
-        prelit_color = profile.get_color()
-        self.props.prelit_stroke_color = prelit_color.get_stroke_color()
-        self.props.prelit_fill_color = prelit_color.get_fill_color()
 
 
 class CellRendererActivityIcon(CellRendererIcon):

--- a/src/jarabe/journal/keepicon.py
+++ b/src/jarabe/journal/keepicon.py
@@ -33,8 +33,6 @@ class KeepIcon(Gtk.ToggleButton):
                           pixel_size=style.SMALL_ICON_SIZE)
         self.set_image(self._icon)
         self.connect('toggled', self.__toggled_cb)
-        self.connect('leave-notify-event', self.__leave_notify_event_cb)
-        self.connect('enter-notify-event', self.__enter_notify_event_cb)
         self.connect('button-press-event', self.__button_press_event_cb)
         self.connect('button-release-event', self.__button_release_event_cb)
 
@@ -61,14 +59,5 @@ class KeepIcon(Gtk.ToggleButton):
         if self.get_active():
             self._icon.props.xo_color = self._xo_color
         else:
-            self._icon.props.stroke_color = style.COLOR_BUTTON_GREY.get_svg()
-            self._icon.props.fill_color = style.COLOR_TRANSPARENT.get_svg()
-
-    def __enter_notify_event_cb(self, icon, event):
-        if not self.get_active():
-            self._icon.props.xo_color = self._xo_color
-
-    def __leave_notify_event_cb(self, icon, event):
-        if not self.get_active():
             self._icon.props.stroke_color = style.COLOR_BUTTON_GREY.get_svg()
             self._icon.props.fill_color = style.COLOR_TRANSPARENT.get_svg()

--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -754,9 +754,6 @@ class CellRendererFavorite(CellRendererIcon):
         self.props.size = style.SMALL_ICON_SIZE
         self.props.icon_name = 'emblem-favorite'
         self.props.mode = Gtk.CellRendererMode.ACTIVATABLE
-        prelit_color = profile.get_color()
-        self.props.prelit_stroke_color = prelit_color.get_stroke_color()
-        self.props.prelit_fill_color = prelit_color.get_fill_color()
 
 
 class CellRendererDetail(CellRendererIcon):


### PR DESCRIPTION
Change the star color on hovering cnfuses to the user,
because think the favorite state has changed.
This can be seen in the activities list view, in the Journal listview,
and in the Journal detail view.