### PR TITLE
Fix trailing whitespace on firmware version

### DIFF
--- a/extensions/cpsection/aboutcomputer/model.py
+++ b/extensions/cpsection/aboutcomputer/model.py
@@ -93,7 +93,7 @@ def get_firmware_number():
         # try to extract Open Firmware version from OLPC style version
         # string, e.g. "CL2   Q4B11  Q4B"
         if firmware_no.startswith('CL'):
-            firmware_no = firmware_no[6:13]
+            firmware_no = firmware_no[6:13].strip()
         ec_name = _read_device_tree('ec-name')
         if ec_name:
             firmware_no = '%(firmware)s with %(ec)s' % {


### PR DESCRIPTION
On most XO laptops the firmware version doesn't have the engineer's build number appended, and this results in "Q7C05   with 0.5.01" shown.  Oh the irony.

Strip the trailing whitespace before using the version number.