### PR TITLE
Disable overlay scrolling, fixes #4854

### DIFF
--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -34,6 +34,9 @@ import shutil
 reload(sys)
 sys.setdefaultencoding('utf-8')
 
+# Disable overlay scrolling - before GTK is loaded
+os.environ['GTK_OVERLAY_SCROLLING'] = '0'
+
 import gettext
 from dbus.mainloop.glib import DBusGMainLoop
 DBusGMainLoop(set_as_default=True)


### PR DESCRIPTION
This commit disables overlay scrollig in Sugar.  Although this should
be set in the sugar theme, that is not possible.

Setting the environment variable disables the overlay scrolling for
both Sugar Shell and all sub processes (eg. activities).

Ticket URL:  http://bugs.sugarlabs.org/ticket/4854