### PR TITLE
Add escape key to close help

### DIFF
--- a/src/jarabe/view/viewhelp.py
+++ b/src/jarabe/view/viewhelp.py
@@ -163,6 +163,7 @@ class ViewHelp(Gtk.Window):
         self.set_size_request(width, height)
 
         self.connect('realize', self.__realize_cb)
+        self.connect('key-press-event', self.__key_press_event_cb)
 
         toolbar = Toolbar(title, has_local_help)
         box.pack_start(toolbar, False, False, 0)
@@ -214,6 +215,10 @@ class ViewHelp(Gtk.Window):
     def __stop_clicked_cb(self, widget):
         self.destroy()
         shell.get_model().pop_modal()
+
+    def __key_press_event_cb(self, window, event):
+        if event.keyval == Gdk.KEY_Escape:
+            self.__stop_clicked_cb(None)
 
     def __mode_changed_cb(self, toolbar, mode):
         if self._mode == _MODE_HELP:


### PR DESCRIPTION
For consistency with other modal dialogs such as view source and control panel, add a handler to translate escape key into stop button.

Tested on XO-4 with 14.1.0 and Sugar 0.105.1, using this method:
* change file on target, restart display manager:
```
rsync src/jarabe/view/viewhelp.py \
    target:/usr/lib/python2.7/site-packages/jarabe/view/viewhelp.py
ssh target service olpc-dm restart
```
* start Implode activity, use Alt-Shift-H to display help window,
* press Escape, and window does close,
* check for interesting logs.