### PR TITLE
Fix favorite view scroll to top

### DIFF
--- a/src/jarabe/journal/listmodel.py
+++ b/src/jarabe/journal/listmodel.py
@@ -92,8 +92,15 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
         # avoid hitting D-Bus and disk.
         self.view_is_resizing = False
 
+        # HACK: Store some changes as patches so we do not need to regenerate
+        # the model and stuff up the scroll position
+        self._patches = {}
+
         self._result_set.ready.connect(self.__result_set_ready_cb)
         self._result_set.progress.connect(self.__result_set_progress_cb)
+
+    def add_patch(self, metadata):
+        self._patches[metadata['uid']] = metadata
 
     def get_all_ids(self):
         return self._all_ids
@@ -141,6 +148,7 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
 
         self._result_set.seek(index)
         metadata = self._result_set.read()
+        metadata.update(self._patches.get(metadata['uid'], {}))
 
         self._last_requested_index = index
         self._cached_row = []


### PR DESCRIPTION
Replaces #514

This patch changes the way favorite changes are done in the journal.
Now, the user clicks the icon, which then adds a patch to the list
view and redraws that square - this removes the whole redo the model
dance that happened before.

1/2 of a fix to #4852