### PR TITLE
Update metadata in the treeview without reload all - Fixes #4852

### DIFF
--- a/src/jarabe/journal/listmodel.py
+++ b/src/jarabe/journal/listmodel.py
@@ -92,6 +92,10 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
         # avoid hitting D-Bus and disk.
         self.view_is_resizing = False
 
+        # Store the changes originated in the treeview so we do not need
+        # to regenerate the model and stuff up the scroll position
+        self._updated_entries = {}
+
         self._result_set.ready.connect(self.__result_set_ready_cb)
         self._result_set.progress.connect(self.__result_set_progress_cb)
 
@@ -107,8 +111,9 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
     def __result_set_progress_cb(self, **kwargs):
         self.emit('progress')
 
-    def setup(self):
+    def setup(self, updated_callback=None):
         self._result_set.setup()
+        self._updated_callback = updated_callback
 
     def stop(self):
         self._result_set.stop()
@@ -128,6 +133,25 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
         else:
             return 0
 
+    def set_value(self, iterator, column, value):
+        index = iterator.user_data
+        self._result_set.seek(index)
+        metadata = self._result_set.read()
+        if column == ListModel.COLUMN_FAVORITE:
+            metadata['keep'] = value
+        if column == ListModel.COLUMN_TITLE:
+            metadata['title'] = value
+        self._updated_entries[metadata['uid']] = metadata
+        if self._updated_callback is not None:
+            model.updated.disconnect(self._updated_callback)
+        model.write(metadata, update_mtime=False,
+                    ready_callback=self.__reconect_updates_cb)
+
+    def __reconect_updates_cb(self, metadata, filepath, uid):
+        logging.error('__reconect_updates_cb')
+        if self._updated_callback is not None:
+            model.updated.connect(self._updated_callback)
+
     def do_get_value(self, iterator, column):
         if self.view_is_resizing:
             return None
@@ -141,6 +165,7 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
 
         self._result_set.seek(index)
         metadata = self._result_set.read()
+        metadata.update(self._updated_entries.get(metadata['uid'], {}))
 
         self._last_requested_index = index
         self._cached_row = []

--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -236,12 +236,13 @@ class BaseListView(Gtk.Bin):
         cell_favorite = CellRendererFavorite()
         cell_favorite.connect('clicked', self._favorite_clicked_cb)
 
-        column = Gtk.TreeViewColumn()
-        column.props.sizing = Gtk.TreeViewColumnSizing.FIXED
-        column.props.fixed_width = cell_favorite.props.width
-        column.pack_start(cell_favorite, True)
-        column.set_cell_data_func(cell_favorite, self.__favorite_set_data_cb)
-        self.tree_view.append_column(column)
+        self._fav_column = Gtk.TreeViewColumn()
+        self._fav_column.props.sizing = Gtk.TreeViewColumnSizing.FIXED
+        self._fav_column.props.fixed_width = cell_favorite.props.width
+        self._fav_column.pack_start(cell_favorite, True)
+        self._fav_column.set_cell_data_func(
+            cell_favorite, self.__favorite_set_data_cb)
+        self.tree_view.append_column(self._fav_column)
 
         self.cell_icon = CellRendererActivityIcon()
 
@@ -369,14 +370,20 @@ class BaseListView(Gtk.Bin):
 
     def _favorite_clicked_cb(self, cell, path):
         row = self._model[path]
+        iterator = self._model.get_iter(path)
         metadata = model.get(row[ListModel.COLUMN_UID])
         if not model.is_editable(metadata):
             return
         if metadata.get('keep', 0) == '1':
             metadata['keep'] = '0'
+            self._model[iterator][ListModel.COLUMN_FAVORITE] = '0'
         else:
             metadata['keep'] = '1'
-        model.write(metadata, update_mtime=False)
+            self._model[iterator][ListModel.COLUMN_FAVORITE] = '1'
+
+        cell_rect = self.tree_view.get_cell_area(path, self._fav_column)
+        self.tree_view.queue_draw_area(cell_rect.x, cell_rect.y,
+                                       cell_rect.width, cell_rect.height)
 
     def __select_set_data_cb(self, column, cell, tree_model, tree_iter,
                              data):
@@ -426,7 +433,7 @@ class BaseListView(Gtk.Bin):
         self._model = ListModel(self._query)
         self._model.connect('ready', self.__model_ready_cb)
         self._model.connect('progress', self.__model_progress_cb)
-        self._model.setup()
+        self._model.setup(self.__model_updated_cb)
         window = self.get_toplevel().get_window()
         if window is not None:
             window.set_cursor(None)
@@ -731,11 +738,8 @@ class ListView(BaseListView):
                     alert_window=journalwindow.get_journal_window())
 
     def __cell_title_edited_cb(self, cell, path, new_text):
-        row = self._model[path]
-        metadata = model.get(row[ListModel.COLUMN_UID])
-        metadata['title'] = new_text
-        model.write(metadata, update_mtime=False)
-        self.cell_title.props.editable = False
+        iterator = self._model.get_iter(path)
+        self._model[iterator][ListModel.COLUMN_TITLE] = new_text
         self.emit('title-edit-finished')
 
     def __editing_canceled_cb(self, cell):


### PR DESCRIPTION
Implement a set_value method in the model, and move the logic
to write to the datastore to the ListModel. To be able to
update the model without trigger a update in the treeview,
we pass the updated callback in the ListModel.setup() method,
and the callback is disconnected and connected in every update.

The treeview have the responsabilty of redraw the cell after
the change was done.

The listmodel stores a dictionary with the entries uodated,
to provide that data until the next update in the Journal.

This patch is heavily based in the work of
Sam Parkinson <sam.parkinson3@gmail.com>