### PR TITLE
request for discussion: brightness controls: fedora 18

### DIFF
--- a/src/jarabe/model/brightness.py
+++ b/src/jarabe/model/brightness.py
@@ -70,8 +70,12 @@ class Brightness(GObject.GObject):
         if not self.get_path():
             return
 
+        try:
+            flags = Gio.FileMonitorFlags.WATCH_HARD_LINKS
+        except:
+            flags = 0
         self._monitor = Gio.File.new_for_path(self.get_path()) \
-            .monitor_file(Gio.FileMonitorFlags.WATCH_HARD_LINKS, None)
+            .monitor_file(flags, None)
         self._monitor.set_rate_limit(self._MONITOR_RATE)
         self._monitor_changed_hid = \
             self._monitor.connect('changed', self.__monitor_changed_cb)


### PR DESCRIPTION
On Fedora 18, XO-1.5 with 13.2.4 and Sugar 0.105.1 as upgrade, the display icon is missing from the frame and shell.log shows
```
AttributeError: type object 'GFileMonitorFlags'
    has no attribute 'WATCH_HARD_LINKS'
```

Using 0 for flag does not fail with an error, the display icon is present, can be used to change brightness, but changes to brightness made externally (using echo, or powerd, or olpc-kbdshim) do not move the slider.

inotifywatch does show events for changes to brightness, so kernel support is present, missing support is probably because of Gio.

This patch only suppresses the error.

@tchx84, others, can you suggest a fix?