### PR TITLE
Hide power control panel if powerd missing

### DIFF
--- a/extensions/cpsection/power/__init__.py
+++ b/extensions/cpsection/power/__init__.py
@@ -15,8 +15,11 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 
 from gettext import gettext as _
+import os
 
-CLASS = 'Power'
+POWERD_FLAG_DIR = '/etc/powerd/flags'
+if os.access(POWERD_FLAG_DIR, os.W_OK):
+    CLASS = 'Power'
 ICON = 'module-power'
 TITLE = _('Power')
 KEYWORDS = ['automatic', 'extreme', 'power', 'suspend', 'battery']

--- a/extensions/cpsection/power/__init__.py
+++ b/extensions/cpsection/power/__init__.py
@@ -22,4 +22,4 @@ if os.access(POWERD_FLAG_DIR, os.W_OK):
     CLASS = 'Power'
 ICON = 'module-power'
 TITLE = _('Power')
-KEYWORDS = ['automatic', 'extreme', 'power', 'suspend', 'battery']
+KEYWORDS = ['automatic', 'power', 'suspend', 'battery']

--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -318,7 +318,7 @@ class ControlPanel(Gtk.Window):
                             keywords.append(item)
                         options[item]['keywords'] = keywords
                     else:
-                        _logger.error('no CLASS attribute in %r', item)
+                        _logger.debug('no CLASS attribute in %r', item)
                 except Exception:
                     logging.exception('Exception while loading extension:')
 


### PR DESCRIPTION
On commodity hardware the power control panel does nothing useful.

With this patch, if powerd is not present, the CLASS global is not set, causing the panel to be omitted from the control panel.

The message about missing CLASS is demoted from error to debug.

Tested on Ubuntu 15.04 Vivid with Sugar 0.105.2 (without powerd) and Fedora 18 with Sugar 0.104.1 (with powerd).