### PR TITLE
Fix favorite selection in multiple home views

### DIFF
--- a/src/jarabe/desktop/activitieslist.py
+++ b/src/jarabe/desktop/activitieslist.py
@@ -70,17 +70,13 @@ class ActivitiesTreeView(Gtk.TreeView):
         self._model.set_visible_func(self.__model_visible_cb)
         self.set_model(self._model)
 
-        column = Gtk.TreeViewColumn()
-
-        cell_favorites = []
         for i in range(desktop.get_number_of_views()):
-            cell_favorites.append(CellRendererFavorite(i))
-            cell_favorites[i].connect('clicked', self.__favorite_clicked_cb)
-            column.pack_start(cell_favorites[i], True)
-            column.set_cell_data_func(cell_favorites[i],
-                                      self.__favorite_set_data_cb)
-
-        self.append_column(column)
+            column = Gtk.TreeViewColumn()
+            cell = CellRendererFavorite(i)
+            cell.connect('clicked', self.__favorite_clicked_cb)
+            column.pack_start(cell, True)
+            column.set_cell_data_func(cell, self.__favorite_set_data_cb)
+            self.append_column(column)
 
         cell_icon = CellRendererActivityIcon()
         cell_icon.connect('clicked', self.__icon_clicked_cb)


### PR DESCRIPTION
Use different Gtk.TreeViewColumn for each favorite column,
otherwise only the fist one can be clicked and prevents
populating the other home views.

Slightly cleanup that code.

Signed-off-by: Martin Abente Lahaye <tch@sugarlabs.org>