### PR TITLE
Fix logic hole in BundleRegistry.add_bundle

### DIFF
--- a/src/jarabe/model/bundleregistry.py
+++ b/src/jarabe/model/bundleregistry.py
@@ -287,6 +287,11 @@ class BundleRegistry(GObject.GObject):
             logging.exception('Error loading bundle %r', bundle_path)
             return None
 
+        # None is a valid return value from bundle_from_dir helper.
+        if bundle is None:
+            logging.error('No bundle in %r', bundle_path)
+            return None
+
         bundle_id = bundle.get_bundle_id()
         logging.debug('STARTUP: Adding bundle %s', bundle_id)
         installed = self.get_bundle(bundle_id)


### PR DESCRIPTION
BundleRegistry uses Gio.FileMonitor to track changes in activity
installation directories. Any changes in these directories will be
detected and processed by the BundleRegistry.

When processed, the registry will simply assume it is a new bundle
and it will use "bundle_from_dir" helper to load it. The helper
has 3 potential results, (a) it returns a bundle, (b) it throwns
an exception if something went wrong while loading the bundle, or
(c) returns None if the directory is not a bundle.

BundleRegistry.add_bundle did not covered the case (c), therefore
it was failing when non-bundle directories were creates. E.g, when
package managers (such as dpkg) creates temporary directories.

This patch add an extra check to cover the missing case (c) from
when the "bundle_from_dir" helper.

Signed-off-by: Martin Abente Lahaye <tch@sugarlabs.org>