### PR TITLE
Do not open multiple help windows - Fixes #4799

### DIFF
--- a/src/jarabe/model/shell.py
+++ b/src/jarabe/model/shell.py
@@ -132,6 +132,9 @@ class Activity(GObject.GObject):
         """
         self._shell_windows.remove(window)
 
+    def have_shell_window(self):
+        return bool(self._shell_windows)
+
     def stop(self):
         # For web activities the Apisocket will connect to the 'stop'
         # signal, thus preventing the window close.  Then, on the

--- a/src/jarabe/view/viewhelp.py
+++ b/src/jarabe/view/viewhelp.py
@@ -118,7 +118,7 @@ def should_show_view_help(activity):
 
 
 def setup_view_help(activity):
-    if shell.get_model().has_modal():
+    if activity.have_shell_window():
         return
     # check whether the execution was from an activity
     bundle_path = activity.get_bundle_path()


### PR DESCRIPTION
If a user press multiple times the view help shortcut (Alt+Shift+H)
we need check if a window is opened before open another.
The bug was the result of check on a different windows array.