### PR TITLE
translations: add custom entry for Guarani

### DIFF
--- a/extensions/cpsection/language/model.py
+++ b/extensions/cpsection/language/model.py
@@ -62,6 +62,7 @@ def read_all_languages():
     # FIXME: This is a temporary workaround for locales that are essential to
     # OLPC, but are not in Glibc yet.
     locales.append(('Dari', 'Afghanistan', 'fa_AF.utf8'))
+    locales.append(('Guarani', 'Paraguay', 'gn.utf8'))
 
     locales.sort()
     return locales


### PR DESCRIPTION
A group of kids from the OLPC project in Caacupe have translated both
the sugar shell and the sugar gtk3 toolkit to Guarani. They are also in
the process of translating sugar activities [1].

Therefore, it would be a big encouragment for them if we could enable
these translations in the control panel.

This patch adds a custom entry for Guarani as is not yet included in
Fedora [2].

[1] http://translate.sugarlabs.org/gn/
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1207485

Signed-off-by: Martin Abente Lahaye <tch@sugarlabs.org>