### PR TITLE
Fix journal translations try1

### DIFF
--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -25,7 +25,6 @@ import time
 from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Gdk
-from gi.repository import Pango
 
 from sugar3.graphics.palette import Palette
 from sugar3.graphics.toolbarbox import ToolbarBox

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -692,12 +692,6 @@ class SortingButton(ToolButton):
                                   ([])),
     }
 
-    _SORT_OPTIONS = [
-        ('timestamp', 'view-lastedit', _('Sort by date modified')),
-        ('creation_time', 'view-created', _('Sort by date created')),
-        ('filesize', 'view-size', _('Sort by size')),
-    ]
-
     def __init__(self):
         ToolButton.__init__(self)
 
@@ -714,7 +708,13 @@ class SortingButton(ToolButton):
         self.props.palette.set_content(menu_box)
         menu_box.show()
 
-        for property_, icon, label in self._SORT_OPTIONS:
+        sort_options = [
+            ('timestamp', 'view-lastedit', _('Sort by date modified')),
+            ('creation_time', 'view-created', _('Sort by date created')),
+            ('filesize', 'view-size', _('Sort by size')),
+        ]
+
+        for property_, icon, label in sort_options:
             button = PaletteMenuItem(label)
             button_icon = Icon(pixel_size=style.SMALL_ICON_SIZE,
                                icon_name=icon)


### PR DESCRIPTION
Some strings in the Journal are never translated, even when there are proper translations in the .PO.

To test:
1. Go to CP and switch language to Spanish (restart shell).
2. Once in Sugar again, go to Journal and click on Sort tool button.

Without this patch, only english strings can be seen. With the patch, the strings are properly translated.

EXTRA: Fixed a pep8 warning in that file, in a separate commit.