### PR TITLE
Help window: check if another window is opened - Fixes 4801

### DIFF
--- a/src/jarabe/view/viewhelp.py
+++ b/src/jarabe/view/viewhelp.py
@@ -131,6 +131,9 @@ def setup_view_help(activity):
     if not should_show_view_help(activity):
         return
 
+    if shell.get_model().has_modal():
+        return
+
     viewhelp = ViewHelp(activity, window_xid)
     activity.push_shell_window(viewhelp)
     viewhelp.connect('hide', activity.pop_shell_window)


### PR DESCRIPTION
We need check if another window is opened before open the help window.
When the help is related to a activity, is already solved
checking activity.has_shell_window(), but if is in the Home View,
we need avoid open when the My Settings window is opened.
This patch solve the last case.