### PR TITLE
Don't check window type before change view - Fixes #4795

### DIFF
--- a/src/jarabe/model/shell.py
+++ b/src/jarabe/model/shell.py
@@ -463,12 +463,6 @@ class ShellModel(GObject.GObject):
         if old_level == new_level:
             return
 
-        if old_level != self.ZOOM_ACTIVITY:
-            screen = Gdk.Screen.get_default()
-            active_window_type = screen.get_active_window().get_type_hint()
-            if active_window_type != Gdk.WindowTypeHint.DESKTOP:
-                return
-
         self._zoom_level = new_level
         if new_level is not self.ZOOM_ACTIVITY:
             self._desktop_level = new_level


### PR DESCRIPTION
The code removed was introduced on commit 9406c42e to avoid change
views when the My Settings window was opened, but that didn't worked,
and we added the control of modal windows on the shell on 14956762
to solve that case.
But this control have the lateral effect of block change the views
when a popup is opened. Remove this control solves the problem.