### PR TITLE
Set default language when read .i18n file - Fixes #4868

### DIFF
--- a/extensions/cpsection/language/model.py
+++ b/extensions/cpsection/language/model.py
@@ -110,6 +110,7 @@ def get_languages():
     fd.close()
 
     langlist = None
+    lang = _default_lang
 
     for line in lines:
         if line.startswith('LANGUAGE='):


### PR DESCRIPTION
If the file is empty or corrupted, use the default language.