### PR TITLE
Bundle of Clipboard changes

### DIFF
--- a/src/jarabe/frame/clipboardicon.py
+++ b/src/jarabe/frame/clipboardicon.py
@@ -19,6 +19,7 @@ import logging
 
 from gi.repository import Gtk
 from gi.repository import Gdk
+from gi.repository import GdkPixbuf
 from gi.repository import SugarExt
 
 from sugar3.graphics.radiotoolbutton import RadioToolButton
@@ -132,9 +133,9 @@ class ClipboardIcon(RadioToolButton):
             return
 
         if cb_object.get_icon():
-            self._icon.props.icon_name = cb_object.get_icon()
+            self._icon.props.file = cb_object.get_icon()
             if self._notif_icon:
-                self._notif_icon.props.icon_name = self._icon.props.icon_name
+                self._notif_icon.props.icon_filename = self._icon.props.file
         else:
             self._icon.props.icon_name = 'application-octet-stream'
 
@@ -163,7 +164,7 @@ class ClipboardIcon(RadioToolButton):
 
     def show_notification(self):
         self._notif_icon = NotificationIcon()
-        self._notif_icon.props.icon_name = self._icon.props.icon_name
+        self._notif_icon.props.icon_filename = self._icon.props.file
         self._notif_icon.props.xo_color = \
             XoColor('%s,%s' % (self._icon.props.stroke_color,
                                self._icon.props.fill_color))
@@ -172,9 +173,9 @@ class ClipboardIcon(RadioToolButton):
 
     def _drag_begin_cb(self, widget, context):
         # TODO: We should get the pixbuf from the icon, with colors, etc.
-        icon_theme = Gtk.IconTheme.get_default()
-        pixbuf = icon_theme.load_icon(self._icon.props.icon_name,
-                                      style.STANDARD_ICON_SIZE, 0)
+        pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(
+            self._icon.props.file,
+            style.STANDARD_ICON_SIZE, style.STANDARD_ICON_SIZE)
         Gtk.drag_set_icon_pixbuf(context, pixbuf, hot_x=pixbuf.props.width / 2,
                                  hot_y=pixbuf.props.height / 2)
 

--- a/src/jarabe/frame/clipboardmenu.py
+++ b/src/jarabe/frame/clipboardmenu.py
@@ -64,6 +64,10 @@ class ClipboardMenu(Palette):
         box.append_item(self._remove_item)
         self._remove_item.show()
 
+        self._resume_item = PaletteMenuItem(_('Resume'), 'activity-start')
+        self._resume_item.connect('activate', self.__resume_item_activate_cb)
+        box.append_item(self._resume_item)
+
         self._open_item = PaletteMenuItem(_('Open'), 'zoom-activity')
         self._open_item.connect('activate', self._open_item_activate_cb)
         box.append_item(self._open_item)
@@ -81,6 +85,14 @@ class ClipboardMenu(Palette):
     def _update_open(self):
         activities = self._get_activities()
         logging.debug('_update_open_submenu: %r', activities)
+
+        if self._cb_object.can_resume():
+            self._resume_item.show()
+            self._open_item.hide()
+            return
+        else:
+            self._resume_item.hide()
+            self._open_item.show()
 
         if activities is None or len(activities) <= 1:
             self._open_item.set_label(_('Open'))
@@ -131,6 +143,9 @@ class ClipboardMenu(Palette):
             self.props.secondary_text = preview
         self._update_items_visibility()
         self._update_open()
+
+    def __resume_item_activate_cb(self, menu_item):
+        self._cb_object.resume()
 
     def _open_item_activate_cb(self, menu_item):
         logging.debug('_open_item_activate_cb')

--- a/src/jarabe/journal/listmodel.py
+++ b/src/jarabe/journal/listmodel.py
@@ -79,6 +79,7 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
         GObject.GObject.__init__(self)
 
         self._last_requested_index = None
+        self._temp_drag_file_uid = None
         self._cached_row = None
         self._query = query
         self._all_ids = []
@@ -254,8 +255,11 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
         target_atom = selection.get_target()
         target_name = target_atom.name()
         if target_name == 'text/uri-list':
-            # Get hold of a reference so the temp file doesn't get deleted
-            self._temp_drag_file_path = model.get_file(uid)
+            # Only get a new temp path if we have a new file
+            if uid != self._temp_drag_file_uid:
+                # Get hold of a reference so the temp file doesn't get deleted
+                self._temp_drag_file_path = model.get_file(uid)
+                self._temp_drag_file_uid = uid
             logging.debug('putting %r in selection', self._temp_drag_file_path)
             selection.set(target_atom, 8, self._temp_drag_file_path)
             return True


### PR DESCRIPTION
Feature Page:  http://wiki.sugarlabs.org/go/Features/Replace_GtkMenu

Requires:  https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/238 (and therefore https://github.com/sugarlabs/sugar-artwork/pull/69)

See the toolkit pull request for screenshots.

Hopefully I will also have a patch for the journal palettes.  But there are treeviews and invokers involved, and those 2 things have never gone well for me :smile:

I also think that this patch has a net loss of 3 lines of code!  Yay!