### PR TITLE
Don't let the label expand the icons in the clipboard tray

### DIFF
--- a/src/jarabe/frame/clipboardicon.py
+++ b/src/jarabe/frame/clipboardicon.py
@@ -56,6 +56,10 @@ class ClipboardIcon(RadioToolButton):
         self.set_icon_widget(self._icon)
         self._icon.show()
 
+        # Stop Gtk from displaying a label and expanding the size of
+        # the button.
+        self.props.label_widget = Gtk.Box()
+
         cb_service = clipboard.get_instance()
         cb_service.connect('object-state-changed',
                            self._object_state_changed_cb)


### PR DESCRIPTION
| **Before** | **After** |
| ---------- | ---------- |
| ![1before](https://cloud.githubusercontent.com/assets/6022042/8558765/22825b9a-254a-11e5-9204-4a8b6a494319.png) | ![1after](https://cloud.githubusercontent.com/assets/6022042/8558743/f6742ff6-2549-11e5-8a1d-f0aad038033b.png) |
