### PR TITLE
Set a env variable SUGAR_VERSION

### DIFF
--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -46,6 +46,9 @@ gettext.bindtextdomain('sugar', config.locale_path)
 gettext.bindtextdomain('sugar-toolkit-gtk3', config.locale_path)
 gettext.textdomain('sugar')
 
+# publish sugar version in the environment
+os.environ['SUGAR_VERSION'] = config.version
+
 from dbus.mainloop.glib import DBusGMainLoop
 DBusGMainLoop(set_as_default=True)
 


### PR DESCRIPTION
Browse activity need know the Sugar version to communicate to ASLO.
Until now, we updated Browse activity with a constant,
but is not a good solution.
Other activities can use this version, by example Log.