### PR TITLE
View source gtkmenu

### DIFF
--- a/src/jarabe/view/customizebundle.py
+++ b/src/jarabe/view/customizebundle.py
@@ -78,8 +78,10 @@ def generate_bundle(nick, new_basename):
                                            'dist', '*')):
             os.remove(path)
 
-    config = bundlebuilder.Config(source_dir=os.path.join(
-        user_activities_path, new_basename),
+    source_dir = os.path.join(user_activities_path, new_basename)
+    config = bundlebuilder.Config(
+        source_dir=source_dir,
+        dist_dir=os.path.join(source_dir, 'dist'),
         dist_name='%s-1' % (new_activity_name))
     bundlebuilder.cmd_dist_xo(config, None)
 


### PR DESCRIPTION
```
commit a91462e71904c3358a74cd5f48b6d9d2287d2707
Author: Sam Parkinson <sam.parkinson3@gmail.com>
Date:   Sat Aug 8 08:39:38 2015 +1000

    Display an alert after duplicating bundles in view source
    
    The current system provides no indication to the user that the
    duplication has finished or succeeded.  This is confusing behavior.

commit bdf136df0aec5535c4763621b278edf1a576d50b
Author: Sam Parkinson <sam.parkinson3@gmail.com>
Date:   Sat Aug 8 08:38:59 2015 +1000

    Ensure duplicated xo bundle is placed in expected directory
```