### PR TITLE
Fix journal palettes when missing contact connection

### DIFF
--- a/src/jarabe/model/filetransfer.py
+++ b/src/jarabe/model/filetransfer.py
@@ -296,8 +296,15 @@ def file_transfer_available():
     conn_watcher = connection_watcher.get_instance()
     for connection in conn_watcher.get_connections():
 
-        properties_iface = connection[dbus.PROPERTIES_IFACE]
-        properties = properties_iface.GetAll(CONNECTION_INTERFACE_REQUESTS)
+        try:
+            properties_iface = connection[
+                dbus.PROPERTIES_IFACE]
+            properties = properties_iface.GetAll(
+                CONNECTION_INTERFACE_REQUESTS)
+        except dbus.DBusException as e:
+            logging.exception(e)
+            continue
+
         classes = properties['RequestableChannelClasses']
         for prop, allowed_prop in classes:
 


### PR DESCRIPTION
When the journal palettes are being created, it checks whether
or not there are friends to be added to the send-to menu. This
check is being done via the file_transfer_available helper.

The helper uses the telepathy connection watcher and, under some
circunstances that I haven't been able to reproduce, the connections
in the watcher cannot be reached via the DBus interface.

When this happens, an unhandled DBusException is thrown, breaking
the palette. In other words, the journal palettes are not being
displayed anymore until the shell session is restarted.

This issue was noticed running on Ubuntu 14.04. Created a ticket to
track the source of this issue in SL#4887.

This patch improves the robustness of this helper, but it logs the error
so we don't loose track of this issue.

Signed-off-by: Martin Abente Lahaye <tch@sugarlabs.org>