### PR TITLE
Add setting for frame trigger size, fixes #4835

### DIFF
--- a/data/org.sugarlabs.gschema.xml
+++ b/data/org.sugarlabs.gschema.xml
@@ -152,6 +152,11 @@
             <summary>Corner Delay</summary>
             <description>Delay for the activation of the frame using the corners.</description>
         </key>
+        <key name="trigger-size" type="i">
+            <default>1</default>
+            <summary>Trigger Size</summary>
+            <description>Size of the frame trigger area, in px from the corner/edge.</description>
+        </key>
     </schema>
     <schema id="org.sugarlabs.collaboration" path="/org/sugarlabs/collaboration/">
         <key name="jabber-server" type="s">

--- a/extensions/cpsection/frame/model.py
+++ b/extensions/cpsection/frame/model.py
@@ -67,3 +67,32 @@ def set_edge_delay(delay):
     settings = Gio.Settings('org.sugarlabs.frame')
     settings.set_int('edge-delay', int(delay))
     return 0
+
+
+def get_trigger_size():
+    settings = Gio.Settings('org.sugarlabs.frame')
+    edge_delay = settings.get_int('edge-delay')
+    return edge_delay
+
+
+def print_trigger_size():
+    print '{}px'.format(get_trigger_size())
+
+
+def set_trigger_size(size):
+    """
+    Set the size of the frame trigger area, in px from the corner/edge.
+
+    exactly on the edge: 1
+    """
+    try:
+        int(size)
+    except ValueError:
+        raise ValueError(_('Value must be an integer.'))
+
+    if int(size) < 1:
+        raise ValueError(_('Value must be more than 1.'))
+
+    settings = Gio.Settings('org.sugarlabs.frame')
+    settings.set_int('trigger-size', int(size))
+    return 0

--- a/src/jarabe/frame/eventarea.py
+++ b/src/jarabe/frame/eventarea.py
@@ -20,6 +20,8 @@ from gi.repository import GObject
 from gi.repository import Wnck
 from gi.repository import Gio
 
+from sugar3.graphics import style
+
 
 _MAX_DELAY = 1000
 
@@ -39,44 +41,49 @@ class EventArea(GObject.GObject):
         settings = Gio.Settings('org.sugarlabs.frame')
         self._edge_delay = settings.get_int('edge-delay')
         self._corner_delay = settings.get_int('corner-delay')
+        self._size = settings.get_int('trigger-size')
 
-        right = Gdk.Screen.width() - 1
-        bottom = Gdk.Screen.height() - 1
-        width = Gdk.Screen.width() - 2
-        height = Gdk.Screen.height() - 2
+        if self._size > style.GRID_CELL_SIZE:
+            # This should never happen and will block the user
+            self._size = style.GRID_CELL_SIZE
+
+        right = Gdk.Screen.width() - self._size
+        bottom = Gdk.Screen.height() - self._size
+        width = Gdk.Screen.width() - self._size * 2
+        height = Gdk.Screen.height() - self._size * 2
 
         if self._edge_delay != _MAX_DELAY:
-            invisible = self._create_invisible(1, 0, width, 1,
-                                               self._edge_delay)
+            invisible = self._create_invisible(
+                self._size, 0, width, self._size, self._edge_delay)
             self._windows.append(invisible)
 
-            invisible = self._create_invisible(1, bottom, width, 1,
-                                               self._edge_delay)
+            invisible = self._create_invisible(
+                self._size, bottom, width, self._size, self._edge_delay)
             self._windows.append(invisible)
 
-            invisible = self._create_invisible(0, 1, 1, height,
-                                               self._edge_delay)
+            invisible = self._create_invisible(
+                0, self._size, self._size, height, self._edge_delay)
             self._windows.append(invisible)
 
-            invisible = self._create_invisible(right, 1, 1, height,
-                                               self._edge_delay)
+            invisible = self._create_invisible(
+                right, self._size, self._size, height, self._edge_delay)
             self._windows.append(invisible)
 
         if self._corner_delay != _MAX_DELAY:
-            invisible = self._create_invisible(0, 0, 1, 1,
-                                               self._corner_delay)
+            invisible = self._create_invisible(
+                0, 0, self._size, self._size, self._corner_delay)
             self._windows.append(invisible)
 
-            invisible = self._create_invisible(right, 0, 1, 1,
-                                               self._corner_delay)
+            invisible = self._create_invisible(
+                right, 0, self._size, self._size, self._corner_delay)
             self._windows.append(invisible)
 
-            invisible = self._create_invisible(0, bottom, 1, 1,
-                                               self._corner_delay)
+            invisible = self._create_invisible(
+                0, bottom, self._size, self._size, self._corner_delay)
             self._windows.append(invisible)
 
-            invisible = self._create_invisible(right, bottom, 1, 1,
-                                               self._corner_delay)
+            invisible = self._create_invisible(
+                right, bottom, self._size, self._size, self._corner_delay)
             self._windows.append(invisible)
 
         screen = Wnck.Screen.get_default()


### PR DESCRIPTION
When sugar is run inside a window, the frame trigger is a very target to hit.
This can be improved by making the trigger area bigger, however it is only
needed in some environments, not those where sugar is fullscreen.

Ticket URL  <https://bugs.sugarlabs.org/ticket/4835>

BTW:  Not 100% sure if this is a bug fix or a feature.  It's pretty small, but whatever :smile: