### PR TITLE
Use busy cursor when duplicating activities

### DIFF
--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2008 One Laptop Per Child
 # Copyright (C) 2009 Tomeu Vizoso, Simon Schampijer
 # Copyright (C) 2011 Walter Bender
-# Copyright (C) 2014 Ignacio Rodriguez
+# Copyright (C) 2014-15 Ignacio Rodriguez
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -371,6 +371,13 @@ class DocumentButton(RadioToolButton):
         box.append_item(menu_item)
         menu_item.show()
 
+    def __set_busy_cursor(self, busy):
+        cursor = None
+        if busy:
+            cursor = Gdk.Cursor(Gdk.CursorType.WATCH)
+        gdk_window = self.get_root_window()
+        gdk_window.set_cursor(cursor)
+
     def __copy_to_home_cb(self, menu_item):
         """Make a local copy of the activity bundle in user_activities_path"""
         user_activities_path = get_user_activities_path()
@@ -379,10 +386,18 @@ class DocumentButton(RadioToolButton):
             nick, os.path.basename(self._document_path))
         if not os.path.exists(os.path.join(user_activities_path,
                                            new_basename)):
-            shutil.copytree(self._document_path,
-                            os.path.join(user_activities_path, new_basename),
-                            symlinks=True)
-            customizebundle.generate_bundle(nick, new_basename)
+            self.__set_busy_cursor(True)
+
+            def async_copy_activity_tree():
+                shutil.copytree(self._document_path,
+                                os.path.join(
+                                    user_activities_path,
+                                    new_basename),
+                                symlinks=True)
+                customizebundle.generate_bundle(nick, new_basename)
+                self.__set_busy_cursor(False)
+
+            GObject.idle_add(async_copy_activity_tree)
         else:
             _logger.debug('%s already exists', new_basename)
 


### PR DESCRIPTION
I wasn't able to get the Duplicate option working, but the busy cursor is working..

I get (tested with Moon / TurtleArt activity)

``Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/jarabe/view/viewsource.py", line 397, in async_copy_activity_tree
    customizebundle.generate_bundle(nick, new_basename)
  File "/usr/lib/python2.7/site-packages/jarabe/view/customizebundle.py", line 84, in generate_bundle
    bundlebuilder.cmd_dist_xo(config, None)
  File "/usr/lib/python2.7/site-packages/sugar3/activity/bundlebuilder.py", line 354, in cmd_dist_xo
    packager = XOPackager(Builder(config, options.no_fail))
AttributeError: 'NoneType' object has no attribute 'no_fail'``

I think the duplicate option is totally broken?
Log: http://fpaste.org/275403/44146581/