### PR TITLE
Ensure duplicated xo bundle is placed in expected directory

### DIFF
--- a/src/jarabe/view/customizebundle.py
+++ b/src/jarabe/view/customizebundle.py
@@ -78,8 +78,10 @@ def generate_bundle(nick, new_basename):
                                            'dist', '*')):
             os.remove(path)
 
-    config = bundlebuilder.Config(source_dir=os.path.join(
-        user_activities_path, new_basename),
+    source_dir = os.path.join(user_activities_path, new_basename)
+    config = bundlebuilder.Config(
+        source_dir=source_dir,
+        dist_dir=os.path.join(source_dir, 'dist'),
         dist_name='%s-1' % (new_activity_name))
     bundlebuilder.cmd_dist_xo(config, None)
 


### PR DESCRIPTION
This fixes a crash during the duplicate function in view source.

Steps to reproduce:

1. Open view source for an activity
2. Duplicate
3. See error in shell.log
4. See that there wasn't an xo bundle created in the journal

@i5o, does this fix your issue in sugar-build?

Note to self:  reopen https://github.com/samdroid-apps/sugar/commit/63348be2485a8b84f321fedc322715f3678f4399 after merge