### PR TITLE
Clear journal search with escape key

### DIFF
--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -287,6 +287,7 @@ class JournalActivity(JournalWindow):
 
         keyname = Gdk.keyval_name(event.keyval)
         if keyname == 'Escape':
+            self._main_toolbox.clear_query()
             self.show_main_view()
 
     def __detail_clicked_cb(self, list_view, object_id):


### PR DESCRIPTION
As mentioned in the issue #4892

> search entry box is cleared with escape key in
* neighbourhood view,
* friends view, and;
* home view (list and circle),
>
but not in journal.
when a journal entry is expanded, the escape key returns to the main journal view. (_key_press_event_cb in journalactivity.py)
please also clear the search entry. ;-)

Regards