### PR TITLE
Do not crash if brightness manager can not get a path

### DIFF
--- a/src/jarabe/model/brightness.py
+++ b/src/jarabe/model/brightness.py
@@ -116,7 +116,8 @@ class Brightness(GObject.GObject):
 
     def set_brightness(self, value):
         # do not monitor the external change we are about to trigger
-        if self._monitor_timeout_id is None:
+        if self._monitor is not None \
+           and self._monitor_timeout_id is None:
             self._monitor.handler_block(self._monitor_changed_hid)
 
         self._helper_write('set-brightness', value)


### PR DESCRIPTION
If the brightness manager does not get authentication from polkit,
it does not get a path.  This causes a crash because no file
mointor is created, causing sugar to crash when calling a method
of None.