### PR TITLE
Hide battery icon when battery is not present

### DIFF
--- a/extensions/deviceicon/battery.py
+++ b/extensions/deviceicon/battery.py
@@ -28,7 +28,6 @@ from sugar3.graphics.icon import get_icon_state
 from sugar3.graphics.tray import TrayIcon
 from sugar3.graphics.palette import Palette
 from sugar3.graphics.palettemenu import PaletteMenuBox
-from sugar3.graphics.xocolor import XoColor
 
 from jarabe.frame.frameinvoker import FrameWidgetInvoker
 
@@ -79,12 +78,12 @@ class DeviceView(TrayIcon):
         current_level = self._model.props.level
         xo_color = self._color
         badge_name = None
+        self.show()
 
         if not self._model.props.present:
+            self.hide()
             status = _STATUS_NOT_PRESENT
-            badge_name = None
-            xo_color = XoColor('%s,%s' % (style.COLOR_WHITE.get_svg(),
-                                          style.COLOR_WHITE.get_svg()))
+
         elif self._model.props.charging:
             status = _STATUS_CHARGING
             name += '-charging'
@@ -96,10 +95,11 @@ class DeviceView(TrayIcon):
         else:
             status = _STATUS_FULLY_CHARGED
 
-        self.icon.props.icon_name = get_icon_state(name, current_level,
-                                                   step=-5)
-        self.icon.props.xo_color = xo_color
-        self.icon.props.badge_name = badge_name
+        if self._model.props.present:
+            self.icon.props.icon_name = get_icon_state(name, current_level,
+                                                       step=-5)
+            self.icon.props.xo_color = xo_color
+            self.icon.props.badge_name = badge_name
 
         self.palette.set_info(current_level, self._model.props.time_remaining,
                               status)


### PR DESCRIPTION
Right now it shows a full white battery when it's not present
more logical would be if its not showed.

This patch does that