### PR TITLE
Check if remove_alert is present in toplevel

### DIFF
--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -467,7 +467,9 @@ class DocumentButton(RadioToolButton):
             self.get_toplevel().add_alert(alert)
 
     def __alert_response_cb(self, alert, response_id):
-        self.get_toplevel().remove_alert(alert)
+        toplevel = self.get_toplevel()
+        if hasattr(toplevel, 'remove_alert'):
+            toplevel.remove_alert(alert)
 
     def __keep_in_journal_cb(self, menu_item):
         mime_type = mime.get_from_file_name(self._document_path)


### PR DESCRIPTION
Sometimes the toplevel is changed to DocumentButton,
and there is no remove_alert on DocumentButton.

The idea is to check if there is remove_alert on toplevel,
to prevent a false function call

I made this patch because of this error in logs after duplicate activity (appears -I think- 10 seconds after the duplication process)

`
Traceback (most recent call last):
  File "/home/broot/sugar-build/build/out/install/lib/python2.7/site-packages/jarabe/view/viewsource.py", line 470, in __alert_response_cb
    self.get_toplevel().remove_alert(alert)
AttributeError: 'DocumentButton' object has no attribute 'remove_alert'
`