### PR TITLE
add logout failure alert, for review

### DIFF
--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -378,6 +378,7 @@ class ControlPanel(Gtk.Window):
         elif response_id is Gtk.ResponseType.APPLY:
             session_manager = get_session_manager()
             session_manager.logout()
+            # FIXME: deal more cleanly with no response to save yourself
 
     def __select_option_cb(self, button, event, option):
         self.show_section_view(option)

--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -110,6 +110,13 @@ class ControlPanel(Gtk.Window):
         self.get_window().set_cursor(cursor)
         Gdk.flush()
 
+    def add_alert(self, alert):
+        self._vbox.pack_start(alert, False, False, 0)
+        self._vbox.reorder_child(alert, 2)
+
+    def remove_alert(self, alert):
+        self._vbox.remove(alert)
+
     def grab_focus(self):
         # overwrite grab focus in order to grab focus on the view
         self._main_view.get_child().grab_focus()
@@ -373,15 +380,14 @@ class ControlPanel(Gtk.Window):
             alert.add_button(Gtk.ResponseType.APPLY, _('Restart now'), icon)
             icon.show()
 
-            self._vbox.pack_start(alert, False, False, 0)
-            self._vbox.reorder_child(alert, 2)
+            self.add_alert(alert)
             alert.connect('response', self.__response_cb)
             alert.show()
         else:
             self._show_main_view()
 
     def __response_cb(self, alert, response_id):
-        self._vbox.remove(alert)
+        self.remove_alert(alert)
         self._section_toolbar.accept_button.set_sensitive(True)
         self._section_toolbar.cancel_button.set_sensitive(True)
         if response_id is Gtk.ResponseType.CANCEL:

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -620,11 +620,8 @@ class CurrentActivityIcon(CanvasIcon):
             self.props.xo_color = self._home_activity.get_icon_color()
 
             if self._home_activity.is_journal():
-                if self.get_window():
-                    self.get_window().set_cursor(None)
-                else:
-                    # the window is not visible yet, try again in one second
-                    GLib.timeout_add_seconds(1, self._reset_cursor)
+                if self._unbusy():
+                    GLib.timeout_add(333, self._unbusy)
 
         self.props.pixel_size = style.STANDARD_ICON_SIZE
 
@@ -632,9 +629,10 @@ class CurrentActivityIcon(CanvasIcon):
             self.palette.destroy()
             self.palette = None
 
-    def _reset_cursor(self):
+    def _unbusy(self):
         if self.get_window():
-            self.get_window().set_cursor(None)
+            import jarabe.desktop.homewindow
+            jarabe.desktop.homewindow.get_instance().unbusy()
             return False
         return True
 

--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -109,6 +109,7 @@ class HomeWindow(Gtk.Window):
         self._alerts.append(alert)
         if len(self._alerts) == 1:
             self._display_alert(alert)
+            # FIXME: alerts displayed here are lost on view switch
 
     def remove_alert(self, alert):
         if alert in self._alerts:

--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -62,8 +62,8 @@ class HomeWindow(Gtk.Window):
                               screen.get_height())
 
         self.realize()
-        self.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
-        Gdk.flush()
+        self._busy_count = 0
+        self.busy()
 
         self.set_type_hint(Gdk.WindowTypeHint.DESKTOP)
         self.modify_bg(Gtk.StateType.NORMAL,
@@ -263,18 +263,20 @@ class HomeWindow(Gtk.Window):
     def get_home_box(self):
         return self._home_box
 
-    def busy_during_delayed_action(self, action):
-        """Use busy cursor during execution of action, scheduled via idle_add.
-        """
-        def action_wrapper(old_cursor):
-            try:
-                action()
-            finally:
-                self.get_window().set_cursor(old_cursor)
+    def busy(self):
+        if self._busy_count == 0:
+            self._old_cursor = self.get_window().get_cursor()
+            self._set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
+        self._busy_count += 1
 
-        old_cursor = self.get_window().get_cursor()
-        self.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
-        GLib.idle_add(action_wrapper, old_cursor)
+    def unbusy(self):
+        self._busy_count -= 1
+        if self._busy_count == 0:
+            self._set_cursor(self._old_cursor)
+
+    def _set_cursor(self, cursor):
+        self.get_window().set_cursor(cursor)
+        Gdk.flush()
 
 
 def get_instance():

--- a/src/jarabe/model/session.py
+++ b/src/jarabe/model/session.py
@@ -64,8 +64,15 @@ class SessionManager(GObject.GObject):
         self.shutdown_signal.emit()
         self.session.initiate_shutdown()
 
+    def cancel_shutdown(self):
+        self.session.cancel_shutdown()
+        self._shutdown_tries = 0
+        self._logout_mode = None
+
     def __shutdown_completed_cb(self, session):
-        GObject.timeout_add_seconds(self.SHUTDOWN_TIMEOUT, self._try_shutdown)
+        if self._logout_mode is not None:
+            if self._try_shutdown():
+                GObject.timeout_add(self.SHUTDOWN_TIMEOUT, self._try_shutdown)
 
     def _try_shutdown(self):
         if len(self._shell_model) > 0:

--- a/src/jarabe/view/buddymenu.py
+++ b/src/jarabe/view/buddymenu.py
@@ -21,11 +21,13 @@ from gettext import gettext as _
 
 from gi.repository import Gtk
 from gi.repository import Gio
+from gi.repository import GObject
 import dbus
 
 from sugar3.graphics.palette import Palette
 from sugar3.graphics.palettemenu import PaletteMenuItem
 from sugar3.graphics.icon import Icon
+from sugar3.graphics.alert import Alert
 from sugar3.graphics import style
 
 from jarabe.model import shell
@@ -127,6 +129,34 @@ class BuddyMenu(Palette):
     def _quit(self, action):
         jarabe.desktop.homewindow.get_instance().busy()
         action()
+        GObject.timeout_add_seconds(3, self.__quit_timeout_cb)
+
+    def __quit_timeout_cb(self):
+        jarabe.desktop.homewindow.get_instance().unbusy()
+        alert = Alert()
+        alert.props.title = _('Warning')
+        alert.props.msg = _('An activity is not responding.')
+
+        icon = Icon(icon_name='dialog-ok')
+        alert.add_button(Gtk.ResponseType.ACCEPT, _('Lose unsaved work'), icon)
+        icon.show()
+
+        icon = Icon(icon_name='dialog-cancel')
+        alert.add_button(Gtk.ResponseType.CANCEL, _('Cancel'), icon)
+        icon.show()
+
+        alert.connect('response', self.__quit_accept_cb)
+
+        jarabe.desktop.homewindow.get_instance().add_alert(alert)
+        alert.show()
+
+    def __quit_accept_cb(self, alert, response_id):
+        jarabe.desktop.homewindow.get_instance().remove_alert(alert)
+        if response_id is Gtk.ResponseType.ACCEPT:
+            jarabe.desktop.homewindow.get_instance().busy()
+            get_session_manager().shutdown_completed()
+        if response_id is Gtk.ResponseType.CANCEL:
+            get_session_manager().cancel_shutdown()
 
     def __logout_activate_cb(self, menu_item):
         self._quit(get_session_manager().logout)

--- a/src/jarabe/view/buddymenu.py
+++ b/src/jarabe/view/buddymenu.py
@@ -32,6 +32,7 @@ from jarabe.model import shell
 from jarabe.model import friends
 from jarabe.model.session import get_session_manager
 from jarabe.controlpanel.gui import ControlPanel
+import jarabe.desktop.homewindow
 
 
 class BuddyMenu(Palette):
@@ -124,10 +125,8 @@ class BuddyMenu(Palette):
         item.show()
 
     def _quit(self, action):
-        import jarabe.desktop.homewindow
-
-        home_window = jarabe.desktop.homewindow.get_instance()
-        home_window.busy_during_delayed_action(action)
+        jarabe.desktop.homewindow.get_instance().busy()
+        action()
 
     def __logout_activate_cb(self, menu_item):
         self._quit(get_session_manager().logout)

--- a/src/jarabe/view/keyhandler.py
+++ b/src/jarabe/view/keyhandler.py
@@ -160,6 +160,7 @@ class KeyHandler(object):
     def handle_logout(self, event_time):
         if "SUGAR_DEVELOPER" in os.environ:
             session.get_session_manager().logout()
+            # FIXME: deal more cleanly with no response to save yourself
 
     def handle_open_search(self, event_time):
         journalactivity.get_journal().show_journal()


### PR DESCRIPTION
DO NOT MERGE

Issues are:

 - alert is lost if F1 then F3 key is pressed, seems to be a problem generally with alerts on the home window,

 - control panel restart is not yet handled

 - logout shortcut key is not yet handled, but it is developer only feature.
