### PR TITLE
check before remove on control panel section end

### DIFF
--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -111,7 +111,8 @@ class ControlPanel(Gtk.Window):
 
     def _set_canvas(self, canvas):
         if self._canvas:
-            self._main_view.remove(self._canvas)
+            if self._canvas in self._main_view:
+                self._main_view.remove(self._canvas)
         if canvas:
             self._main_view.add(canvas)
         self._canvas = canvas


### PR DESCRIPTION
A critical warning appears in shell.log when a control panel section is removed from screen:

```(main.py:6713): Gtk-CRITICAL **: gtk_container_remove: assertion 'gtk_widget_get_parent (widget) == GTK_WIDGET (container) || GTK_IS_ASSISTANT (container)' failed```

Fix the warning by checking the object is in the container before trying to remove it.

Reproducer: choose My Settings, then any icon, such as About Me, then press ```ESCAPE``` key once.  Examine shell.log.