### PR TITLE
add control panel section view deferrable property

### DIFF
--- a/extensions/cpsection/aboutme/view.py
+++ b/extensions/cpsection/aboutme/view.py
@@ -160,6 +160,7 @@ class AboutMe(SectionView):
 
         self._model = model
         self.restart_alerts = alerts if alerts else set()
+        self.props.is_deferrable = False
         self._nick_sid = 0
         self._color_valid = True
         self._nick_valid = True

--- a/extensions/cpsection/backup/view.py
+++ b/extensions/cpsection/backup/view.py
@@ -41,6 +41,7 @@ class BackupView(SectionView):
     def __init__(self, model, alerts=None):
         SectionView.__init__(self)
         self.needs_restart = False
+        self.props.is_deferrable = False
 
         # add the initial panel
         self.set_canvas(SelectBackupRestorePanel(self))

--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -347,7 +347,7 @@ class ControlPanel(Gtk.Window):
                                  _('Cancel changes'), icon)
                 icon.show()
 
-            if self._current_option not in ('aboutme', 'backup'):
+            if self._section_view.props.is_deferrable:
                 icon = Icon(icon_name='dialog-ok')
                 alert.add_button(Gtk.ResponseType.ACCEPT, _('Later'), icon)
                 icon.show()

--- a/src/jarabe/controlpanel/sectionview.py
+++ b/src/jarabe/controlpanel/sectionview.py
@@ -29,6 +29,7 @@ class SectionView(Gtk.VBox):
     __gproperties__ = {
         'is_valid': (bool, None, None, True, GObject.PARAM_READWRITE),
         'is_cancellable': (bool, None, None, True, GObject.PARAM_READWRITE),
+        'is_deferrable': (bool, None, None, True, GObject.PARAM_READWRITE),
     }
 
     _APPLY_TIMEOUT = 1000
@@ -37,6 +38,7 @@ class SectionView(Gtk.VBox):
         Gtk.VBox.__init__(self)
         self._is_valid = True
         self._is_cancellable = True
+        self._is_deferrable = True
         self.auto_close = False
         self.needs_restart = False
         self.restart_alerts = []
@@ -49,12 +51,17 @@ class SectionView(Gtk.VBox):
         if pspec.name == 'is-cancellable':
             if self._is_cancellable != value:
                 self._is_cancellable = value
+        if pspec.name == 'is-deferrable':
+            if self._is_deferrable != value:
+                self._is_deferrable = value
 
     def do_get_property(self, pspec):
         if pspec.name == 'is-valid':
             return self._is_valid
         if pspec.name == 'is-cancellable':
             return self._is_cancellable
+        if pspec.name == 'is-deferrable':
+            return self._is_deferrable
 
     def undo(self):
         """Undo here the changes that have been made in this section."""


### PR DESCRIPTION
The restart warning when committing a section view has a "Later" button, which keeps the changes but does not restart.

About Me and Backup control panels omit the button.

Let external control panels also omit the button.

(For example, http://dev.laptop.org/git/projects/olpc-switch-desktop)