### PR TITLE
fixes for logout hang

### DIFF
--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -24,7 +24,7 @@ from gi.repository import Gdk
 
 from sugar3.graphics.icon import Icon
 from sugar3.graphics import style
-from sugar3.graphics.alert import Alert
+from sugar3.graphics.alert import Alert, TimeoutAlert
 
 from jarabe.model.session import get_session_manager
 from jarabe.controlpanel.toolbar import MainToolbar
@@ -399,8 +399,31 @@ class ControlPanel(Gtk.Window):
                 self._section_view.restart_alerts
             self._show_main_view()
         elif response_id is Gtk.ResponseType.APPLY:
-            session_manager = get_session_manager()
-            session_manager.logout()
+            self.busy()
+            self._section_toolbar.accept_button.set_sensitive(False)
+            self._section_toolbar.cancel_button.set_sensitive(False)
+            get_session_manager().logout()
+            GObject.timeout_add_seconds(4, self.__quit_timeout_cb)
+
+    def __quit_timeout_cb(self):
+        self.unbusy()
+        alert = TimeoutAlert(30)
+        alert.props.title = _('An activity is not responding.')
+        alert.props.msg = _('You may lose unsaved work if you continue.')
+        alert.connect('response', self.__quit_accept_cb)
+
+        self.add_alert(alert)
+        alert.show()
+
+    def __quit_accept_cb(self, alert, response_id):
+        self.remove_alert(alert)
+        if response_id is Gtk.ResponseType.CANCEL:
+            get_session_manager().cancel_shutdown()
+            self._section_toolbar.accept_button.set_sensitive(True)
+            self._section_toolbar.cancel_button.set_sensitive(True)
+        else:
+            self.busy()
+            get_session_manager().shutdown_completed()
 
     def __select_option_cb(self, button, event, option):
         self.show_section_view(option)

--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -110,6 +110,13 @@ class ControlPanel(Gtk.Window):
         self.get_window().set_cursor(cursor)
         Gdk.flush()
 
+    def add_alert(self, alert):
+        self._vbox.pack_start(alert, False, False, 0)
+        self._vbox.reorder_child(alert, 2)
+
+    def remove_alert(self, alert):
+        self._vbox.remove(alert)
+
     def grab_focus(self):
         # overwrite grab focus in order to grab focus on the view
         self._main_view.get_child().grab_focus()
@@ -373,15 +380,14 @@ class ControlPanel(Gtk.Window):
             alert.add_button(Gtk.ResponseType.APPLY, _('Restart now'), icon)
             icon.show()
 
-            self._vbox.pack_start(alert, False, False, 0)
-            self._vbox.reorder_child(alert, 2)
+            self.add_alert(alert)
             alert.connect('response', self.__response_cb)
             alert.show()
         else:
             self._show_main_view()
 
     def __response_cb(self, alert, response_id):
-        self._vbox.remove(alert)
+        self.remove_alert(alert)
         self._section_toolbar.accept_button.set_sensitive(True)
         self._section_toolbar.cancel_button.set_sensitive(True)
         if response_id is Gtk.ResponseType.CANCEL:

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -33,7 +33,7 @@ from sugar3.graphics.icon import Icon
 from sugar3.graphics.icon import CanvasIcon
 from sugar3.graphics.palettemenu import PaletteMenuItem
 from sugar3.graphics.palettemenu import PaletteMenuItemSeparator
-from sugar3.graphics.alert import Alert
+from sugar3.graphics.alert import Alert, ErrorAlert
 from sugar3.graphics.xocolor import XoColor
 from sugar3.activity import activityfactory
 from sugar3 import dispatch
@@ -380,7 +380,7 @@ class FavoritesView(ViewContainer):
 
     def __register(self):
         self._box.remove_alert()
-        alert = Alert()
+        alert = ErrorAlert()
         try:
             schoolserver.register_laptop()
         except RegisterError, e:
@@ -391,11 +391,8 @@ class FavoritesView(ViewContainer):
             alert.props.msg = _('You are now registered '
                                 'with your school server.')
 
-        ok_icon = Icon(icon_name='dialog-ok')
-        alert.add_button(Gtk.ResponseType.OK, _('Ok'), ok_icon)
-
-        self._box.add_alert(alert)
         alert.connect('response', self.__register_alert_response_cb)
+        self._box.add_alert(alert)
         return False
 
     def __register_alert_response_cb(self, alert, response_id):

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -620,11 +620,8 @@ class CurrentActivityIcon(CanvasIcon):
             self.props.xo_color = self._home_activity.get_icon_color()
 
             if self._home_activity.is_journal():
-                if self.get_window():
-                    self.get_window().set_cursor(None)
-                else:
-                    # the window is not visible yet, try again in one second
-                    GLib.timeout_add_seconds(1, self._reset_cursor)
+                if self._unbusy():
+                    GLib.timeout_add(100, self._unbusy)
 
         self.props.pixel_size = style.STANDARD_ICON_SIZE
 
@@ -632,9 +629,10 @@ class CurrentActivityIcon(CanvasIcon):
             self.palette.destroy()
             self.palette = None
 
-    def _reset_cursor(self):
+    def _unbusy(self):
         if self.get_window():
-            self.get_window().set_cursor(None)
+            import jarabe.desktop.homewindow
+            jarabe.desktop.homewindow.get_instance().unbusy()
             return False
         return True
 

--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -109,6 +109,7 @@ class HomeWindow(Gtk.Window):
         self._alerts.append(alert)
         if len(self._alerts) == 1:
             self._display_alert(alert)
+            # FIXME: alerts displayed here are lost on view switch
 
     def remove_alert(self, alert):
         if alert in self._alerts:

--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -62,8 +62,8 @@ class HomeWindow(Gtk.Window):
                               screen.get_height())
 
         self.realize()
-        self.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
-        Gdk.flush()
+        self._busy_count = 0
+        self.busy()
 
         self.set_type_hint(Gdk.WindowTypeHint.DESKTOP)
         self.modify_bg(Gtk.StateType.NORMAL,
@@ -263,18 +263,20 @@ class HomeWindow(Gtk.Window):
     def get_home_box(self):
         return self._home_box
 
-    def busy_during_delayed_action(self, action):
-        """Use busy cursor during execution of action, scheduled via idle_add.
-        """
-        def action_wrapper(old_cursor):
-            try:
-                action()
-            finally:
-                self.get_window().set_cursor(old_cursor)
+    def busy(self):
+        if self._busy_count == 0:
+            self._old_cursor = self.get_window().get_cursor()
+            self._set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
+        self._busy_count += 1
 
-        old_cursor = self.get_window().get_cursor()
-        self.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
-        GLib.idle_add(action_wrapper, old_cursor)
+    def unbusy(self):
+        self._busy_count -= 1
+        if self._busy_count == 0:
+            self._set_cursor(self._old_cursor)
+
+    def _set_cursor(self, cursor):
+        self.get_window().set_cursor(cursor)
+        Gdk.flush()
 
 
 def get_instance():

--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -84,7 +84,7 @@ class HomeWindow(Gtk.Window):
         self._box.pack_start(self._toolbar, False, True, 0)
         self._toolbar.show()
 
-        self._alerts = []
+        self._alert = None
 
         self._home_box = HomeBox(self._toolbar)
         self._box.pack_start(self._home_box, True, True, 0)
@@ -106,23 +106,22 @@ class HomeWindow(Gtk.Window):
             self.__zoom_level_changed_cb)
 
     def add_alert(self, alert):
-        self._alerts.append(alert)
-        if len(self._alerts) == 1:
-            self._display_alert(alert)
-            # FIXME: alerts displayed here are lost on view switch
+        self._alert = alert
+        self._show_alert()
 
     def remove_alert(self, alert):
-        if alert in self._alerts:
-            self._alerts.remove(alert)
-            # if the alert is the visible one on top of the queue
-            if alert.get_parent() is not None:
-                self._box.remove(alert)
-                if len(self._alerts) >= 1:
-                    self._display_alert(self._alerts[0])
+        if alert == self._alert:
+            self._box.remove(self._alert)
+            self._alert = None
 
-    def _display_alert(self, alert):
-        self._box.pack_start(alert, False, False, 0)
-        self._box.reorder_child(alert, 1)
+    def _show_alert(self):
+        if self._alert:
+            self._box.pack_start(self._alert, False, False, 0)
+            self._box.reorder_child(self._alert, 1)
+
+    def _hide_alert(self):
+        if self._alert:
+            self._box.remove(self._alert)
 
     def _deactivate_view(self, level):
         group = palettegroup.get_group('default')
@@ -182,7 +181,7 @@ class HomeWindow(Gtk.Window):
         return False
 
     def __button_pressed_cb(self, widget, event):
-        current_box = self._box.get_children()[1]
+        current_box = self._box.get_children()[-1]
         current_box.grab_focus()
         return False
 
@@ -204,6 +203,7 @@ class HomeWindow(Gtk.Window):
 
         if old_level != ShellModel.ZOOM_ACTIVITY and \
            new_level != ShellModel.ZOOM_ACTIVITY:
+            self._hide_alert()
             children = self._box.get_children()
             if len(children) >= 2:
                 self._box.remove(children[1])
@@ -235,6 +235,7 @@ class HomeWindow(Gtk.Window):
         if level == ShellModel.ZOOM_ACTIVITY:
             return
 
+        self._hide_alert()
         children = self._box.get_children()
         if len(children) >= 2:
             self._box.remove(children[1])
@@ -260,6 +261,7 @@ class HomeWindow(Gtk.Window):
             self._toolbar.set_placeholder_text_for_view(_('Neighborhood'))
             self._mesh_box.grab_focus()
             self._toolbar.hide_view_buttons()
+        self._show_alert()
 
     def get_home_box(self):
         return self._home_box

--- a/src/jarabe/model/session.py
+++ b/src/jarabe/model/session.py
@@ -64,8 +64,15 @@ class SessionManager(GObject.GObject):
         self.shutdown_signal.emit()
         self.session.initiate_shutdown()
 
+    def cancel_shutdown(self):
+        self.session.cancel_shutdown()
+        self._shutdown_tries = 0
+        self._logout_mode = None
+
     def __shutdown_completed_cb(self, session):
-        GObject.timeout_add_seconds(self.SHUTDOWN_TIMEOUT, self._try_shutdown)
+        if self._logout_mode is not None:
+            if self._try_shutdown():
+                GObject.timeout_add(self.SHUTDOWN_TIMEOUT, self._try_shutdown)
 
     def _try_shutdown(self):
         if len(self._shell_model) > 0:

--- a/src/jarabe/view/buddymenu.py
+++ b/src/jarabe/view/buddymenu.py
@@ -32,6 +32,7 @@ from jarabe.model import shell
 from jarabe.model import friends
 from jarabe.model.session import get_session_manager
 from jarabe.controlpanel.gui import ControlPanel
+import jarabe.desktop.homewindow
 
 
 class BuddyMenu(Palette):
@@ -124,10 +125,8 @@ class BuddyMenu(Palette):
         item.show()
 
     def _quit(self, action):
-        import jarabe.desktop.homewindow
-
-        home_window = jarabe.desktop.homewindow.get_instance()
-        home_window.busy_during_delayed_action(action)
+        jarabe.desktop.homewindow.get_instance().busy()
+        action()
 
     def __logout_activate_cb(self, menu_item):
         self._quit(get_session_manager().logout)

--- a/src/jarabe/view/buddymenu.py
+++ b/src/jarabe/view/buddymenu.py
@@ -21,11 +21,13 @@ from gettext import gettext as _
 
 from gi.repository import Gtk
 from gi.repository import Gio
+from gi.repository import GObject
 import dbus
 
 from sugar3.graphics.palette import Palette
 from sugar3.graphics.palettemenu import PaletteMenuItem
 from sugar3.graphics.icon import Icon
+from sugar3.graphics.alert import TimeoutAlert
 from sugar3.graphics import style
 
 from jarabe.model import shell
@@ -127,6 +129,25 @@ class BuddyMenu(Palette):
     def _quit(self, action):
         jarabe.desktop.homewindow.get_instance().busy()
         action()
+        GObject.timeout_add_seconds(3, self.__quit_timeout_cb)
+
+    def __quit_timeout_cb(self):
+        jarabe.desktop.homewindow.get_instance().unbusy()
+        alert = TimeoutAlert(30)
+        alert.props.title = _('An activity is not responding.')
+        alert.props.msg = _('You may lose unsaved work if you continue.')
+        alert.connect('response', self.__quit_accept_cb)
+
+        jarabe.desktop.homewindow.get_instance().add_alert(alert)
+        alert.show()
+
+    def __quit_accept_cb(self, alert, response_id):
+        jarabe.desktop.homewindow.get_instance().remove_alert(alert)
+        if response_id is Gtk.ResponseType.CANCEL:
+            get_session_manager().cancel_shutdown()
+        else:
+            jarabe.desktop.homewindow.get_instance().busy()
+            get_session_manager().shutdown_completed()
 
     def __logout_activate_cb(self, menu_item):
         self._quit(get_session_manager().logout)

--- a/src/jarabe/view/keyhandler.py
+++ b/src/jarabe/view/keyhandler.py
@@ -160,6 +160,7 @@ class KeyHandler(object):
     def handle_logout(self, event_time):
         if "SUGAR_DEVELOPER" in os.environ:
             session.get_session_manager().logout()
+            # FIXME: deal more cleanly with no response to save yourself
 
     def handle_open_search(self, event_time):
         journalactivity.get_journal().show_journal()

--- a/src/jarabe/view/keyhandler.py
+++ b/src/jarabe/view/keyhandler.py
@@ -18,6 +18,7 @@
 import os
 import logging
 
+from gi.repository import GObject
 from gi.repository import Gdk
 from gi.repository import SugarExt
 
@@ -159,8 +160,9 @@ class KeyHandler(object):
 
     def handle_logout(self, event_time):
         if "SUGAR_DEVELOPER" in os.environ:
-            session.get_session_manager().logout()
-            # FIXME: deal more cleanly with no response to save yourself
+            session_manager = session.get_session_manager()
+            session_manager.logout()
+            GObject.timeout_add_seconds(3, session_manager.shutdown_completed)
 
     def handle_open_search(self, event_time):
         journalactivity.get_journal().show_journal()


### PR DESCRIPTION
A series of fixes for failure to logout, restart or shutdown, when an activity is hung.  See the individual commits for narrative detail.

To cause a logout failure alert, start Terminal, then start ```xclock``` or ```xterm```, then click on the Terminal and press Ctrl-Z, this sends a SIGSTOP to the child process. Now switch to home view or control panel and try to logout, restart, or shutdown.

Other methods are to send SIGSTOP to any activity process.

Other test cases:

 - check there is a busy cursor during startup and it goes away once journal is ready,

 - check there is a busy cursor during shutdown, restart, or logout, if there is enough time to see it,

 - make an activity not respond, check the logout failure alert appears,

 - click cancel on the alert, switch to the hung activity, unhang it, resume working; the system shall not quit,

 - click cancel on the alert, switch to the hung activity, switch to home view, try logout again, click cancel, switch to hung activity, unhang it, resume working; the system shall not quit,

 - click continue on the alert; the system shall quit,

 - allow the timer to expire; the system shall quit.

Replaces https://github.com/sugarlabs/sugar/pull/587

Requires https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/263 and https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/266.

References http://lists.sugarlabs.org/archive/sugar-devel/2015-October/050877.html