### PR TITLE
check before remove on control panel section end

### DIFF
--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -110,7 +110,7 @@ class ControlPanel(Gtk.Window):
             self._setup_options()
 
     def _set_canvas(self, canvas):
-        if self._canvas:
+        if self._canvas in self._main_view:
             self._main_view.remove(self._canvas)
         if canvas:
             self._main_view.add(canvas)


### PR DESCRIPTION
A critical message appears in shell.log when a control panel section is removed from screen:

```(main.py:6713): Gtk-CRITICAL **: gtk_container_remove: assertion 'gtk_widget_get_parent (widget) == GTK_WIDGET (container) || GTK_IS_ASSISTANT (container)' failed```

There is no other effect of the message.

Fix the warning by checking the object is in the container before trying to remove it.

Since None can't be a child of the container, the check for None is redundant, so is removed.  (This complication requested by review on https://github.com/sugarlabs/sugar/pull/588).

Reproducer: choose My Settings, then any icon, such as About Me, then press ```ESCAPE``` key once.  Examine shell.log.

Replaces https://github.com/sugarlabs/sugar/pull/588