### PR TITLE
serial number helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ data/sugar.xml
 data/sugar-xo.gtkrc
 data/sugar-emulator.desktop
 data/org.sugar.brightness.policy
+data/org.sugar.serial-number.policy

--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -1,4 +1,5 @@
 python_scripts =		\
+	sugar-serial-number-helper	\
 	sugar-backlight-helper	\
 	sugar-backlight-setup	\
 	sugar-control-panel	\

--- a/bin/sugar-serial-number-helper
+++ b/bin/sugar-serial-number-helper
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+device=/sys/class/dmi/id
+
+read value < $device/product_serial
+echo "$value"

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -66,11 +66,10 @@ gsettings_SCHEMAS = org.sugarlabs.gschema.xml
 convertdir = $(datarootdir)/GConf/gsettings
 convert_DATA = sugar-schemas.convert
 
-org.sugar.brightness.policy: org.sugar.brightness.policy.in
-	sed -e "s|\@bindir\@|$(bindir)|g" $< > $@
+%.policy : %.policy.in ; sed -e "s|\@bindir\@|$(bindir)|g" $< > $@
 
 polkit_policydir = $(datadir)/polkit-1/actions
-polkit_in_files = org.sugar.brightness.policy.in
+polkit_in_files = org.sugar.brightness.policy.in org.sugar.serial-number.policy.in
 polkit_policy_DATA = $(polkit_in_files:.policy.in=.policy)
 
 EXTRA_DIST = $(sugar_DATA) $(xsessions_DATA) $(nmservice_DATA) $(mime_xml_in_files) em.py gtkrc.em $(schema_in_files) $(icon_DATA) $(gsettings_SCHEMAS) $(convert_DATA) $(polkit_in_files)

--- a/data/org.sugar.serial-number.policy.in
+++ b/data/org.sugar.serial-number.policy.in
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+
+  <vendor>Sugar</vendor>
+  <vendor_url>https://www.sugarlabs.org</vendor_url>
+  <icon_name>battery</icon_name>
+
+  <action id="org.sugar.serial-number-helper">
+    <_description>Read serial number</_description>
+    <_message>Reading the serial number of your computer requires authentication</_message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">@bindir@/sugar-serial-number-helper</annotate>
+  </action>
+
+</policyconfig>

--- a/extensions/cpsection/aboutcomputer/model.py
+++ b/extensions/cpsection/aboutcomputer/model.py
@@ -23,6 +23,7 @@ import errno
 import time
 
 from gi.repository import Gio
+from gi.repository import GLib
 
 from jarabe import config
 from jarabe.model.network import get_wireless_interfaces
@@ -35,6 +36,7 @@ _DMI_DIRECTORY = '/sys/class/dmi/id'
 _logger = logging.getLogger('ControlPanel - AboutComputer')
 _not_available = _('Not available')
 
+_serial_no = None
 
 def get_aboutcomputer():
     msg = 'Serial Number: %s \nBuild Number: %s \nFirmware Number: %s \n' \
@@ -46,11 +48,38 @@ def print_aboutcomputer():
     print get_aboutcomputer()
 
 
-def get_serial_number():
+def _get_serial_number():
     serial_no = _read_device_tree('serial-number')
-    if serial_no is None:
-        serial_no = _not_available
-    return serial_no
+    if serial_no is not None:
+        return serial_no
+
+    def _helper():
+        binary = 'sugar-serial-number-helper'
+        for path in os.environ['PATH'].split(os.pathsep):
+            binary_path = os.path.join(path, binary)
+            if os.path.exists(binary_path):
+                return binary_path
+        return None
+
+    helper = _helper()
+    if helper is None:
+        return _not_available
+
+    cmd = 'pkexec %s' % helper
+    result, output, error, status = GLib.spawn_command_line_sync(cmd)
+    if status != 0:
+        return _not_available
+
+    return output.rstrip('\0\n')
+
+
+def get_serial_number():
+    global _serial_no
+
+    if _serial_no is None:
+        _serial_no = _get_serial_number()
+
+    return _serial_no
 
 
 def print_serial_number():

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,2 +1,3 @@
 data/sugar.xml.in
 data/org.sugar.brightness.policy.in
+data/org.sugar.serial-number.policy.in


### PR DESCRIPTION
On commodity x86 and x86_64 hardware the serial number is available to
root in /sys/class/dmi/id/product_serial, but Sugar does not run as
root, so per commit 612842c the string "Not available" is shown.

Add a polkit helper to read the serial number.