### PR TITLE
Add setting for frame trigger size, fixes #4835

### DIFF
--- a/data/org.sugarlabs.gschema.xml
+++ b/data/org.sugarlabs.gschema.xml
@@ -152,6 +152,11 @@
             <summary>Corner Delay</summary>
             <description>Delay for the activation of the frame using the corners.</description>
         </key>
+        <key name="trigger-size" type="i">
+            <default>1</default>
+            <summary>Trigger Size</summary>
+            <description>Size of the frame trigger area, in px from the corner/edge.</description>
+        </key>
     </schema>
     <schema id="org.sugarlabs.collaboration" path="/org/sugarlabs/collaboration/">
         <key name="jabber-server" type="s">

--- a/extensions/cpsection/frame/model.py
+++ b/extensions/cpsection/frame/model.py
@@ -67,3 +67,32 @@ def set_edge_delay(delay):
     settings = Gio.Settings('org.sugarlabs.frame')
     settings.set_int('edge-delay', int(delay))
     return 0
+
+
+def get_trigger_size():
+    settings = Gio.Settings('org.sugarlabs.frame')
+    edge_delay = settings.get_int('edge-delay')
+    return edge_delay
+
+
+def print_trigger_size():
+    print '{}px'.format(get_trigger_size())
+
+
+def set_trigger_size(size):
+    """
+    Set the size of the frame trigger area, in px from the corner/edge.
+
+    exactly on the edge: 1
+    """
+    try:
+        int(size)
+    except ValueError:
+        raise ValueError(_('Value must be an integer.'))
+
+    if int(size) < 1:
+        raise ValueError(_('Value must be more than 1.'))
+
+    settings = Gio.Settings('org.sugarlabs.frame')
+    settings.set_int('trigger-size', int(size))
+    return 0

--- a/extensions/cpsection/frame/view.py
+++ b/extensions/cpsection/frame/view.py
@@ -41,6 +41,9 @@ class Frame(SectionView):
         self._edge_delay_sid = 0
         self._edge_delay_is_valid = True
         self._edge_delay_change_handler = None
+        self._trigger_size_sid = 0
+        self._trigger_size_is_valid = True
+        self._trigger_size_change_handler = None
         self.restart_alerts = alerts
 
         self.set_border_width(style.DEFAULT_SPACING * 2)
@@ -67,6 +70,10 @@ class Frame(SectionView):
         self._edge_delay_slider = None
         self._edge_delay_alert = None
         self._setup_edge()
+
+        self._trigger_size_slider = None
+        self._trigger_size_alert = None
+        self._setup_trigger()
 
         self.pack_start(self._box_sliders, False, True, 0)
         self._box_sliders.show()
@@ -145,26 +152,69 @@ class Frame(SectionView):
             self._edge_delay_alert.props.msg = self.restart_msg
             self._edge_delay_alert.show()
 
+    def _setup_trigger(self):
+        box_trigger = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        label_trigger = Gtk.Label(label=_('Trigger Size'))
+        label_trigger.set_alignment(1, 0.75)
+        label_trigger.modify_fg(Gtk.StateType.NORMAL,
+                                style.COLOR_SELECTION_GREY.get_gdk_color())
+        box_trigger.pack_start(label_trigger, False, True, 0)
+        self._group.add_widget(label_trigger)
+        label_trigger.show()
+
+        adj = Gtk.Adjustment(value=1, lower=1, upper=style.GRID_CELL_SIZE,
+                             step_incr=1, page_incr=1, page_size=0)
+        self._trigger_size_slider = Gtk.HScale()
+        self._trigger_size_slider.set_adjustment(adj)
+        self._trigger_size_slider.set_digits(0)
+        self._trigger_size_slider.connect('format-value',
+                                          self.__trigger_size_format_cb)
+        box_trigger.pack_start(self._trigger_size_slider, True, True, 0)
+        self._trigger_size_slider.show()
+        self._box_sliders.pack_start(box_trigger, False, True, 0)
+        box_trigger.show()
+
+        self._trigger_size_alert = InlineAlert()
+        label_trigger_error = Gtk.Label()
+        self._group.add_widget(label_trigger_error)
+
+        trigger_alert_box = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        trigger_alert_box.pack_start(label_trigger_error, False, True, 0)
+        label_trigger_error.show()
+        trigger_alert_box.pack_start(self._trigger_size_alert, False, True, 0)
+        self._box_sliders.pack_start(trigger_alert_box, False, True, 0)
+        trigger_alert_box.show()
+        if 'trigger_size' in self.restart_alerts:
+            self._trigger_size_alert.props.msg = self.restart_msg
+            self._trigger_size_alert.show()
+
     def setup(self):
         self._corner_delay_slider.set_value(self._model.get_corner_delay())
         self._edge_delay_slider.set_value(self._model.get_edge_delay())
+        self._trigger_size_slider.set_value(self._model.get_trigger_size())
         self._corner_delay_is_valid = True
         self._edge_delay_is_valid = True
+        self._trigger_size_is_valid = True
         self.needs_restart = False
         self._corner_delay_change_handler = self._corner_delay_slider.connect(
             'value-changed', self.__corner_delay_changed_cb)
         self._edge_delay_change_handler = self._edge_delay_slider.connect(
             'value-changed', self.__edge_delay_changed_cb)
+        self._trigger_size_change_handler = self._trigger_size_slider.connect(
+            'value-changed', self.__trigger_size_changed_cb)
 
     def undo(self):
         self._corner_delay_slider.disconnect(self._corner_delay_change_handler)
         self._edge_delay_slider.disconnect(self._edge_delay_change_handler)
+        self._trigger_size_slider.disconnect(self._trigger_size_change_handler)
         self._model.undo()
         self._corner_delay_alert.hide()
         self._edge_delay_alert.hide()
+        self._trigger_size_alert.hide()
 
     def _validate(self):
-        if self._edge_delay_is_valid and self._corner_delay_is_valid:
+        if self._edge_delay_is_valid and self._corner_delay_is_valid \
+           and self._trigger_size_is_valid:
             self.props.is_valid = True
         else:
             self.props.is_valid = False
@@ -192,6 +242,8 @@ class Frame(SectionView):
 
         self._validate()
         self._corner_delay_alert.show()
+        # This may effect the trigger slider label
+        self._trigger_size_slider.queue_draw()
         return False
 
     def __corner_delay_format_cb(self, scale, value):
@@ -225,6 +277,8 @@ class Frame(SectionView):
 
         self._validate()
         self._edge_delay_alert.show()
+        # This may effect the trigger slider label
+        self._trigger_size_slider.queue_draw()
         return False
 
     def __edge_delay_format_cb(self, scale, value):
@@ -235,6 +289,48 @@ class Frame(SectionView):
         else:
             return _seconds_label % (value / _MAX_DELAY)
 
+    def __trigger_size_changed_cb(self, scale, data=None):
+        if self._trigger_size_sid:
+            GObject.source_remove(self._trigger_size_sid)
+        self._trigger_size_sid = GObject.timeout_add(
+            self._APPLY_TIMEOUT, self.__trigger_size_timeout_cb, scale)
+
+    def __trigger_size_timeout_cb(self, scale):
+        self._trigger_size_sid = 0
+        if scale.get_value() == self._model.get_trigger_size():
+            return
+        try:
+            self._model.set_trigger_size(scale.get_value())
+        except ValueError, detail:
+            self._trigger_size_alert.props.msg = detail
+            self._trigger_size_is_valid = False
+        else:
+            self._trigger_size_alert.props.msg = self.restart_msg
+            self._trigger_size_is_valid = True
+            self.needs_restart = True
+            self.restart_alerts.append('trigger_size')
+
+        self._validate()
+        self._trigger_size_alert.show()
+        return False
+
+    def __trigger_size_format_cb(self, scale, value):
+        value = int(value)
+        if value == style.GRID_CELL_SIZE:
+            return _('toolbar size')
+        elif value == 1:
+            corner = self._model.get_corner_delay() < _MAX_DELAY
+            edge = self._model.get_edge_delay() < _MAX_DELAY
+            if corner and edge:
+                return _('exact corner or edge')
+            elif corner:
+                return _('exact corner')
+            else:
+                return _('exact edge')
+        else:
+            # TRANS: px as in pixels
+            return _('{}px').format(value)
+
     def apply(self):
         if self._corner_delay_sid:
             GObject.source_remove(self._corner_delay_sid)
@@ -242,3 +338,6 @@ class Frame(SectionView):
         if self._edge_delay_sid:
             GObject.source_remove(self._edge_delay_sid)
             self.__edge_delay_timeout_cb(self._edge_delay_slider)
+        if self._trigger_size_sid:
+            GObject.source_remove(self._trigger_size_sid)
+            self.__trigger_size_timeout_cb(self._trigger_size_sid)

--- a/src/jarabe/frame/eventarea.py
+++ b/src/jarabe/frame/eventarea.py
@@ -20,6 +20,8 @@ from gi.repository import GObject
 from gi.repository import Wnck
 from gi.repository import Gio
 
+from sugar3.graphics import style
+
 
 _MAX_DELAY = 1000
 
@@ -39,44 +41,49 @@ class EventArea(GObject.GObject):
         settings = Gio.Settings('org.sugarlabs.frame')
         self._edge_delay = settings.get_int('edge-delay')
         self._corner_delay = settings.get_int('corner-delay')
+        self._size = settings.get_int('trigger-size')
 
-        right = Gdk.Screen.width() - 1
-        bottom = Gdk.Screen.height() - 1
-        width = Gdk.Screen.width() - 2
-        height = Gdk.Screen.height() - 2
+        if self._size > style.GRID_CELL_SIZE:
+            # This should never happen and will block the user
+            self._size = style.GRID_CELL_SIZE
+
+        right = Gdk.Screen.width() - self._size
+        bottom = Gdk.Screen.height() - self._size
+        width = Gdk.Screen.width() - self._size * 2
+        height = Gdk.Screen.height() - self._size * 2
 
         if self._edge_delay != _MAX_DELAY:
-            invisible = self._create_invisible(1, 0, width, 1,
-                                               self._edge_delay)
+            invisible = self._create_invisible(
+                self._size, 0, width, self._size, self._edge_delay)
             self._windows.append(invisible)
 
-            invisible = self._create_invisible(1, bottom, width, 1,
-                                               self._edge_delay)
+            invisible = self._create_invisible(
+                self._size, bottom, width, self._size, self._edge_delay)
             self._windows.append(invisible)
 
-            invisible = self._create_invisible(0, 1, 1, height,
-                                               self._edge_delay)
+            invisible = self._create_invisible(
+                0, self._size, self._size, height, self._edge_delay)
             self._windows.append(invisible)
 
-            invisible = self._create_invisible(right, 1, 1, height,
-                                               self._edge_delay)
+            invisible = self._create_invisible(
+                right, self._size, self._size, height, self._edge_delay)
             self._windows.append(invisible)
 
         if self._corner_delay != _MAX_DELAY:
-            invisible = self._create_invisible(0, 0, 1, 1,
-                                               self._corner_delay)
+            invisible = self._create_invisible(
+                0, 0, self._size, self._size, self._corner_delay)
             self._windows.append(invisible)
 
-            invisible = self._create_invisible(right, 0, 1, 1,
-                                               self._corner_delay)
+            invisible = self._create_invisible(
+                right, 0, self._size, self._size, self._corner_delay)
             self._windows.append(invisible)
 
-            invisible = self._create_invisible(0, bottom, 1, 1,
-                                               self._corner_delay)
+            invisible = self._create_invisible(
+                0, bottom, self._size, self._size, self._corner_delay)
             self._windows.append(invisible)
 
-            invisible = self._create_invisible(right, bottom, 1, 1,
-                                               self._corner_delay)
+            invisible = self._create_invisible(
+                right, bottom, self._size, self._size, self._corner_delay)
             self._windows.append(invisible)
 
         screen = Wnck.Screen.get_default()


### PR DESCRIPTION
Replaces #601 

When sugar is run inside a window, the frame trigger is a very small
target to hit.  This can be improved by making the trigger area bigger,
however it is only needed in some environments, not those where sugar
is fullscreen.

Ticket URL  <https://bugs.sugarlabs.org/ticket/4835>