### PR TITLE
Specify library version prior to import, fixes #4900

### DIFF
--- a/extensions/deviceicon/frame.py
+++ b/extensions/deviceicon/frame.py
@@ -27,7 +27,9 @@ import jarabe.frame
 _ICON_NAME = 'module-keyboard'
 _HAS_MALIIT = False
 
+import gi
 try:
+    gi.require_version('Maliit', '1.0')
     from gi.repository import Maliit
 except ImportError:
     logging.debug('Frame: can not create OSK icon: Maliit is not installed.')

--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -52,6 +52,15 @@ os.environ['SUGAR_VERSION'] = config.version
 from dbus.mainloop.glib import DBusGMainLoop
 DBusGMainLoop(set_as_default=True)
 
+# define the versions of used libraries that are required
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('Gst', '1.0')
+gi.require_version('Wnck', '3.0')
+gi.require_version('SugarExt', '1.0')
+gi.require_version('GdkX11', '3.0')
+gi.require_version('WebKit', '3.0')
+
 from gi.repository import Gio
 from gi.repository import GLib
 from gi.repository import Gtk

--- a/src/jarabe/model/keyboard.py
+++ b/src/jarabe/model/keyboard.py
@@ -17,6 +17,8 @@
 
 import logging
 
+import gi
+gi.require_version('Xkl', '1.0')
 from gi.repository import Gio
 from gi.repository import GdkX11
 from gi.repository import Xkl

--- a/src/jarabe/util/downloader.py
+++ b/src/jarabe/util/downloader.py
@@ -19,6 +19,8 @@ import os
 from urlparse import urlparse
 import tempfile
 
+import gi
+gi.require_version('Soup', '2.4')
 from gi.repository import GObject
 from gi.repository import Soup
 from gi.repository import Gio

--- a/src/jarabe/view/viewhelp.py
+++ b/src/jarabe/view/viewhelp.py
@@ -20,6 +20,8 @@ import logging
 import os
 import json
 
+import gi
+gi.require_version('SoupGNOME', '2.4')
 from gi.repository import Gtk
 from gi.repository import GObject
 from gi.repository import Gdk

--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -23,6 +23,8 @@ import sys
 import logging
 from gettext import gettext as _
 
+import gi
+gi.require_version('GtkSource', '3.0')
 from gi.repository import GObject
 from gi.repository import Pango
 from gi.repository import Gtk


### PR DESCRIPTION
Replaces #600, no longer assumes Maliit is installed.

Gi has been emitting warnings into the log to do this for some
time now.  Not doing this has also caused bugs, such as #4900.

Ticket URL <https://bugs.sugarlabs.org/ticket/4900>