### PR TITLE
Claim file transfer channels, so empathy does not revieve them

### DIFF
--- a/src/jarabe/model/telepathyclient.py
+++ b/src/jarabe/model/telepathyclient.py
@@ -21,6 +21,7 @@ from dbus import PROPERTIES_IFACE
 from telepathy.interfaces import CLIENT, \
     CHANNEL, \
     CHANNEL_TYPE_TEXT, \
+    CHANNEL_TYPE_FILE_TRANSFER, \
     CLIENT_APPROVER, \
     CLIENT_HANDLER, \
     CLIENT_INTERFACE_REQUESTS
@@ -82,8 +83,14 @@ class TelepathyClient(dbus.service.Object, DBusProperties):
         filter_dict = dbus.Dictionary(text_invitation, signature='sv')
         filters.append(filter_dict)
 
-        logging.debug('__get_filters_approver_cb %r', filters)
+        ft_invitation = {
+            CHANNEL + '.ChannelType': CHANNEL_TYPE_FILE_TRANSFER,
+            CHANNEL + '.TargetHandleType': CONNECTION_HANDLE_TYPE_CONTACT,
+        }
+        filter_dict = dbus.Dictionary(ft_invitation, signature='sv')
+        filters.append(filter_dict)
 
+        logging.debug('__get_filters_approver_cb %r', filters)
         return filters
 
     @dbus.service.method(dbus_interface=CLIENT_HANDLER,


### PR DESCRIPTION
If empathy is installed and the user is sent a file transfer (via
the journal), an empathy dialog will pop up asking the user where
to save the file (in the filesystem, not journal).  This conflicts
with the Sugar ui.

Fixes #4907  <https://bugs.sugarlabs.org/ticket/4907>