### PR TITLE
background control panel, alpha level callbacks

### DIFF
--- a/extensions/cpsection/background/view.py
+++ b/extensions/cpsection/background/view.py
@@ -79,19 +79,27 @@ class Background(SectionView):
 
         alpha_box = Gtk.HBox()
         alpha_buttons = []
-        for i in ['000', '020', '040', '060', '080']:
+        alpha_icons = [
+            [1.0, 'network-wireless-000'],
+            [0.8, 'network-wireless-020'],
+            [0.6, 'network-wireless-040'],
+            [0.4, 'network-wireless-060'],
+            [0.2, 'network-wireless-080'],
+             ]
+        for value, icon_name in alpha_icons:
             if len(alpha_buttons) > 0:
-                alpha_buttons.append(RadioToolButton(group=alpha_buttons[0]))
+                button = RadioToolButton(group=alpha_buttons[0])
             else:
-                alpha_buttons.append(RadioToolButton(group=None))
-            alpha_buttons[-1].set_icon_name('network-wireless-' + i)
-            button_alpha_level = 1.0 - float(i) / 100.
-            alpha_buttons[-1].connect('clicked', self._set_alpha_cb,
-                                      button_alpha_level)
-            alpha_box.pack_start(alpha_buttons[-1], False, True, 0)
-            alpha_buttons[-1].show()
-            if alpha < button_alpha_level + 0.1:
-                alpha_buttons[-1].set_active(True)
+                button = RadioToolButton(group=None)
+            button.set_icon_name(icon_name)
+            button.value = value
+            button.props.active = value == alpha
+            button.show()
+            alpha_box.pack_start(button, False, True, 0)
+            alpha_buttons.append(button)
+
+        for button in alpha_buttons:
+            button.connect('toggled', self._set_alpha_cb)
 
         alpha_alignment = Gtk.Alignment()
         alpha_alignment.set(0.5, 0, 0, 0)
@@ -144,8 +152,9 @@ class Background(SectionView):
     def __unrealize_cb(self, widget):
         self.get_window().set_cursor(None)
 
-    def _set_alpha_cb(self, widget, value):
-        self._model.set_background_alpha_level(value)
+    def _set_alpha_cb(self, widget):
+        if widget.get_active():
+            self._model.set_background_alpha_level(widget.value)
 
     def _get_selected_path(self, widget):
         try:


### PR DESCRIPTION
Gio.Settings changes are memory and processor expensive, because the [instance persists](http://lazka.github.io/pgi-docs/Gio-2.0/classes/Settings.html#Gio.Settings) until the change is flushed to disk.

Extra changes were happening during button creation, and for every click of a button.  By default, the first button is created active by Gtk+.  (See [Gtk.RadioButton](http://lazka.github.io/pgi-docs/Gtk-3.0/classes/RadioButton.html#Gtk.RadioButton)).

When the code tries to set another button as active, the clicked callback for the first button is triggered.  When followed by apply, this can lead to incorrect setting.

Changes in this patch are to:

- ignore callbacks for a button changing from active to inactive, by checking get_active(),

- suppress callbacks during button creation, by connecting the toggled signal after the buttons have been created,

- simplify the button creation code.

Fixes [#4912](https://bugs.sugarlabs.org/ticket/4912).