### PR TITLE
frame key double press consistency

### DIFF
--- a/src/jarabe/view/gesturehandler.py
+++ b/src/jarabe/view/gesturehandler.py
@@ -68,10 +68,7 @@ class GestureHandler(object):
         self._controller.append(swipe)
 
     def __swipe_ended_cb(self, controller, event_direction):
-        if self._frame.is_visible():
-            self._frame.hide()
-        else:
-            self._frame.show()
+        self._frame.toggle()
 
 
 def setup(frame):


### PR DESCRIPTION
When the frame key is pressed rapidly, some presses are ignored, because the animation position is used to determine if the frame is visible.

To fix,

- remove class _KeyListener as it is not required, see also 3e28f56,

- add a flag for whether the frame is wanted or not, self._wanted,

- add a toggle() method, which calls show() or hide() according to last known wanted state, and call it from the mouse enter corner or frame key press methods,

- do not test frame visibility in show() or hide(), depend on _wanted,

- in the gesture handler, use toggle() instead of show() or hide(),

Test case:
```
	xdotool key F6 key F6 key F6
```
should be equivalent in final effect to
```
	xdotool key F6
```
Fixes [#4806](https://bugs.sugarlabs.org/ticket/4806).