### PR TITLE
launcher, reduce redraw area

### DIFF
--- a/src/jarabe/view/launcher.py
+++ b/src/jarabe/view/launcher.py
@@ -47,6 +47,11 @@ class LaunchWindow(Gtk.Window):
         header.show()
         canvas.pack_start(header, False, True, 0)
 
+        box = Gtk.HBox()
+        box.set_size_request(Gdk.Screen.width() / 5, -1)
+        box.show()
+        canvas.pack_start(box, True, True, 0)
+
         self._activity_id = activity_id
 
         self._activity_icon = PulsingIcon(file=icon_path,
@@ -56,7 +61,7 @@ class LaunchWindow(Gtk.Window):
                                         style.XLARGE_ICON_SIZE, 10)
         self._activity_icon.set_pulsing(True)
         self._activity_icon.show()
-        canvas.pack_start(self._activity_icon, True, True, 0)
+        box.pack_start(self._activity_icon, True, False, 0)
 
         footer = Gtk.VBox(spacing=style.DEFAULT_SPACING)
         footer.set_size_request(-1, bar_size)


### PR DESCRIPTION
Reduce the pulsing icon launcher redraw area from full width of screen to maximum size of icon, by packing the icon into a horizontal box with a false fill flag.

Tested on XO-1 and XO-1.5 with Sugar 0.107.0 and Fedora 18.

https://bugs.sugarlabs.org/ticket/4914 (#1)