### PR TITLE
request for comment, not for merging, home view redraw excess

### DIFF
--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -161,6 +161,7 @@ class ControlPanel(Gtk.Window):
         self._table.set_border_width(style.GRID_CELL_SIZE)
 
         self._scrolledwindow = Gtk.ScrolledWindow()
+        self._scrolledwindow.set_can_focus(False)
         self._scrolledwindow.set_policy(Gtk.PolicyType.AUTOMATIC,
                                         Gtk.PolicyType.AUTOMATIC)
         self._scrolledwindow.add_with_viewport(self._table)

--- a/src/jarabe/desktop/activitieslist.py
+++ b/src/jarabe/desktop/activitieslist.py
@@ -55,6 +55,7 @@ class ActivitiesTreeView(Gtk.TreeView):
 
     def __init__(self):
         Gtk.TreeView.__init__(self)
+        self.set_can_focus(False)
 
         self._query = ''
 
@@ -442,6 +443,7 @@ class ActivitiesList(Gtk.VBox):
         Gtk.VBox.__init__(self)
 
         self._scrolled_window = Gtk.ScrolledWindow()
+        self._scrolled_window.set_can_focus(False)
         self._scrolled_window.set_policy(Gtk.PolicyType.NEVER,
                                          Gtk.PolicyType.AUTOMATIC)
         self._scrolled_window.set_shadow_type(Gtk.ShadowType.NONE)

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -127,6 +127,7 @@ class FavoritesView(ViewContainer):
         ViewContainer.__init__(self, layout=self._layout,
                                owner_icon=owner_icon,
                                activity_icon=current_activity)
+        self.set_can_focus(False)
 
         self.add_events(Gdk.EventMask.BUTTON_PRESS_MASK |
                         Gdk.EventMask.POINTER_MOTION_HINT_MASK)

--- a/src/jarabe/desktop/groupbox.py
+++ b/src/jarabe/desktop/groupbox.py
@@ -39,6 +39,7 @@ class GroupBox(ViewContainer):
         owner_icon = BuddyIcon(get_owner_instance(),
                                style.LARGE_ICON_SIZE & ~1)
         ViewContainer.__init__(self, layout, owner_icon)
+        self.set_can_focus(False)
 
         self._query = ''
         toolbar.connect('query-changed', self._toolbar_query_changed_cb)

--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -89,7 +89,6 @@ class HomeWindow(Gtk.Window):
         self._home_box = HomeBox(self._toolbar)
         self._box.pack_start(self._home_box, True, True, 0)
         self._home_box.show()
-        self._home_box.grab_focus()
         self._toolbar.show_view_buttons()
 
         self._group_box = GroupBox(self._toolbar)
@@ -245,21 +244,18 @@ class HomeWindow(Gtk.Window):
             self._home_box.show()
             self._toolbar.clear_query()
             self._toolbar.set_placeholder_text_for_view(_('Home'))
-            self._home_box.grab_focus()
             self._toolbar.show_view_buttons()
         elif level == ShellModel.ZOOM_GROUP:
             self._box.pack_start(self._group_box, True, True, 0)
             self._group_box.show()
             self._toolbar.clear_query()
             self._toolbar.set_placeholder_text_for_view(_('Group'))
-            self._group_box.grab_focus()
             self._toolbar.hide_view_buttons()
         elif level == ShellModel.ZOOM_MESH:
             self._box.pack_start(self._mesh_box, True, True, 0)
             self._mesh_box.show()
             self._toolbar.clear_query()
             self._toolbar.set_placeholder_text_for_view(_('Neighborhood'))
-            self._mesh_box.grab_focus()
             self._toolbar.hide_view_buttons()
         self._show_alert()
 

--- a/src/jarabe/desktop/meshbox.py
+++ b/src/jarabe/desktop/meshbox.py
@@ -365,6 +365,7 @@ class MeshBox(ViewContainer):
         owner_icon = BuddyIcon(get_owner_instance(),
                                style.STANDARD_ICON_SIZE & ~1)
         ViewContainer.__init__(self, layout, owner_icon)
+        self.set_can_focus(False)
 
         self.wireless_networks = {}
         self._adhoc_manager = None

--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -355,6 +355,7 @@ def setup_theme():
             sugar_theme = 'sugar-100'
     settings.set_property('gtk-theme-name', sugar_theme)
     settings.set_property('gtk-icon-theme-name', 'sugar')
+    settings.set_property('gtk-cursor-blink', False)
 
     icons_path = os.path.join(config.data_path, 'icons')
     Gtk.IconTheme.get_default().append_search_path(icons_path)


### PR DESCRIPTION
 - do not let the view children of the home window take focus; this prevents redraw, proving it is the focus change causing [#4914.2](https://bugs.sugarlabs.org/ticket/4914),

 - but as a side effect focus is always in the search box, and the blinking cursor is a bother; it consumes power,

 - gtk-cursor-blink Gdk.Settings might help with the blinking cursor, but don't know how to set them, changing the gtk-widgets.css files did nothing,

 - perhaps a better solution may be to ensure there are no focus rectangles drawn by children of the home window,

Any ideas welcome.