### PR TITLE
fix control panel layout

### DIFF
--- a/extensions/cpsection/modemconfiguration/__init__.py
+++ b/extensions/cpsection/modemconfiguration/__init__.py
@@ -18,4 +18,4 @@ from gettext import gettext as _
 
 CLASS = 'ModemConfiguration'
 ICON = 'module-modemconfiguration'
-TITLE = _('Modem Configuration')
+TITLE = _('Modem')

--- a/extensions/cpsection/webaccount/__init__.py
+++ b/extensions/cpsection/webaccount/__init__.py
@@ -21,4 +21,4 @@ __path__ = extend_path(__path__, __name__)
 
 CLASS = 'WebServicesConfig'
 ICON = 'module-webaccount'
-TITLE = _('Configure your Web Services')
+TITLE = _('Web Services')


### PR DESCRIPTION
Settings icons in the control panel were not evenly distributed, on screens with 1200 pixels horizontal, because some icon titles were very long.

Remove "Configuration" and "Configure your".

(the words are redundant; everything in my settings is a configuration).