### PR TITLE
Allow activities to pass file transfers without shell notification

### DIFF
--- a/src/jarabe/model/filetransfer.py
+++ b/src/jarabe/model/filetransfer.py
@@ -259,6 +259,10 @@ def _new_channels_cb(connection, channels):
         if props[CHANNEL + '.ChannelType'] == CHANNEL_TYPE_FILE_TRANSFER and \
                 not props[CHANNEL + '.Requested']:
 
+            mime = props[CHANNEL_TYPE_FILE_TRANSFER + '.ContentType']
+            if mime == 'x-sugar/from-activity':
+                continue
+
             logging.debug('__new_channels_cb %r', object_path)
 
             incoming_file_transfer = IncomingFileTransfer(connection,
@@ -287,11 +291,20 @@ def _got_dispatch_operation_cb(**kwargs):
     channel_type = channel_properties[CHANNEL + '.ChannelType']
     handle_type = channel_properties[CHANNEL + '.TargetHandleType']
 
-    if handle_type == CONNECTION_HANDLE_TYPE_CONTACT and \
-       channel_type == CHANNEL_TYPE_FILE_TRANSFER:
+    if handle_type != CONNECTION_HANDLE_TYPE_CONTACT or \
+       channel_type != CHANNEL_TYPE_FILE_TRANSFER:
+        return
+
+    mime_type = channel_properties[CHANNEL_TYPE_FILE_TRANSFER + '.ContentType']
+    filename = channel_properties[CHANNEL_TYPE_FILE_TRANSFER + '.Filename']
+
+    bus = dbus.Bus()
+    operation = bus.get_object(CHANNEL_DISPATCHER, dispatch_operation_path)
+    if mime_type == 'x-sugar/from-activity':
+        # The requested activity client is in the file name
+        operation.HandleWith(str(filename))
+    else:
         # We must claim our file transfers so that empathy doesn't get it
-        bus = dbus.Bus()
-        operation = bus.get_object(CHANNEL_DISPATCHER, dispatch_operation_path)
         operation.Claim()
 
 


### PR DESCRIPTION
File transfer channels are a powerful solution for transfering data
1-to-1 over telepathy.  However, currently the shell will try to
claim all file transfer channels and show a notification to the
user.

This commit makes the shell ignore the channel if it has the
content type of 'x-sugar/from-activity'.  It will instead pass it
to the telepathy client specified in the file name.  The file name
was used to house the client name because there does not appear
to be a dedicated place for this information in telepathy.
Activities can still use the description to store their metadata.

**Note**:  This patch makes a lot more sense with the new collab wrapper patch.  There is lots of lines changed in the collab wrapper to use file transfers.  I need to review those myself to before I can share that.  I will update this pull request when that happens.