### PR TITLE
Add the ability for change homeviews names

### DIFF
--- a/src/jarabe/desktop/viewtoolbar.py
+++ b/src/jarabe/desktop/viewtoolbar.py
@@ -205,7 +205,7 @@ class FavoritesButton(RadioToolButton):
     def __init__(self, favorite_view):
         RadioToolButton.__init__(self)
 
-        self.props.tooltip = _('Favorites view %d' % (favorite_view + 1))
+        self.props.tooltip = desktop.get_view_labels()[favorite_view]
         self.props.accelerator = _('<Ctrl>%d' % (favorite_view + 1))
         self.props.group = None
         self.props.icon_name = desktop.get_view_icons()[favorite_view]

--- a/src/jarabe/model/desktop.py
+++ b/src/jarabe/model/desktop.py
@@ -15,6 +15,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
+from gettext import gettext as _
+
 from gi.repository import GObject
 from gi.repository import Gio
 
@@ -37,6 +39,7 @@ class DesktopViewModel(GObject.GObject):
         self._number_of_views = 1
         self._view_icons = None
         self._favorite_icons = None
+        self._view_labels = None
 
         self._settings = Gio.Settings(_DESKTOP_CONF_DIR)
         self._ensure_view_icons()
@@ -58,6 +61,11 @@ class DesktopViewModel(GObject.GObject):
 
     favorite_icons = GObject.property(type=object, getter=get_favorite_icons)
 
+    def get_view_labels(self):
+        return self._view_labels
+
+    view_labels = GObject.property(type=object, getter=get_view_labels)
+
     def _ensure_view_icons(self, update=False):
         if self._view_icons and not update:
             return
@@ -71,6 +79,12 @@ class DesktopViewModel(GObject.GObject):
         self._number_of_views = len(homeviews)
         self._view_icons = [view['view-icon'] for view in homeviews]
         self._favorite_icons = [view['favorite-icon'] for view in homeviews]
+        self._view_labels = []
+        for view in homeviews:
+            if 'view-label' not in view:
+                view['view-label'] = _('Favorites view %d' % (
+                    len(self._view_labels) + 1))
+            self._view_labels.append(view['view-label'])
 
         self.emit('desktop-view-icons-changed')
 
@@ -91,6 +105,10 @@ def get_view_icons():
 
 def get_favorite_icons():
     return get_model().get_favorite_icons()
+
+
+def get_view_labels():
+    return get_model().get_view_labels()
 
 
 def get_number_of_views():


### PR DESCRIPTION
Before the GConf to Gsettings port changing the homeviews names
was possible.

This patch adds the ability to change it again using gsettings
config, "view-label".

How to test:
Follow the instruction for "gsettings instructions for Sugar 102+" in
https://wiki.sugarlabs.org/go/Features/Multiple_home_views
and add the key "view-label" to the homeview you want.

This is a GCI task:
https://codein.withgoogle.com/tasks/4788542454628352/