### PR TITLE
Hide frame on control panel accelerator

### DIFF
--- a/src/jarabe/view/keyhandler.py
+++ b/src/jarabe/view/keyhandler.py
@@ -172,6 +172,9 @@ class KeyHandler(object):
     def handle_open_controlpanel(self, event_time):
         if shell.get_model().has_modal():
             return
+
+        self._frame.hide()
+
         panel = ControlPanel()
         panel.show()
 


### PR DESCRIPTION
Both frame and control panel are visible; by pressing F6 then
Alt-Shift-M.

Hide the frame when the accelerator is used, in the same way that the
buddy menu does hide the frame.

Regression introduced by e43d177.