### PR TITLE
Fix remaining icon_size references

### DIFF
--- a/extensions/deviceicon/audio.py
+++ b/extensions/deviceicon/audio.py
@@ -102,7 +102,7 @@ class AudioManagerWidget(Gtk.VBox):
         self._ok_icon = Icon(icon_name='dialog-ok')
         self._cancel_icon = Icon(icon_name='dialog-cancel')
 
-        icon = Icon(icon_size=Gtk.IconSize.MENU)
+        icon = Icon(pixel_size=style.SMALL_ICON_SIZE)
         icon.props.icon_name = icon_name
         icon.props.xo_color = XoColor('%s,%s' % (style.COLOR_WHITE.get_svg(),
                                       style.COLOR_BUTTON_GREY.get_svg()))

--- a/extensions/deviceicon/display.py
+++ b/extensions/deviceicon/display.py
@@ -89,7 +89,7 @@ class BrightnessManagerWidget(Gtk.VBox):
         self._progress_bar = None
         self._adjustment = None
 
-        icon = Icon(icon_size=Gtk.IconSize.MENU)
+        icon = Icon(pixel_size=style.SMALL_ICON_SIZE)
         icon.props.icon_name = icon_name
         icon.props.xo_color = XoColor('%s,%s' % (style.COLOR_WHITE.get_svg(),
                                       style.COLOR_BUTTON_GREY.get_svg()))

--- a/src/jarabe/desktop/networkviews.py
+++ b/src/jarabe/desktop/networkviews.py
@@ -117,7 +117,7 @@ class WirelessNetworkView(EventPulsingIcon):
     def _create_palette(self):
         icon_name = get_icon_state(_AP_ICON_NAME, self._strength)
         self._palette_icon = Icon(icon_name=icon_name,
-                                  icon_size=style.STANDARD_ICON_SIZE,
+                                  pixel_size=style.STANDARD_ICON_SIZE,
                                   badge_name=self.props.badge_name)
 
         p = palette.Palette(primary_text=self._display_name,
@@ -491,7 +491,7 @@ class SugarAdhocView(EventPulsingIcon):
     def _create_palette(self):
         self._palette_icon = Icon(
             icon_name=self._ICON_NAME + str(self._channel),
-            icon_size=style.STANDARD_ICON_SIZE)
+            pixel_size=style.STANDARD_ICON_SIZE)
 
         palette_ = palette.Palette(_('Ad-hoc Network %d') % (self._channel, ),
                                    icon=self._palette_icon)

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -922,11 +922,11 @@ class FilterToolItem(Gtk.ToolButton):
     def set_widget_icon(self, icon_name=None, file_name=None):
         if file_name is not None:
             icon = Icon(file=file_name,
-                        icon_size=style.SMALL_ICON_SIZE,
+                        pixel_size=style.SMALL_ICON_SIZE,
                         xo_color=XoColor('white'))
         else:
             icon = Icon(icon_name=icon_name,
-                        icon_size=style.SMALL_ICON_SIZE,
+                        pixel_size=style.SMALL_ICON_SIZE,
                         xo_color=XoColor('white'))
         self.set_icon_widget(icon)
         icon.show()

--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -531,7 +531,7 @@ class BuddyPalette(Palette):
 
         nick, colors = buddy
         buddy_icon = Icon(icon_name='computer-xo',
-                          icon_size=style.STANDARD_ICON_SIZE,
+                          pixel_size=style.STANDARD_ICON_SIZE,
                           xo_color=XoColor(colors))
 
         Palette.__init__(self, primary_text=nick, icon=buddy_icon)


### PR DESCRIPTION
icon_size was changed to pixel_size, yet several references remained,
causing extra log data.

Previous #630.