### PR TITLE
Configurable launcher pulsing icon interval

### DIFF
--- a/data/org.sugarlabs.gschema.xml
+++ b/data/org.sugarlabs.gschema.xml
@@ -140,6 +140,11 @@
             <summary>Home views</summary>
             <description>List of home views, including the view icon, the favorite icon and the layout</description>
         </key>
+        <key name="launcher-interval" type="i">
+            <default>100</default>
+            <summary>Launcher animation interval</summary>
+            <description>Delay in milliseconds between animation updates for launcher pulsing icon.</description>
+        </key>
     </schema>
     <schema id="org.sugarlabs.frame" path="/org/sugarlabs/frame/">
         <key name="edge-delay" type="i">

--- a/src/jarabe/view/launcher.py
+++ b/src/jarabe/view/launcher.py
@@ -17,6 +17,7 @@
 import logging
 from gettext import gettext as _
 
+from gi.repository import Gio
 from gi.repository import Gtk
 from gi.repository import Gdk
 
@@ -25,6 +26,9 @@ from sugar3.graphics import style
 
 from jarabe.model import shell
 from jarabe.view.pulsingicon import PulsingIcon
+
+
+_INTERVAL = 100
 
 
 class LaunchWindow(Gtk.Window):
@@ -55,7 +59,8 @@ class LaunchWindow(Gtk.Window):
         self._activity_id = activity_id
 
         self._activity_icon = PulsingIcon(file=icon_path,
-                                          pixel_size=style.XLARGE_ICON_SIZE)
+                                          pixel_size=style.XLARGE_ICON_SIZE,
+                                          interval=_INTERVAL)
         self._activity_icon.set_base_color(icon_color)
         self._activity_icon.set_zooming(style.SMALL_ICON_SIZE,
                                         style.XLARGE_ICON_SIZE, 10)
@@ -116,6 +121,11 @@ class LaunchWindow(Gtk.Window):
 
 
 def setup():
+    global _INTERVAL
+
+    settings = Gio.Settings('org.sugarlabs.desktop')
+    _INTERVAL = settings.get_int('launcher-interval')
+
     model = shell.get_model()
     model.connect('launch-started', __launch_started_cb)
     model.connect('launch-failed', __launch_failed_cb)

--- a/src/jarabe/view/pulsingicon.py
+++ b/src/jarabe/view/pulsingicon.py
@@ -29,9 +29,10 @@ _MINIMAL_ALPHA_VALUE = 0.33
 
 
 class Pulser(object):
-    def __init__(self, icon):
+    def __init__(self, icon, interval=_INTERVAL):
         self._pulse_hid = None
         self._icon = icon
+        self._interval = interval
         self._phase = 0
         self._start_scale = 1.0
         self._end_scale = 1.0
@@ -52,7 +53,8 @@ class Pulser(object):
         if restart:
             self._phase = 0
         if self._pulse_hid is None:
-            self._pulse_hid = GObject.timeout_add(_INTERVAL, self.__pulse_cb)
+            self._pulse_hid = GObject.timeout_add(self._interval,
+                                                  self.__pulse_cb)
         if self._start_scale != self._end_scale:
             self._icon.scale = self._start_scale + \
                 self._current_scale_step * self._current_zoom_step
@@ -84,8 +86,8 @@ class Pulser(object):
 class PulsingIcon(Icon):
     __gtype_name__ = 'SugarPulsingIcon'
 
-    def __init__(self, **kwargs):
-        self._pulser = Pulser(self)
+    def __init__(self, interval=_INTERVAL, **kwargs):
+        self._pulser = Pulser(self, interval)
         self._base_color = None
         self._pulse_color = None
         self._paused = False
@@ -174,8 +176,8 @@ class PulsingIcon(Icon):
 class EventPulsingIcon(CanvasIcon):
     __gtype_name__ = 'SugarEventPulsingIcon'
 
-    def __init__(self, **kwargs):
-        self._pulser = Pulser(self)
+    def __init__(self, interval=_INTERVAL, **kwargs):
+        self._pulser = Pulser(self, interval)
         self._base_color = None
         self._pulse_color = None
         self._paused = False


### PR DESCRIPTION
On some computers, the activity startup pulsing icon steals resources, increasing startup time.

Add a launcher-interval setting, and use it in pulsing icon.

Test case:
```
gsettings set org.sugarlabs.desktop launcher-interval 500
```
Then restart Sugar.  The pulsing icon should be slow.

Measurements:

On one of the oldest computers that Sugar is used, an OLPC XO-1, CPU usage of the X server and Jarabe were measured during launch of Moon activity using top(1):

- launcher-interval=50 ms, gave 42% usage,

- launcher-interval=100 ms, gave 21% usage,

- launcher-interval=500 ms, gave 8% usage,

- launcher-interval=1000 ms, gave 4% usage.

Test configuration was Fedora 18 with Sugar 0.107.0, and commit d349379 (launcher, reduce redraw area).

References:

- olpc-os-builder/v7.0 [xo1: reduce pulsing icon rate](http://dev.laptop.org/git/projects/olpc-os-builder/commit/?h=v7.0&id=28b669a1004207b537fe82e2211a44acfbb60a6a)