### PR TITLE
Neighborhood buddies aren't placed randomly

### DIFF
--- a/src/jarabe/desktop/favoriteslayout.py
+++ b/src/jarabe/desktop/favoriteslayout.py
@@ -172,7 +172,15 @@ class SpreadLayout(ViewLayout):
         for child in children:
             if not self._grid.is_in_grid(child):
                 width, height = self._get_child_grid_size(child)
-                self._grid.add(child, width, height, None, None, locked=False)
+                x = y = None
+                if hasattr(child, "get_buddy"):
+                    md5hash = hashlib.md5(child.get_buddy().get_key())
+                    digest = abs(hash(md5hash.digest()))
+                    w = (self._width - (width * 3)) / 4
+                    h = (self._height - (height * 3)) / 4
+                    x = ((digest & 0xFFFFFFFF) % w) * ((digest >> 126) + 1)
+                    y = ((digest >> 32) % h) * (((digest >> 124) & 0b11) + 1)
+                self._grid.add(child, width, height, x, y, locked=False)
 
             requisition = child.get_preferred_size()[0]
             rect = self._grid.get_child_rect(child)


### PR DESCRIPTION
* Neighborhood buddies are placed according to their key
* Bug ticket 381 (https://bugs.sugarlabs.org/ticket/381)
* This is a GCI 2015 task: https://codein.withgoogle.com/tasks/6733138625560576/