### PR TITLE
Fixed neighborhood icon placing (commit 5c3de75) in 32 bits

### DIFF
--- a/src/jarabe/desktop/favoriteslayout.py
+++ b/src/jarabe/desktop/favoriteslayout.py
@@ -177,10 +177,10 @@ class SpreadLayout(ViewLayout):
                 if hasattr(child, "get_positioning_data"):
                     md5hash = hashlib.md5(child.get_positioning_data())
                     digest = abs(hash(md5hash.digest()))
-                    w = (self._width - (width * 3)) / 4
-                    h = (self._height - (height * 3)) / 4
-                    x = ((digest & 0xFFFFFFFF) % w) * ((digest >> 126) + 1)
-                    y = ((digest >> 32) % h) * (((digest >> 124) & 0b11) + 1)
+                    w = (self._grid.width - (width * 3))
+                    h = (self._grid.height - (width * 3))
+                    x = ((digest & 0xFFFF) % w)
+                    y = ((digest >> 16) % h)
 
                 self._grid.add(child, width, height, x, y, locked=False)
 


### PR DESCRIPTION
* Fixes 5c3de755cb9848154347991fdb369a7ea41004ae
* Now the neighborhood icon placing will work on 32 bits computers
* Supercedes #640