### PR TITLE
Set css name for widgets

### DIFF
--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -481,6 +481,8 @@ class ModelWrapper(object):
                     method(self._options[key])
                 except Exception, detail:
                     _logger.debug('Error undo option: %s', detail)
+if hasattr(ControlPanel, 'set_css_name'):
+    ControlPanel.set_css_name('controlpanel')
 
 
 class _SectionIcon(Gtk.EventBox):

--- a/src/jarabe/controlpanel/sectionview.py
+++ b/src/jarabe/controlpanel/sectionview.py
@@ -66,3 +66,5 @@ class SectionView(Gtk.VBox):
     def undo(self):
         """Undo here the changes that have been made in this section."""
         pass
+if hasattr(SectionView, 'set_css_name'):
+    SectionView.set_css_name('cpanelsectionview')

--- a/src/jarabe/frame/framewindow.py
+++ b/src/jarabe/frame/framewindow.py
@@ -156,3 +156,5 @@ class FrameWindow(Gtk.Window):
 
     def _size_changed_cb(self, screen):
         self._update_size()
+if hasattr(FrameWindow, 'set_css_name'):
+    FrameWindow.set_css_name('framewindow')

--- a/src/jarabe/intro/window.py
+++ b/src/jarabe/intro/window.py
@@ -449,6 +449,8 @@ class IntroWindow(Gtk.Window):
             self._intro_box.back()
             return True
         return False
+if hasattr(IntroWindow, 'set_css_name'):
+    IntroWindow.set_css_name('introwindow')
 
 
 if __name__ == '__main__':

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -981,6 +981,8 @@ class FilterToolItem(Gtk.ToolButton):
             invoker.draw_rectangle(cr, self.palette)
 
         return False
+if hasattr(FilterToolItem, 'set_css_name'):
+    FilterToolItem.set_css_name('filtertoolbutton')
 
 
 def set_palette_list(palette_list):

--- a/src/jarabe/journal/keepicon.py
+++ b/src/jarabe/journal/keepicon.py
@@ -61,3 +61,5 @@ class KeepIcon(Gtk.ToggleButton):
         else:
             self._icon.props.stroke_color = style.COLOR_BUTTON_GREY.get_svg()
             self._icon.props.fill_color = style.COLOR_TRANSPARENT.get_svg()
+if hasattr(KeepIcon, 'set_css_name'):
+    KeepIcon.set_css_name('canvasicon')


### PR DESCRIPTION
Required by https://github.com/sugarlabs/sugar-artwork/pull/86

In Gtk+ 3.20, you need to use the css name to select elements,
rather than the gtype name.  Therefore, these must be added.

The css name must be set before the class instances are created, as
it effects the class rather than the instance.  This is why it must
be places after the class definition.