### PR TITLE
Focus homeview search entry on key press, fixes #4930

### DIFF
--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -166,6 +166,9 @@ class HomeWindow(Gtk.Window):
             self._alt_timeout_sid = GObject.timeout_add(100,
                                                         self.__alt_timeout_cb)
 
+        if not self._toolbar.search_entry.props.has_focus:
+            self._toolbar.search_entry.grab_focus()
+
         return False
 
     def __key_release_event_cb(self, window, event):


### PR DESCRIPTION
This was not done explicitly before, however on Gtk3.19 this
must be done explicitly.  Grabbing focus on the key press event
means that the entry still records that key press.

Ticket URL  <https://bugs.sugarlabs.org/ticket/4930>