### PR TITLE
Set default collaberation model to salut (no jabber server)

### DIFF
--- a/data/org.sugarlabs.gschema.xml
+++ b/data/org.sugarlabs.gschema.xml
@@ -165,7 +165,7 @@
     </schema>
     <schema id="org.sugarlabs.collaboration" path="/org/sugarlabs/collaboration/">
         <key name="jabber-server" type="s">
-            <default>'jabber.sugarlabs.org'</default>
+            <default>''</default>
             <summary>Jabber Server</summary>
             <description>URL of the jabber server to use.</description>
         </key>


### PR DESCRIPTION
This allows for better activity support on newer systems, better
speed and privacy amongst other reasons.  It will not break
exsisting XO or schoolserver workflows.

The changes was discussed in [1].

[1]  http://lists.sugarlabs.org/archive/sugar-devel/2016-January/051187.html

@tchx84 is this ok for 108?