### PR TITLE
Implemented toggled sorting order

### DIFF
--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -695,6 +695,7 @@ class SortingButton(ToolButton):
         ToolButton.__init__(self)
 
         self._property = 'timestamp'
+        self.order_type='ascending'
         self._order = Gtk.SortType.ASCENDING
 
         self.props.tooltip = _('Sort view')
@@ -719,6 +720,7 @@ class SortingButton(ToolButton):
                                icon_name=icon)
             button.set_image(button_icon)
             button_icon.show()
+            
             button.connect('activate',
                            self.__sort_type_changed_cb,
                            property_,
@@ -727,9 +729,20 @@ class SortingButton(ToolButton):
             menu_box.append_item(button)
 
     def __sort_type_changed_cb(self, widget, property_, icon_name):
+        if(self._property == property_):
+              if(self.order_type=='ascending'):
+                   self.order_type='descending'
+              else:
+                   self.order_type='ascending'
+        else:
+             self.order_type='ascending'
+
         self._property = property_
-        # FIXME: Implement sorting order
-        self._order = Gtk.SortType.ASCENDING
+       
+        if(self.order_type=='ascending'):
+                   self._order = Gtk.SortType.ASCENDING
+        else:
+                   self._order=Gtk.SortType.DESCENDING
         self.emit('sort-property-changed')
 
         self.props.icon_name = icon_name

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -693,17 +693,13 @@ class SortingButton(ToolButton):
 
     def __init__(self):
         ToolButton.__init__(self)
-
         self._property = 'timestamp'
         self.order_type='ascending'
         self._order = Gtk.SortType.ASCENDING
-
         self.props.tooltip = _('Sort view')
         self.props.icon_name = 'view-lastedit'
-
         self.props.hide_tooltip_on_click = False
         self.palette_invoker.props.toggle_palette = True
-
         menu_box = PaletteMenuBox()
         self.props.palette.set_content(menu_box)
         menu_box.show()
@@ -727,6 +723,12 @@ class SortingButton(ToolButton):
                            icon)
             button.show()
             menu_box.append_item(button)
+        button = Gtk.ToggleButton('Reverse Order')
+        button.set_active(False)
+        button.connect('toggled',
+                       self.reverse_order)
+        button.show()
+        menu_box.append_item(button)
 
     def __sort_type_changed_cb(self, widget, property_, icon_name):
         if(self._property == property_):
@@ -738,17 +740,27 @@ class SortingButton(ToolButton):
              self.order_type='ascending'
 
         self._property = property_
+<<<<<<< HEAD
        
         if(self.order_type=='ascending'):
                    self._order = Gtk.SortType.ASCENDING
         else:
                    self._order=Gtk.SortType.DESCENDING
+=======
+        self._order = Gtk.SortType.ASCENDING
+>>>>>>> Implemented toggled sorting order
         self.emit('sort-property-changed')
-
         self.props.icon_name = icon_name
 
     def get_current_sort(self):
         return (self._property, self._order)
+
+    def reverse_order(self, button):
+        if button.get_active():
+            self._order = Gtk.SortType.DESCENDING
+        else:
+            self._order = Gtk.SortType.ASCENDING
+        self.emit('sort-property-changed')
 
 
 class EditToolbox(ToolbarBox):


### PR DESCRIPTION
For Sort view, I observed that it sorts in only one order (i.e. for sort by size its in descending order of size of journal entries, the list remains in descending order of sizes!) .So I added a feature of toggling the sorting order as well (like take for size on first click it shows list in descending order on second click list reverses to ascending order).
