### PR TITLE
Fixed issue #4942 Typo in sugar

### DIFF
--- a/extensions/cpsection/language/view.py
+++ b/extensions/cpsection/language/view.py
@@ -380,7 +380,7 @@ class Language(SectionView):
             logging.exception('Error writing i18n config %s', e)
             self.undo()
             self._lang_alert.props.msg = gettext.gettext(
-                'Error writting language configuration (%s)') % e
+                'Error writing language configuration (%s)') % e
             self._lang_alert.show()
             self.props.is_valid = False
         return False


### PR DESCRIPTION
The typo error of "writting" instead of "writing" fixed.
Fixed issue [#4942](https://bugs.sugarlabs.org/ticket/4942)