### PR TITLE
Fixed #3146: Dragging a Journal entry drags the whole white entry bar instead of icon

### DIFF
--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -23,6 +23,7 @@ from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import Pango
+from gi.repository import GdkPixbuf
 
 from sugar3.graphics import style
 from sugar3.graphics.icon import Icon, CellRendererIcon
@@ -191,10 +192,12 @@ class BaseListView(Gtk.Bin):
         model.deleted.connect(self.__model_deleted_cb)
 
     def enable_drag_and_copy(self):
-        self.tree_view.enable_model_drag_source(Gdk.ModifierType.BUTTON1_MASK,
-                                                [('text/uri-list', 0, 0),
-                                                 ('journal-object-id', 0, 0)],
-                                                Gdk.DragAction.COPY)
+        self.tree_view.drag_source_set(Gdk.ModifierType.BUTTON1_MASK,
+                                       [Gtk.TargetEntry.new(
+                                           'text/uri-list', 0, 0),
+                                        Gtk.TargetEntry.new(
+                                            'journal-object-id', 0, 0)],
+                                       Gdk.DragAction.COPY)
 
     def disable_drag_and_copy(self):
         self.tree_view.unset_rows_drag_source()
@@ -702,6 +705,13 @@ class ListView(BaseListView):
         return self._is_dragging
 
     def __drag_begin_cb(self, widget, drag_context):
+        path, _column = self.tree_view.get_cursor()
+        if path is None:
+            return
+
+        row = self.tree_view.get_model()[path]
+        _pixbuf = GdkPixbuf.Pixbuf.new_from_file(row[ListModel.COLUMN_ICON])
+        self.tree_view.drag_source_set_icon_pixbuf(_pixbuf)
         self._is_dragging = True
 
     def __drag_data_get_cb(self, widget, context, selection, info, time):


### PR DESCRIPTION
Fixes issue [#3146](https://bugs.sugarlabs.org/ticket/3146) . Now only icon of entry can be dragged. 

Below is the result.
 
![drag](https://cloud.githubusercontent.com/assets/16541261/13203466/e8da836a-d8de-11e5-9048-73118f5363c3.png)

