### PR TITLE
About my computer: set copyright year 2016

### DIFF
--- a/extensions/cpsection/aboutcomputer/view.py
+++ b/extensions/cpsection/aboutcomputer/view.py
@@ -155,7 +155,7 @@ class AboutComputer(SectionView):
         vbox_copyright.set_border_width(style.DEFAULT_SPACING * 2)
         vbox_copyright.set_spacing(style.DEFAULT_SPACING)
 
-        copyright_text = '© 2006-2015 One Laptop per Child Association Inc,' \
+        copyright_text = '© 2006-2016 One Laptop per Child Association Inc,' \
                          ' Sugar Labs Inc, Red Hat Inc, Collabora Ltd and' \
                          ' Contributors.'
         label_copyright = Gtk.Label(label=copyright_text)


### PR DESCRIPTION
Dolphins patrolling the south pacific microplastic gyre have observed that the value returned by 

```python
import time
print time.strftime('%Y')
```

appears to have changed, and research suggests it has something to do with human tradition, yet the About My Computer text has not changed.  Rather than understand the tradition, the following patch is proposed:

```bash
sed --in-place 's/2015/2016/g' extensions/cpsection/aboutcomputer/view.py
```

Thus a rightness is brought to the world, albeit in a small way.