### PR TITLE
Fixed #4945: fixed the layout of alert message that appears on erasing an entry with lengthy titles

### DIFF
--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -581,8 +581,12 @@ class DetailToolbox(ToolbarBox):
         alert = Alert()
         erase_string = _('Erase')
         alert.props.title = erase_string
+        _erase_title = self._metadata['title']
+        if len(self._metadata['title']) > 25:
+            _erase_title = self._metadata['title'][:15] + '...'
+
         alert.props.msg = _('Do you want to permanently erase \"%s\"?') \
-            % self._metadata['title']
+            % _erase_title
         icon = Icon(icon_name='dialog-cancel')
         alert.add_button(Gtk.ResponseType.CANCEL, _('Cancel'), icon)
         icon.show()

--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -160,8 +160,12 @@ class ObjectPalette(Palette):
         alert = Alert()
         erase_string = _('Erase')
         alert.props.title = erase_string
+        _erase_title = self._metadata['title']
+        if len(self._metadata['title']) > 25:
+            _erase_title = self._metadata['title'][:15] + '...'
+
         alert.props.msg = _('Do you want to permanently erase \"%s\"?') \
-            % self._metadata['title']
+            % _erase_title
         icon = Icon(icon_name='dialog-cancel')
         alert.add_button(Gtk.ResponseType.CANCEL, _('Cancel'), icon)
         icon.show()


### PR DESCRIPTION
Used Ellipsis for entries with lengthy titles instead of the whole title.