### PR TITLE
Fix frame toggle issue and journal button toggle issue

### DIFF
--- a/src/jarabe/frame/eventarea.py
+++ b/src/jarabe/frame/eventarea.py
@@ -69,8 +69,10 @@ class EventArea(GObject.GObject):
         self._edge_delay = min(settings.get_int('edge-delay'), _MAX_DELAY)
         self._corner_delay = min(settings.get_int('corner-delay'), _MAX_DELAY)
         ts = min(settings.get_int('trigger-size'), style.GRID_CELL_SIZE)
-        sw = Gdk.Screen.width()
-        sh = Gdk.Screen.height()
+        
+        #Ensure that the frame toggle gets called only when we reach the boundaries of the screen
+        sw = Gdk.Screen.width() + style.GRID_CELL_SIZE - 1
+        sh = Gdk.Screen.height() + style.GRID_CELL_SIZE - 1
 
         if self._edge_delay == _MAX_DELAY:
             self._hide(_EDGES)


### PR DESCRIPTION
1)In the journal view, when we try to access the buttons on the bottom it becomes hard since the frame keeps popping up as soon as we go near the buttons.
2)Another issue in the journal view is that 'Journal' icon on the bottom left cannot be clicked on again if we move to either the 'Documents' or any of the mounted devices. This is because the frame gets called upon and the click is not detected by the button.

1)a)The frame starts popping up blocking the buttons
![screenshot from 2016-02-29 00 43 11](https://cloud.githubusercontent.com/assets/9864149/13381313/eb445720-de7e-11e5-9b0e-53053e87338f.png)

1)b)The frame completely covers the buttons and I have to find other means to get to the buttons
![screenshot from 2016-02-29 00 42 23](https://cloud.githubusercontent.com/assets/9864149/13381312/eb43fbe0-de7e-11e5-99dc-d82c94bef1ec.png)

2)a)Select another icon,
![screenshot from 2016-02-29 00 42 42](https://cloud.githubusercontent.com/assets/9864149/13381314/eb486446-de7e-11e5-8132-25ab74b8c890.png)

2)b)Unable to select the jounal icon again.
![screenshot from 2016-02-29 00 42 48](https://cloud.githubusercontent.com/assets/9864149/13381315/eb489e0c-de7e-11e5-8f93-0898fc6ddbf4.png)

Ensuring the frame pops up only when we reach the boundaries of the screen will solve both of these problems.