### PR TITLE
Add manual proxy settings manager in network settings

### DIFF
--- a/data/org.sugarlabs.gschema.xml
+++ b/data/org.sugarlabs.gschema.xml
@@ -390,23 +390,8 @@
             (something like 192.168.0.0/24).
             </description>
         </key>
-        <key name="use-same-proxy" type="b">
-            <default>true</default>
-            <summary>Unused; ignore</summary>
-            <description>
-            This key is not used, and should not be read or modified.
-            </description>
-        </key>
     </schema>
     <schema id="org.sugarlabs.system.proxy.http" path="/org/sugarlabs/system/proxy/http/">
-        <key name="enabled" type="b">
-            <default>false</default>
-            <summary>Unused; ignore</summary>
-            <description>
-            This key is not used; HTTP proxying is enabled when the host
-            key is non-empty and the port is non-0.
-            </description>
-        </key>
         <key name="host" type="s">
             <default>''</default>
             <summary>HTTP proxy host name</summary>

--- a/data/org.sugarlabs.gschema.xml
+++ b/data/org.sugarlabs.gschema.xml
@@ -333,4 +333,177 @@
             <description>This string is displayed in the control panel, about computer section.</description>
         </key>
     </schema>
+    <enum id='org.sugarlabs.desktop.GDesktopProxyMode'>
+        <value nick='none' value='0'/>
+        <value nick='manual' value='1'/>
+        <value nick='auto' value='2'/>
+        <value nick='system' value='3'/>
+    </enum>
+    <schema id="org.sugarlabs.system.proxy" path="/org/sugarlabs/system/proxy/">
+        <child name="http" schema="org.sugarlabs.system.proxy.http"/>
+        <child name="https" schema="org.sugarlabs.system.proxy.https"/>
+        <child name="ftp" schema="org.sugarlabs.system.proxy.ftp"/>
+        <child name="socks" schema="org.sugarlabs.system.proxy.socks"/>
+        <key name="mode" enum="org.sugarlabs.desktop.GDesktopProxyMode">
+            <default>'none'</default>
+            <summary>Proxy configuration mode</summary>
+            <description>
+            Select the proxy configuration mode. Supported values are "none", 
+            "manual", "auto".
+
+            If this is "none", then proxies are not used.
+
+            If it is "auto", the autoconfiguration URL described by the
+            "autoconfig-url" key is used.
+
+            If it is "manual", then the proxies described by
+            "/system/proxy/http", "/system/proxy/https",
+            "/system/proxy/ftp" and "/system/proxy/socks" will be used.
+            Each of the 4 proxy types is enabled if its "host" key is
+            non-empty and its "port" key is non-0.
+
+            If an http proxy is configured, but an https proxy is not,
+            then the http proxy is also used for https.
+
+            If a SOCKS proxy is configured, it is used for all protocols,
+            except that the http, https, and ftp proxy settings override
+            it for those protocols only.
+            </description>
+        </key>
+        <key name="autoconfig-url" type="s">
+            <default>''</default>
+            <summary>Automatic proxy configuration URL</summary>
+            <description>
+            URL that provides proxy configuration values. When mode is
+            "auto", this URL is used to look up proxy information for all
+            protocols.
+            </description>
+        </key>
+        <key name="ignore-hosts" type="as">
+            <default>[ 'localhost', '127.0.0.0/8', '::1' ]</default>
+            <summary>Non-proxy hosts</summary>
+            <description>
+            This key contains a list of hosts which are connected to directly, 
+            rather than via the proxy (if it is active). The values can be 
+            hostnames, domains (using an initial wildcard like *.foo.com), IP host 
+            addresses (both IPv4 and IPv6) and network addresses with a netmask 
+            (something like 192.168.0.0/24).
+            </description>
+        </key>
+        <key name="use-same-proxy" type="b">
+            <default>true</default>
+            <summary>Unused; ignore</summary>
+            <description>
+            This key is not used, and should not be read or modified.
+            </description>
+        </key>
+    </schema>
+    <schema id="org.sugarlabs.system.proxy.http" path="/org/sugarlabs/system/proxy/http/">
+        <key name="enabled" type="b">
+            <default>false</default>
+            <summary>Unused; ignore</summary>
+            <description>
+            This key is not used; HTTP proxying is enabled when the host
+            key is non-empty and the port is non-0.
+            </description>
+        </key>
+        <key name="host" type="s">
+            <default>''</default>
+            <summary>HTTP proxy host name</summary>
+            <description>
+            The machine name to proxy HTTP through.
+            </description>
+        </key>
+        <key name="port" type="i">
+            <range min="0" max="65535"/>
+            <default>8080</default>
+            <summary>HTTP proxy port</summary>
+            <description>
+            The port on the machine defined by "/system/proxy/http/host" that you 
+            proxy through.
+            </description>
+        </key>
+        <key name="use-authentication" type="b">
+            <default>false</default>
+            <summary>Authenticate proxy server connections</summary>
+            <description>
+            If true, then connections to the proxy server require authentication. 
+            The username/password combo is defined by 
+            "/system/proxy/http/authentication-user" and 
+            "/system/proxy/http/authentication-password".
+
+            This applies only to the http proxy; when using a separate
+            https proxy, there is currently no way to specify that it
+            should use authentication.
+            </description>
+        </key>
+        <key name="authentication-user" type="s">
+            <default>''</default>
+            <summary>HTTP proxy username</summary>
+            <description>
+            User name to pass as authentication when doing HTTP proxying.
+            </description>
+        </key>
+        <key name="authentication-password" type="s">
+            <default>''</default>
+            <summary>HTTP proxy password</summary>
+            <description>
+            Password to pass as authentication when doing HTTP proxying.
+            </description>
+        </key>
+    </schema>
+    <schema id="org.sugarlabs.system.proxy.https" path="/org/sugarlabs/system/proxy/https/">
+        <key name="host" type="s">
+            <default>''</default>
+            <summary>Secure HTTP proxy host name</summary>
+            <description>
+            The machine name to proxy secure HTTP through.
+            </description>
+        </key>
+        <key name="port" type="i">
+            <range min="0" max="65535"/>
+            <default>0</default>
+            <summary>Secure HTTP proxy port</summary>
+            <description>
+            The port on the machine defined by "/system/proxy/https/host" that you 
+            proxy through.
+            </description>
+        </key>
+    </schema>
+    <schema id="org.sugarlabs.system.proxy.ftp" path="/org/sugarlabs/system/proxy/ftp/">
+        <key name="host" type="s">
+            <default>''</default>
+            <summary>FTP proxy host name</summary>
+            <description>
+            The machine name to proxy FTP through.
+            </description>
+        </key>
+        <key name="port" type="i">
+            <range min="0" max="65535"/>
+            <default>0</default>
+            <summary>FTP proxy port</summary>
+            <description>
+            The port on the machine defined by "/system/proxy/ftp/host" that you 
+            proxy through.
+            </description>
+        </key>
+    </schema>
+    <schema id="org.sugarlabs.system.proxy.socks" path="/org/sugarlabs/system/proxy/socks/">
+        <key name="host" type="s">
+            <default>''</default>
+            <summary>SOCKS proxy host name</summary>
+            <description>
+            The machine name to use as a SOCKS proxy.
+            </description>
+        </key>
+        <key name="port" type="i">
+            <range min="0" max="65535"/>
+            <default>0</default>
+            <summary>SOCKS proxy port</summary>
+            <description>
+            The port on the machine defined by "/system/proxy/socks/host" that you 
+            proxy through.
+            </description>
+        </key>
+    </schema>    
 </schemalist>

--- a/extensions/cpsection/network/__init__.py
+++ b/extensions/cpsection/network/__init__.py
@@ -19,4 +19,4 @@ from gettext import gettext as _
 CLASS = 'Network'
 ICON = 'module-network'
 TITLE = _('Network')
-KEYWORDS = ['network', 'jabber', 'radio', 'server']
+KEYWORDS = ['network', 'jabber', 'radio', 'server', 'proxy']

--- a/extensions/cpsection/network/view.py
+++ b/extensions/cpsection/network/view.py
@@ -18,16 +18,267 @@
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gettext import gettext as _
+from gi.repository import Gio
+from gi.repository import Pango
+from gi.repository import GLib
 
+from sugar3.graphics.icon import Icon
 from sugar3.graphics import style
+from sugar3.graphics.alert import Alert
 
 from jarabe.controlpanel.sectionview import SectionView
 from jarabe.controlpanel.inlinealert import InlineAlert
 
+import os
 
 CLASS = 'Network'
 ICON = 'module-network'
 TITLE = _('Network')
+
+_APPLY_TIMEOUT = 3000
+
+
+def __setitem__(self, key, value):
+    # set_value() aborts the program on an unknown key
+    if key not in self:
+        raise KeyError('unknown key: %r' % (key,))
+
+    # determine type string of this key
+    range = self.get_range(key)
+    type_ = range.get_child_value(0).get_string()
+    v = range.get_child_value(1)
+    if type_ == 'type':
+        # v is boxed empty array, type of its elements is the allowed value type
+        assert v.get_child_value(0).get_type_string().startswith('a')
+        type_str = v.get_child_value(0).get_type_string()[1:]
+    elif type_ == 'enum':
+        # v is an array with the allowed values
+        assert v.get_child_value(0).get_type_string().startswith('a')
+        type_str = v.get_child_value(0).get_child_value(0).get_type_string()
+    elif type_ == 'flags':
+        # v is an array with the allowed values
+        assert v.get_child_value(0).get_type_string().startswith('a')
+        type_str = v.get_child_value(0).get_type_string()
+    elif type_ == 'range':
+        # type_str is a tuple giving the range
+        assert v.get_child_value(0).get_type_string().startswith('(')
+        type_str = v.get_child_value(0).get_type_string()[1]
+
+    if not self.set_value(key, GLib.Variant(type_str, value)):
+        raise ValueError("value '%s' for key '%s' is outside of valid range" % (value, key))
+
+
+def bind_with_convert(self, key, widget, prop, flags, key_to_prop, prop_to_key):
+    self._ignore_key_changed = False
+
+    def key_changed(settings, key):
+        if self._ignore_key_changed:
+            return
+        self._ignore_prop_changed = True
+        widget.set_property(prop, key_to_prop(self[key]))
+        self._ignore_prop_changed = False
+
+    def prop_changed(widget, param):
+        if self._ignore_prop_changed:
+            return
+        self._ignore_key_changed = True
+        self[key] = prop_to_key(widget.get_property(prop))
+        self._ignore_key_changed = False
+
+    if not (flags & (Gio.SettingsBindFlags.SET | Gio.SettingsBindFlags.GET)):
+        # ie Gio.SettingsBindFlags.DEFAULT
+        flags |= Gio.SettingsBindFlags.SET | Gio.SettingsBindFlags.GET
+    if flags & Gio.SettingsBindFlags.GET:
+        key_changed(self, key)
+        if not (flags & Gio.SettingsBindFlags.GET_NO_CHANGES):
+            self.connect('changed::' + key, key_changed)
+    if flags & Gio.SettingsBindFlags.SET:
+        widget.connect('notify::' + prop, prop_changed)
+    if not (flags & Gio.SettingsBindFlags.NO_SENSITIVITY):
+        self.bind_writable(key, widget, "sensitive", False)
+
+Gio.Settings.bind_with_convert = bind_with_convert
+Gio.Settings.__setitem__ = __setitem__
+
+
+def type_as_to_string(value):
+    return ",".join(value)
+
+
+def string_to_type_as(value):
+    return value.split(',')
+
+
+class NumberEntry(Gtk.Entry):
+    def __init__(self):
+        Gtk.Entry.__init__(self)
+        self.connect('changed', self.on_changed)
+
+    def on_changed(self, *args):
+        text = self.get_text().strip()
+        self.set_text(''.join([i for i in text if i in '0123456789']))
+
+
+class SettingBox(Gtk.HBox):
+    """
+    Base class for "lines" on the screen representing configuration
+    settings.
+    """
+    def __init__(self, name, size_group=None):
+        Gtk.HBox.__init__(self, spacing=style.DEFAULT_SPACING)
+        label = Gtk.Label(name)
+        label.modify_fg(Gtk.StateType.NORMAL,
+                        style.COLOR_SELECTION_GREY.get_gdk_color())
+        label.set_alignment(1, 0.5)
+        if size_group is not None:
+            size_group.add_widget(label)
+        self.pack_start(label, False, False, 0)
+        label.show()
+
+
+class ComboSettingBox(Gtk.VBox):
+    """
+    Container for sets of different settings selected by a top-level
+    setting.
+
+    Renders the top level setting as a ComboBox.  Only the currently
+    active set is shown on screen.
+    """
+    def __init__(self, name, setting, setting_key,
+                 option_sets, size_group=None):
+        Gtk.VBox.__init__(self, spacing=style.DEFAULT_SPACING)
+
+        setting_box = SettingBox(name, size_group)
+        self.pack_start(setting_box, False, False, 0)
+        setting_box.show()
+
+        model = Gtk.ListStore(str, str, object)
+        combo_box = Gtk.ComboBox(model=model)
+        combo_box.connect('changed', self.__combo_changed_cb)
+        setting_box.pack_start(combo_box, True, True, 0)
+        combo_box.show()
+
+        cell_renderer = Gtk.CellRendererText()
+        cell_renderer.props.ellipsize = Pango.EllipsizeMode.MIDDLE
+        cell_renderer.props.ellipsize_set = True
+        combo_box.pack_start(cell_renderer, True)
+        combo_box.add_attribute(cell_renderer, 'text', 0)
+        combo_box.props.id_column = 1
+
+        self._settings_box = Gtk.VBox()
+        self._settings_box.show()
+        self.pack_start(self._settings_box, False, False, 0)
+
+        for optset in option_sets:
+            model.append(optset)
+
+        setting.bind(setting_key, combo_box, 'active-id',
+                     Gio.SettingsBindFlags.DEFAULT)
+
+    def __combo_changed_cb(self, combobox):
+        giter = combobox.get_active_iter()
+        new_box = combobox.get_model().get(giter, 2)[0]
+        current_box = self._settings_box.get_children()
+        if current_box:
+            self._settings_box.remove(current_box[0])
+
+        self._settings_box.add(new_box)
+        new_box.show()
+
+
+class OptionalSettingsBox(Gtk.VBox):
+    """
+    Container for settings (de)activated by a top-level setting.
+
+    Renders the top level setting as a CheckButton. The settings are only
+    shown on screen if the top-level setting is enabled.
+    """
+    def __init__(self, name, setting, setting_key, contents_box):
+        Gtk.VBox.__init__(self, spacing=style.DEFAULT_SPACING)
+
+        check_button = Gtk.CheckButton()
+        check_button.props.label = name
+        check_button.connect('toggled', self.__button_toggled_cb, contents_box)
+        check_button.show()
+        self.pack_start(check_button, True, True, 0)
+        self.pack_start(contents_box, False, False, 0)
+
+        setting.bind(setting_key, check_button, 'active',
+                     Gio.SettingsBindFlags.DEFAULT)
+
+    def __button_toggled_cb(self, check_button, contents_box):
+        contents_box.set_visible(check_button.get_active())
+
+
+class HostPortSettingBox(SettingBox):
+    """
+    A configuration line for a combined host name and port setting.
+    """
+    def __init__(self, name, alert, setting, size_group=None):
+        SettingBox.__init__(self, name, size_group)
+        self.pack_start(alert, False, True, 0)
+        alert.hide()
+
+        host_entry = Gtk.Entry()
+        self.pack_start(host_entry, True, True, 0)
+        host_entry.show()
+
+        setting.bind('host', host_entry, 'text', Gio.SettingsBindFlags.DEFAULT)
+
+        # port number 0 means n/a
+        port_entry = NumberEntry()
+        self.pack_start(port_entry, False, False, 0)
+        port_entry.show()
+        setting.bind_with_convert('port',
+                                  port_entry,
+                                  "text",
+                                  Gio.SettingsBindFlags.GET |
+                                  Gio.SettingsBindFlags.SET |
+                                  Gio.SettingsBindFlags.NO_SENSITIVITY,
+                                  lambda x: str(x),
+                                  lambda x: int(x))
+
+
+class StringSettingBox(SettingBox):
+    """
+    A configuration line for a string setting.
+    """
+    def __init__(self, name, setting, setting_key, size_group=None,
+                 password_field=False):
+        SettingBox.__init__(self, name, size_group)
+
+        entry = Gtk.Entry()
+        self.pack_start(entry, True, True, 0)
+        entry.show()
+        if password_field:
+            entry.set_visibility(False)
+
+        setting.bind(setting_key, entry, 'text', Gio.SettingsBindFlags.DEFAULT)
+
+
+class StringSettingBox_with_convert(SettingBox):
+    """
+    A configuration line for a string setting.
+    """
+    def __init__(self, name, setting, setting_key,
+                 get_method, set_method, size_group=None,
+                 password_field=False):
+        SettingBox.__init__(self, name, size_group)
+
+        entry = Gtk.Entry()
+        self.pack_start(entry, True, True, 0)
+        entry.show()
+        if password_field:
+            entry.set_visibility(False)
+
+        setting.bind_with_convert(setting_key,
+                                  entry,
+                                  "text",
+                                  Gio.SettingsBindFlags.GET |
+                                  Gio.SettingsBindFlags.SET |
+                                  Gio.SettingsBindFlags.NO_SENSITIVITY,
+                                  get_method,
+                                  set_method)
 
 
 class Network(SectionView):
@@ -42,6 +293,8 @@ class Network(SectionView):
         self._radio_change_handler = None
         self._wireless_configuration_reset_handler = None
         self._start_jabber = self._model.get_jabber()
+        self._proxy_settings = {}
+        self._proxy_inline_alerts = {}
 
         self.set_border_width(style.DEFAULT_SPACING * 2)
         self.set_spacing(style.DEFAULT_SPACING)
@@ -190,7 +443,149 @@ class Network(SectionView):
         workspace.pack_start(box_mesh, False, True, 0)
         box_mesh.show()
 
+        separator_proxy = Gtk.HSeparator()
+        workspace.pack_start(separator_proxy, False, False, 0)
+        separator_proxy.show()
+
+        self._add_proxy_section(workspace)
+
         self.setup()
+
+    def _add_proxy_section(self, workspace):
+        label_proxy = Gtk.Label(_('Proxy'))
+        label_proxy.set_alignment(0, 0)
+        workspace.pack_start(label_proxy, False, True, 0)
+        label_proxy.show()
+
+        box_proxy = Gtk.VBox()
+        box_proxy.set_border_width(style.DEFAULT_SPACING * 2)
+        box_proxy.set_spacing(style.DEFAULT_SPACING)
+        workspace.pack_start(box_proxy, False, True, 0)
+        box_proxy.show()
+
+        self._proxy_alert = Alert()
+        self._proxy_alert.props.title = _('Error')
+        self._proxy_alert.props.msg = _('Proxy settings cannot be verified')
+        box_proxy.pack_start(self._proxy_alert, False, False, 0)
+        self._proxy_alert.connect('response', self._response_cb)
+        self._proxy_alert.hide()
+
+        # GSettings schemas for proxy:
+        schemas = ['org.sugarlabs.system.proxy',
+                   'org.sugarlabs.system.proxy.http',
+                   'org.sugarlabs.system.proxy.https',
+                   'org.sugarlabs.system.proxy.ftp',
+                   'org.sugarlabs.system.proxy.socks']
+
+        for schema in schemas:
+            proxy_setting = Gio.Settings.new(schema)
+
+            # We are not going to apply the settings immediatly.
+            # We'll apply them if the user presses the "accept"
+            # button, or we'll revert them if the user presses the
+            # "cancel" button.
+            proxy_setting.delay()
+            alert = InlineAlert()
+
+            self._proxy_settings[schema] = proxy_setting
+            self._proxy_inline_alerts[schema] = alert
+
+        size_group = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
+
+        automatic_proxy_box = Gtk.VBox(spacing=style.DEFAULT_SPACING)
+        manual_proxy_box = Gtk.VBox(spacing=style.DEFAULT_SPACING)
+
+        option_sets = [('None', 'none', Gtk.VBox()),
+                       ('Use system proxy', 'system', Gtk.VBox()),
+                       ('Manual', 'manual', manual_proxy_box),
+                       ('Automatic', 'auto', automatic_proxy_box)]
+
+        box_mode = ComboSettingBox(
+            _('Method:'), self._proxy_settings['org.sugarlabs.system.proxy'],
+            'mode', option_sets, size_group)
+
+        box_proxy.pack_start(box_mode, False, False, 0)
+        box_mode.show()
+
+        url_box = StringSettingBox(
+            _('Configuration URL:'),
+            self._proxy_settings['org.sugarlabs.system.proxy'], 'autoconfig-url',
+            size_group)
+
+        automatic_proxy_box.pack_start(url_box, True, True, 0)
+        url_box.show()
+
+        wpad_help_text = _('Web Proxy Autodiscovery is used when a'
+                           ' Configuration URL is not provided. This is not'
+                           ' recommended for untrusted public networks.')
+        automatic_proxy_help = Gtk.Label(wpad_help_text)
+        automatic_proxy_help.set_alignment(0, 0)
+        automatic_proxy_help.set_line_wrap(True)
+        automatic_proxy_help.show()
+        automatic_proxy_box.pack_start(automatic_proxy_help, True, True, 0)
+
+        # HTTP Section
+        schema = 'org.sugarlabs.system.proxy.http'
+        box_http = HostPortSettingBox(
+            _('HTTP Proxy:'), self._proxy_inline_alerts[schema],
+            self._proxy_settings[schema], size_group)
+        manual_proxy_box.pack_start(box_http, False, False, 0)
+        box_http.show()
+        auth_contents_box = Gtk.VBox(spacing=style.DEFAULT_SPACING)
+        auth_box = OptionalSettingsBox(
+            _('Use authentication'),
+            self._proxy_settings[schema],
+            'use-authentication', auth_contents_box)
+        manual_proxy_box.pack_start(auth_box, False, False, 0)
+        auth_box.show()
+        proxy_http_setting = Gio.Settings.new(schema)
+        proxy_http_setting.delay()
+        box_username = StringSettingBox(
+            _('Username:'),
+            self._proxy_settings[schema],
+            'authentication-user', size_group)
+        auth_contents_box.pack_start(box_username, False, False, 0)
+        box_username.show()
+        box_password = StringSettingBox(
+            _('Password:'),
+            self._proxy_settings[schema],
+            'authentication-password', size_group, password_field=True)
+        auth_contents_box.pack_start(box_password, False, False, 0)
+        box_password.show()
+
+        # HTTPS Section
+        schema = 'org.sugarlabs.system.proxy.https'
+        box_https = HostPortSettingBox(
+            _('HTTPS Proxy:'), self._proxy_inline_alerts[schema],
+            self._proxy_settings[schema],
+            size_group)
+        manual_proxy_box.pack_start(box_https, False, False, 0)
+        box_https.show()
+
+        # FTP Section
+        schema = 'org.sugarlabs.system.proxy.ftp'
+        box_ftp = HostPortSettingBox(
+            _('FTP Proxy:'), self._proxy_inline_alerts[schema],
+            self._proxy_settings[schema],
+            size_group)
+        manual_proxy_box.pack_start(box_ftp, False, False, 0)
+        box_ftp.show()
+
+        # SOCKS Section
+        schema = 'org.sugarlabs.system.proxy.socks'
+        box_socks = HostPortSettingBox(
+            _('SOCKS Proxy:'), self._proxy_inline_alerts[schema],
+            self._proxy_settings[schema],
+            size_group)
+        manual_proxy_box.pack_start(box_socks, False, False, 0)
+        box_socks.show()
+
+        box_ignore = StringSettingBox_with_convert(
+            _('Ignore Hosts:'),
+            self._proxy_settings['org.sugarlabs.system.proxy'], 'ignore-hosts',
+            type_as_to_string, string_to_type_as, size_group)
+        manual_proxy_box.pack_start(box_ignore, False, False, 0)
+        box_ignore.show()
 
     def setup(self):
         self._entry.set_text(self._start_jabber)
@@ -212,13 +607,91 @@ class Network(SectionView):
             self._clear_wireless_button.connect(
                 'clicked', self.__wireless_configuration_reset_cb)
 
+    def _response_cb(self, alert, response_id):
+        if response_id is Gtk.ResponseType.APPLY:
+            self._proxy_alert.hide()
+            self._apply_proxy_settings()
+            self.show_restart_alert = True
+            self.emit('add-alert')
+        elif response_id is Gtk.ResponseType.CANCEL:
+            self.undo()
+            self._proxy_alert.remove_button(Gtk.ResponseType.APPLY)
+            self._proxy_alert.remove_button(Gtk.ResponseType.CANCEL)
+            self._proxy_alert.hide()
+            self.emit('set-toolbar-sensitivity', True)
+
+    def _ping_servers(self):
+        response_to_return = True
+        for schema in list(self._proxy_settings.keys()):
+                if (schema != 'org.sugarlabs.system.proxy'):
+                    hostname = Gio.Settings.get_string(
+                        self._proxy_settings[schema], 'host')
+                    response = os.system("ping -c 1 -W 1 " + hostname)
+                    if (response):
+                        self._proxy_inline_alerts[schema].show()
+                        response_to_return = False
+        return response_to_return
+
+    def _verify_settings(self):
+        self._proxy_alert.props.title = _('Please Wait!')
+        self._proxy_alert.props.msg = _('Proxy settings are being verified.')
+        self._proxy_alert.show()
+        flag_all_true = True
+        g_proxy_schema = self._proxy_settings['org.sugarlabs.system.proxy']
+        g_mode = Gio.Settings.get_string(g_proxy_schema, 'mode')
+        self.show_restart_alert = False
+
+        if g_mode == 'auto':
+            flag_all_true = os.path.isfile(Gio.Settings.get_string(
+                g_proxy_schema, 'autoconfig-url'))
+        elif g_mode == 'manual':
+            flag_all_true = self._ping_servers()
+        if flag_all_true:
+            self.show_restart_alert = True
+            self._proxy_alert.hide()
+            self._apply_proxy_settings()
+        else:
+            self._proxy_alert.props.title = _('Error!')
+            self._proxy_alert.props.msg = _('The following setting(s) seems '
+                                            'to be incorrect and may break '
+                                            'your internet connection')
+
+            icon = Icon(icon_name='dialog-cancel')
+            self._proxy_alert.add_button(Gtk.ResponseType.APPLY,
+                                         _('Break my internet'), icon)
+            icon.show()
+            icon = Icon(icon_name='dialog-ok')
+            self._proxy_alert.add_button(Gtk.ResponseType.CANCEL,
+                                         _('Reset'), icon)
+            icon.show()
+
+    def _apply_proxy_settings(self):
+        for setting in self._proxy_settings.values():
+            if (Gio.Settings.get_has_unapplied(setting)):
+                setting.apply()
+
     def apply(self):
         self._apply_jabber(self._entry.get_text())
         self._model.set_social_help(self._social_help_entry.get_text())
+        settings_changed = False
+        for setting in self._proxy_settings.values():
+            if (Gio.Settings.get_has_unapplied(setting)):
+                settings_changed = True
+        if settings_changed:
+            self.needs_restart = True
+            self._is_cancellable = False
+            self.restart_msg = _('Proxy changes require restart')
+            self._verify_settings()
+        else:
+            self.show_restart_alert = True
 
     def undo(self):
         self._button.disconnect(self._radio_change_handler)
         self._radio_alert.hide()
+        for setting in self._proxy_settings.values():
+            setting.revert()
+        for alert in self._proxy_inline_alerts.values():
+            alert.hide()
 
     def _validate(self):
         if self._radio_valid:

--- a/extensions/cpsection/network/view.py
+++ b/extensions/cpsection/network/view.py
@@ -622,14 +622,19 @@ class Network(SectionView):
 
     def _ping_servers(self):
         response_to_return = True
+        non_blank_host_name_counter = 0  # To check accidental blank hostnames
         for schema in list(self._proxy_settings.keys()):
                 if (schema != 'org.sugarlabs.system.proxy'):
                     hostname = Gio.Settings.get_string(
                         self._proxy_settings[schema], 'host')
-                    response = os.system("ping -c 1 -W 1 " + hostname)
-                    if (response):
-                        self._proxy_inline_alerts[schema].show()
-                        response_to_return = False
+                    if hostname != '':
+                        non_blank_host_name_counter += 1
+                        response = os.system("ping -c 1 -W 1 " + hostname)
+                        if (response):
+                            self._proxy_inline_alerts[schema].show()
+                            response_to_return = False
+        if non_blank_host_name_counter == 0:
+            response_to_return = False
         return response_to_return
 
     def _verify_settings(self):

--- a/src/jarabe/controlpanel/sectionview.py
+++ b/src/jarabe/controlpanel/sectionview.py
@@ -24,6 +24,9 @@ class SectionView(Gtk.VBox):
 
     __gsignals__ = {
         'request-close': (GObject.SignalFlags.RUN_FIRST, None, ([])),
+        'add-alert': (GObject.SignalFlags.RUN_FIRST, None, ([])),
+        'set-toolbar-sensitivity': (GObject.SignalFlags.RUN_FIRST, None,
+                                    (GObject.TYPE_BOOLEAN,)),
     }
 
     __gproperties__ = {
@@ -43,6 +46,7 @@ class SectionView(Gtk.VBox):
         self.needs_restart = False
         self.restart_alerts = []
         self.restart_msg = _('Changes require restart')
+        self.show_restart_alert = True
 
     def do_set_property(self, pspec, value):
         if pspec.name == 'is-valid':

--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -348,42 +348,33 @@ def setup_fonts():
 
 
 def setup_proxy():
-    env_variables = ['http_proxy',
-                     'HTTP_PROXY',
-                     'https_proxy',
-                     'HTTPS_PROXY',
-                     'ftp_proxy',
-                     'FTP_PROXY',
-                     'socks_proxy',
-                     'SOCKS_PROXY']
+    protos = ['http', 'https', 'ftp', 'socks']
+    env_variables = ['{}_proxy'.format(proto) for proto in protos]
+    schemas = ['org.sugarlabs.system.proxy.{}'.format(proto) for proto in protos]
+
     g_mode = Gio.Settings('org.sugarlabs.system.proxy').get_string('mode')
     if g_mode == 'manual':
-        schemas = ['org.sugarlabs.system.proxy.http',
-                   'org.sugarlabs.system.proxy.https',
-                   'org.sugarlabs.system.proxy.ftp',
-                   'org.sugarlabs.system.proxy.socks']
         counter = 0
         for schema in schemas:
             setting_schema = Gio.Settings(schema)
 
-            if ((env_variables[counter] == 'http_proxy' or
-                    env_variables[counter] == 'HTTP_PROXY') and
+            if ((env_variables[counter] == 'http_proxy') and
                     setting_schema.get_boolean('use-authentication')):
                 text_to_set = "%s://%s:%s@%s:%s/" % (
-                    env_variables[counter][:-6],
+                    protos[counter],
                     setting_schema.get_string('authentication-user'),
                     setting_schema.get_string('authentication-password'),
                     setting_schema.get_string('host'),
                     str(setting_schema.get_int('port')))
             else:
                 text_to_set = "%s://%s:%s/" % (
-                    env_variables[counter][:-6],
+                    protos[counter],
                     setting_schema.get_string('host'),
                     str(setting_schema.get_int('port')))
 
             os.environ[env_variables[counter]] = text_to_set
-            os.environ[env_variables[counter + 1]] = text_to_set
-            counter = counter + 2
+            os.environ[env_variables[counter].upper()] = text_to_set
+            counter += 1
         os.environ['no_proxy'] = ",".join(Gio.Settings(
             'org.sugarlabs.system.proxy').get_strv('ignore-hosts'))
 


### PR DESCRIPTION
Add GUI based proxy manager in the Network section of 'My Settings' to
enable management of manual proxy servers.

The proxy settings are stored in /etc/profile.d/proxy.sh as exports to
environment variables and requires re-login to let the changes take effect.

/extensions/cpsection/network/set_proxy.py file writes the proxy settings,
while two polkit policy files org.sugar.proxy.policy and org.sugar.logout.policy
located at /usr/share/polkit-1/actions provide root permissions required
for file handling and logout command. These two polkit files are placed at
data/ directory of this repository.