### PR TITLE
Fix drag_status call to work on fc24/23, fixes #4949

### DIFF
--- a/src/jarabe/frame/eventarea.py
+++ b/src/jarabe/frame/eventarea.py
@@ -137,7 +137,7 @@ class EventArea(GObject.GObject):
         self._notify_leave()
 
     def _drag_motion_cb(self, widget, drag_context, x, y, timestamp):
-        drag_context.drag_status(0, timestamp)
+        Gdk.drag_status(drag_context, 0, timestamp)
         self._notify_enter()
         return True
 


### PR DESCRIPTION
I believe that Gdk.drag_status (new function) has been here forever (tested fc25, fc22), since it doesn't have an "new since" section in the docs [1].

[1]  https://developer.gnome.org/gdk3/unstable/gdk3-Drag-and-Drop.html#gdk-drag-status