### PR TITLE
Add accessibility keys to Journal #4891

### DIFF
--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -374,13 +374,20 @@ class JournalActivity(JournalWindow):
             activity_id=activity_id, project_metadata=self.project_metadata)
 
     def __key_press_event_cb(self, widget, event):
-        #if not self._main_toolbox.search_entry.has_focus():
-        #self._main_toolbox.search_entry.grab_focus()
-
+        '''
+        Grabs keyboard focus to tree view on Up/Down
+        keypress. Focus can be switched b/w search entry
+        and the tree view by the 'Tab' key.
+        '''
         keyname = Gdk.keyval_name(event.keyval)
-        if keyname == 'Escape':
+        if keyname == 'Up' or keyname == 'Down':
+            if not self._list_view.tree_view.has_focus():
+                self._list_view.tree_view.grab_focus()
+
+        if keyname == 'Escape' or keyname == 'Left':
             self._main_toolbox.clear_query()
             self.show_main_view()
+            self._list_view.tree_view.grab_focus()
 
     def __choose_project_cb(self, tree_view, metadata_to_send):
         project_chooser = ObjectChooser(self.get_window())


### PR DESCRIPTION
This PR add this feature request -> https://bugs.sugarlabs.org/ticket/4891

Now the journal can be accessed via keyboard. Following functions are implemeted ->
1. Entries can be scrolled with `'Up'/'Down'` arrow keys.
2. Activity can be started/resumed by pressing `'Enter'` key.
3. `Detail View` can be opened with `'Right'` arrow key.
4. Switching b/w `search entry` and `tree view` can done with `'Tab'` key.
5. `Escape` key can be use to switch back to list from detail view.
6. Activity can be `renamed` by typing anything.

Watch the below gif closely(Mouse is not used). :dancers: 
![desktop-animation2](https://cloud.githubusercontent.com/assets/6258810/13730494/05bf6196-e977-11e5-8443-9c6ddcfb640e.gif)
