### PR TITLE
Fix custom restart message display in control panel

### DIFF
--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -372,7 +372,7 @@ class ControlPanel(Gtk.Window):
             self._section_toolbar.cancel_button.set_sensitive(False)
             alert = Alert()
             alert.props.title = _('Warning')
-            alert.props.msg = _('Changes require restart')
+            alert.props.msg = self._section_view.restart_msg
 
             if self._section_view.props.is_cancellable:
                 icon = Icon(icon_name='dialog-cancel')


### PR DESCRIPTION
Fixed the issue where custom message for restart options, set through
'self.restart_msg = _('Your custom message')' in case of
'self.needs_restart'  set to True was not getting displayed and instead
the default 'Changes require restart' was displayed.

This was solved by simply passing the 'self.restart_msg' variable in
/jarabe/controlpanel/sectionview.py to 'alert.props.msg' variable in
/jarabe/controlpanel/gui.py where it is finally displayed.

![fix-restart_msg](https://cloud.githubusercontent.com/assets/6487572/13808580/d7666b9c-eb8c-11e5-9a74-4f16a2f4f633.png)
