### PR TITLE
Fix brightness restore crash

### DIFF
--- a/src/jarabe/model/brightness.py
+++ b/src/jarabe/model/brightness.py
@@ -104,17 +104,19 @@ class Brightness(GObject.GObject):
 
     def set_brightness(self, value):
         # do not monitor the external change we are about to trigger
-        if self._monitor_timeout_id is None:
-            self._monitor.handler_block(self._monitor_changed_hid)
+        if self._monitor is not None:
+            if self._monitor_timeout_id is None:
+                self._monitor.handler_block(self._monitor_changed_hid)
 
         self._helper_write('set-brightness', value)
         self.changed_signal.emit(value)
 
         # do monitor again only after the rate has passed
-        if self._monitor_timeout_id is not None:
-            GLib.source_remove(self._monitor_timeout_id)
-        self._monitor_timeout_id = GLib.timeout_add(
-            self._MONITOR_RATE * 2, self.__monitor_timeout_cb)
+        if self._monitor is not None:
+            if self._monitor_timeout_id is not None:
+                GLib.source_remove(self._monitor_timeout_id)
+            self._monitor_timeout_id = GLib.timeout_add(
+                self._MONITOR_RATE * 2, self.__monitor_timeout_cb)
 
         # do not store every change while is still changing
         if self._save_timeout_id is not None:


### PR DESCRIPTION
On systems with no brightness control, such as an XO-1 with kernel
4.6-rc1 due to 82ef33af9dd30075adbd9f3dd161b606b8ba88ac, Sugar does
crash on start with this shell.log fragment;

Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/usr/lib/python2.7/site-packages/jarabe/main.py", line 428, in <module>
    main()
  File "/usr/lib/python2.7/site-packages/jarabe/main.py", line 410, in main
    brightness.get_instance()
  File "/usr/lib/python2.7/site-packages/jarabe/model/brightness.py", line 30, in get_instance
    _instance = Brightness()
  File "/usr/lib/python2.7/site-packages/jarabe/model/brightness.py", line 53, in __init__
    self._restore()
  File "/usr/lib/python2.7/site-packages/jarabe/model/brightness.py", line 67, in _restore
    self.set_brightness(value)
  File "/usr/lib/python2.7/site-packages/jarabe/model/brightness.py", line 108, in set_brightness
    self._monitor.handler_block(self._monitor_changed_hid)
AttributeError: 'NoneType' object has no attribute 'handler_block'

Fix is to avoid dereferencing _monitor if it is None.