### PR TITLE
Fix for battery device icon update

### DIFF
--- a/extensions/deviceicon/battery.py
+++ b/extensions/deviceicon/battery.py
@@ -20,6 +20,7 @@ from gettext import gettext as _
 from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gtk
+from gi.repository import UPowerGlib
 import dbus
 
 from sugar3 import profile
@@ -42,14 +43,6 @@ _STATUS_NOT_PRESENT = 3
 _UP_DEVICE_IFACE = 'org.freedesktop.UPower.Device'
 
 _UP_TYPE_BATTERY = 2
-
-_UP_STATE_UNKNOWN = 0
-_UP_STATE_CHARGING = 1
-_UP_STATE_DISCHARGING = 2
-_UP_STATE_EMPTY = 3
-_UP_STATE_FULL = 4
-_UP_STATE_CHARGE_PENDING = 5
-_UP_STATE_DISCHARGE_PENDING = 6
 
 _WARN_MIN_PERCENTAGE = 15
 
@@ -188,50 +181,64 @@ class DeviceModel(GObject.GObject):
 
     def __init__(self, battery):
         GObject.GObject.__init__(self)
-        self._battery = battery
-        self._battery_props_iface = dbus.Interface(self._battery,
-                                                   dbus.PROPERTIES_IFACE)
-        self._battery.connect_to_signal('Changed',
-                                        self.__battery_properties_changed_cb,
-                                        dbus_interface=_UP_DEVICE_IFACE)
+        self._battery = UPowerGlib.Device()
+        self._battery.set_object_path_sync(battery, None)
+        self._connect_battery()
         self._fetch_properties_from_upower()
+        self._timeout_sid = False
+
+    def _connect_battery(self):
+        """Connect to battery signals so we are told of changes."""
+
+        if 'changed' not in GObject.signal_list_names(UPowerGlib.Device):
+            # For UPower 0.99.4 and later
+            self._battery.connect('notify::percentage', self.__notify_cb)
+            self._battery.connect('notify::state', self.__notify_cb)
+            self._battery.connect('notify::is-present', self.__notify_cb)
+            self._battery.connect('notify::time-to-empty', self.__notify_cb)
+            self._battery.connect('notify::time-to-full', self.__notify_cb)
+        else:
+            # For UPower 0.19.9
+            self._battery.connect('changed', self.__notify_cb, None)
 
     def _fetch_properties_from_upower(self):
         """Get current values from UPower."""
-        # pylint: disable=W0201
-        try:
-            dbus_props = self._battery_props_iface.GetAll(_UP_DEVICE_IFACE)
-        except dbus.DBusException:
-            logging.error('Cannot access battery properties')
-            dbus_props = {}
 
-        self._level = dbus_props.get('Percentage', 0)
-        self._state = dbus_props.get('State', _UP_STATE_UNKNOWN)
-        self._present = dbus_props.get('IsPresent', False)
-        self._time_to_empty = dbus_props.get('TimeToEmpty', 0)
-        self._time_to_full = dbus_props.get('TimeToFull', 0)
+        self._level = self._battery.props.percentage
+        self._state = self._battery.props.state
+        self._present = self._battery.props.is_present
+        self._time_to_empty = self._battery.props.time_to_empty
+        self._time_to_full = self._battery.props.time_to_full
 
     def do_get_property(self, pspec):
         """Return current value of given GObject property."""
         if pspec.name == 'level':
             return self._level
         if pspec.name == 'charging':
-            return self._state == _UP_STATE_CHARGING
+            return self._state == UPowerGlib.DeviceState.CHARGING
         if pspec.name == 'discharging':
-            return self._state == _UP_STATE_DISCHARGING
+            return self._state == UPowerGlib.DeviceState.DISCHARGING
         if pspec.name == 'present':
             return self._present
         if pspec.name == 'time-remaining':
-            if self._state == _UP_STATE_CHARGING:
+            if self._state == UPowerGlib.DeviceState.CHARGING:
                 return self._time_to_full
-            if self._state == _UP_STATE_DISCHARGING:
+            if self._state == UPowerGlib.DeviceState.DISCHARGING:
                 return self._time_to_empty
             return 0
 
     def get_type(self):
         return 'battery'
 
-    def __battery_properties_changed_cb(self):
+    def __notify_cb(self, device, name):
+        """Defer response to notifications; they arrive in a burst,
+        but without any indication that the burst is complete, so we
+        use a timeout to respond."""
+        if self._timeout_sid:
+            GObject.source_remove(self._timeout_sid)
+        self._timeout_sid = GObject.timeout_add(100, self.__timeout_cb)
+
+    def __timeout_cb(self):
         old_level = self._level
         old_state = self._state
         old_present = self._present
@@ -248,6 +255,8 @@ class DeviceModel(GObject.GObject):
             self.notify('time-remaining')
 
         self.emit('updated')
+        self._timeout_sid = None
+        return False
 
 
 def setup(tray):
@@ -261,4 +270,4 @@ def setup(tray):
         device_prop_iface = dbus.Interface(device, dbus.PROPERTIES_IFACE)
         device_type = device_prop_iface.Get(_UP_DEVICE_IFACE, 'Type')
         if device_type == _UP_TYPE_BATTERY:
-            tray.add_device(DeviceView(device))
+            tray.add_device(DeviceView(device_path))


### PR DESCRIPTION
_(this is the updated commit message from 67ffe98)_

Frame battery device is static on Ubuntu 16.04, with UPower 0.99.4.

The 'changed' signal is not sent.  UPower had deprecated 'changed', replacing with 'notify' for all properties, or on per-property basis.

* switch to UPowerGlib GObject introspection API,

* continue to use 'changed' signals on older UPower, for compatibility with OLPC OS 13.2.7, Fedora 18, UPower 0.9.19,

- switch to 'notify' signals if they are present,

- continue to use D-Bus API to get device path, because the older UPower fails on get_devices method, and doesn't have get_display_device,

- ignore bursts of notify signals; reduces frame icon redraws,

- fixes https://bugs.sugarlabs.org/ticket/4781.

Tested with OLPC OS 13.2.7 on XO-4, and Ubuntu 16.04 on commodity hardware.

Requires gir1.2-upowerglib-1.0 on Ubuntu 16.04.