### PR TITLE
Fixed background render of cellrenderericon while scrolling

### DIFF
--- a/src/jarabe/desktop/activitieslist.py
+++ b/src/jarabe/desktop/activitieslist.py
@@ -72,18 +72,20 @@ class ActivitiesTreeView(Gtk.TreeView):
 
         for i in range(desktop.get_number_of_views()):
             column = Gtk.TreeViewColumn()
-            cell = CellRendererFavorite(i)
-            cell.connect('clicked', self.__favorite_clicked_cb)
-            column.pack_start(cell, True)
-            column.set_cell_data_func(cell, self.__favorite_set_data_cb)
+            self.cell_favorite = CellRendererFavorite(i)
+            self.cell_favorite.connect('clicked', self.__favorite_clicked_cb)
+            column.pack_start(self.cell_favorite, True)
+            column.set_cell_data_func(self.cell_favorite,
+                                      self.__favorite_set_data_cb)
             self.append_column(column)
 
-        cell_icon = CellRendererActivityIcon()
-        cell_icon.connect('clicked', self.__icon_clicked_cb)
+        self.cell_icon = CellRendererActivityIcon()
+        self.cell_icon.connect('clicked', self.__icon_clicked_cb)
 
         column = Gtk.TreeViewColumn()
-        column.pack_start(cell_icon, True)
-        column.add_attribute(cell_icon, 'file-name', self._model.column_icon)
+        column.pack_start(self.cell_icon, True)
+        column.add_attribute(self.cell_icon, 'file-name',
+                             self._model.column_icon)
         self.append_column(column)
 
         self._icon_column = column
@@ -235,6 +237,8 @@ class ActivitiesTreeView(Gtk.TreeView):
     def connect_to_scroller(self, scrolled):
         scrolled.connect('scroll-start', self._scroll_start_cb)
         scrolled.connect('scroll-end', self._scroll_end_cb)
+        self.cell_icon.connect_to_scroller(scrolled)
+        self.cell_favorite.connect_to_scroller(scrolled)
 
     def _scroll_start_cb(self, event):
         self._invoker.detach()

--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -185,10 +185,10 @@ class BaseListView(Gtk.Bin):
         self.cell_icon = None
         self._title_column = None
         self.sort_column = None
-        self._add_columns()
-        scrolling_detector = ScrollingDetector(self._scrolled_window)
-        self.tree_view.connect_to_scroller(scrolling_detector)
+        self._scrolling_detector = ScrollingDetector(self._scrolled_window)
+        self.tree_view.connect_to_scroller(self._scrolling_detector)
 
+        self._add_columns()
         self.enable_drag_and_copy()
 
         # Auto-update stuff
@@ -250,6 +250,7 @@ class BaseListView(Gtk.Bin):
 
         cell_favorite = CellRendererFavorite()
         cell_favorite.connect('clicked', self._favorite_clicked_cb)
+        cell_favorite.connect_to_scroller(self._scrolling_detector)
 
         self._fav_column = Gtk.TreeViewColumn()
         self._fav_column.props.sizing = Gtk.TreeViewColumnSizing.FIXED
@@ -260,6 +261,7 @@ class BaseListView(Gtk.Bin):
         self.tree_view.append_column(self._fav_column)
 
         self.cell_icon = CellRendererActivityIcon()
+        self.cell_icon.connect_to_scroller(self._scrolling_detector)
 
         column = Gtk.TreeViewColumn()
         self.tree_view.icon_activity_column = column


### PR DESCRIPTION
Issue: Background of multiple cellrendericons in column rendered while scrolling
Link to issue on tracer: https://bugs.sugarlabs.org/ticket/4957
Fixed: Connected scroller to cellrenderericon using the connect_to_scroller() method in sugar3.graphics.icon.py

Issue ->
![desktop-animation](https://cloud.githubusercontent.com/assets/16541261/14394290/3273ced0-fde9-11e5-8982-d7ed8d77da80.gif)
