### PR TITLE
Start activity on single-clicking the corresponding row

### DIFF
--- a/src/jarabe/desktop/activitieslist.py
+++ b/src/jarabe/desktop/activitieslist.py
@@ -56,6 +56,9 @@ class ActivitiesTreeView(Gtk.TreeView):
     def __init__(self):
         Gtk.TreeView.__init__(self)
         self.set_can_focus(False)
+        self.props.activate_on_single_click = True
+
+        self.connect('row-activated', self.__on_row_activated)
 
         self._query = ''
 
@@ -80,7 +83,6 @@ class ActivitiesTreeView(Gtk.TreeView):
             self.append_column(column)
 
         self.cell_icon = CellRendererActivityIcon()
-        self.cell_icon.connect('clicked', self.__icon_clicked_cb)
 
         column = Gtk.TreeViewColumn()
         column.pack_start(self.cell_icon, True)
@@ -154,7 +156,8 @@ class ActivitiesTreeView(Gtk.TreeView):
             not row[self._model.column_favorites[cell.favorite_view]],
             cell.favorite_view)
 
-    def __icon_clicked_cb(self, cell, path):
+    def __on_row_activated(self, treeview, path, col):
+        model = treeview.get_model()
         self._start_activity(path)
 
     def _start_activity(self, path):


### PR DESCRIPTION
This  patch add this requested feature -> https://bugs.sugarlabs.org/ticket/4919

Now the user can start an activity by just single clicking the row in the list view.
![desktop-animation](https://cloud.githubusercontent.com/assets/6258810/14583493/f6ae8f94-0440-11e6-9d23-d00b948111a3.gif)
