### PR TITLE
Start activity on single-clicking the corresponding row #680

### DIFF
--- a/src/jarabe/desktop/activitieslist.py
+++ b/src/jarabe/desktop/activitieslist.py
@@ -157,8 +157,10 @@ class ActivitiesTreeView(Gtk.TreeView):
             cell.favorite_view)
 
     def __on_row_activated(self, treeview, path, col):
-        model = treeview.get_model()
-        self._start_activity(path)
+        # Checks if the 'star' icon is clicked
+        if col is not treeview.get_column(0):
+            model = treeview.get_model()
+            self._start_activity(path)
 
     def _start_activity(self, path):
         model = self.get_model()
@@ -183,10 +185,6 @@ class ActivitiesTreeView(Gtk.TreeView):
         title = model[tree_iter][self._model.column_title]
         title = normalize_string(title.decode('utf-8'))
         return title is not None and title.find(self._query) > -1
-
-    def do_row_activated(self, path, column):
-        if column == self._icon_column:
-            self._start_activity(path)
 
     def create_palette(self, path, column):
         if column == self._icon_column:


### PR DESCRIPTION
This  patch add this requested feature -> https://bugs.sugarlabs.org/ticket/4919

Now the user can start an activity by just single clicking the row in the list view.
![desktop-animation](https://cloud.githubusercontent.com/assets/6258810/14583493/f6ae8f94-0440-11e6-9d23-d00b948111a3.gif)
