### PR TITLE
Erase bundle fixes

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -4,6 +4,7 @@ python_scripts =		\
 	sugar-backlight-setup	\
 	sugar-control-panel	\
 	sugar-install-bundle	\
+	sugar-erase-bundle	\
 	sugar-launch
 
 bin_SCRIPTS = 			\

--- a/bin/sugar-erase-bundle
+++ b/bin/sugar-erase-bundle
@@ -1,0 +1,25 @@
+#!/usr/bin/env python2
+import os
+import sys
+
+from dbus.mainloop.glib import DBusGMainLoop
+DBusGMainLoop(set_as_default=True)
+
+from jarabe.model import bundleregistry
+
+def cmd_help():
+    print 'Usage: sugar-erase-bundle bundle_id [...] \n\n\
+    Erase activity bundles\n'
+
+if len(sys.argv) < 2:
+    cmd_help()
+    exit(2)
+
+for name in sys.argv[1:]:
+    registry = bundleregistry.get_registry()
+    bundle = registry.get_bundle(name)
+    if not bundle:
+        print 'Cannot find %s bundle.' % name
+        continue
+
+    registry.uninstall(bundle, delete_profile=True)

--- a/src/jarabe/model/bundleregistry.py
+++ b/src/jarabe/model/bundleregistry.py
@@ -140,6 +140,24 @@ class BundleRegistry(GObject.GObject):
             self.add_bundle(one_file.get_path(), set_favorite=True)
         elif event_type == Gio.FileMonitorEvent.DELETED:
             self.remove_bundle(one_file.get_path())
+            for root in GLib.get_system_data_dirs():
+                root = os.path.join(root, 'sugar', 'activities')
+
+                try:
+                    dir_list = os.listdir(root)
+                except OSError:
+                    logging.debug('Can not find GLib system dir %s', root)
+                    continue
+                activity_dir = os.path.basename(one_file.get_path())
+                try:
+                    bundle = bundle_from_dir(os.path.join(root, activity_dir))
+                except MalformedBundleException:
+                    continue
+
+                if bundle is not None:
+                    path = bundle.get_path()
+                    if path is not None:
+                        self.add_bundle(path)
 
     def _load_mime_defaults(self):
         defaults = {}


### PR DESCRIPTION
Add sugar-erase-bundle next to sugar-install-bundle.

Expose system activity after user erase; when a user activity is erased using "rm -rf" or sugar-erase-bundle, any system activity was not exposed.  Handle a FileMonitorEvent.DELETED by also looking for the same activity in the system activity directories.