### PR TITLE
Revert "Fixed #3146: Dragging a Journal entry drags the whole white e…

### DIFF
--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -23,7 +23,6 @@ from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import Pango
-from gi.repository import GdkPixbuf
 
 from sugar3.graphics import style
 from sugar3.graphics.icon import Icon, CellRendererIcon
@@ -204,12 +203,10 @@ class BaseListView(Gtk.Bin):
         model.deleted.connect(self.__model_deleted_cb)
 
     def enable_drag_and_copy(self):
-        self.tree_view.drag_source_set(Gdk.ModifierType.BUTTON1_MASK,
-                                       [Gtk.TargetEntry.new(
-                                           'text/uri-list', 0, 0),
-                                        Gtk.TargetEntry.new(
-                                            'journal-object-id', 0, 0)],
-                                       Gdk.DragAction.COPY)
+        self.tree_view.enable_model_drag_source(Gdk.ModifierType.BUTTON1_MASK,
+                                                [('text/uri-list', 0, 0),
+                                                 ('journal-object-id', 0, 0)],
+                                                Gdk.DragAction.COPY)
 
     def disable_drag_and_copy(self):
         self.tree_view.unset_rows_drag_source()
@@ -719,13 +716,6 @@ class ListView(BaseListView):
         return self._is_dragging
 
     def __drag_begin_cb(self, widget, drag_context):
-        path, _column = self.tree_view.get_cursor()
-        if path is None:
-            return
-
-        row = self.tree_view.get_model()[path]
-        _pixbuf = GdkPixbuf.Pixbuf.new_from_file(row[ListModel.COLUMN_ICON])
-        self.tree_view.drag_source_set_icon_pixbuf(_pixbuf)
         self._is_dragging = True
 
     def __drag_data_get_cb(self, widget, context, selection, info, time):


### PR DESCRIPTION
…ntry bar, not just the icon"

This reverts commit 89f460b88d84c0887c0b458cf2bcffd0a55c3427.

Breaks on Fedora 18.  Cursor changes to "+" at the start of the drag,
but the drag survives only a very short distance before the cursor
returns to normal, and there is no floating icon following the cursor.