### PR TITLE
Remove log noise in Journal List View

### DIFF
--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -361,7 +361,6 @@ class BaseListView(Gtk.Bin):
         if buddy is None:
             cell.props.visible = False
             return
-        logging.error('__buddies_set_data_cb %s', buddy)
         # FIXME workaround for pygobject bug, see
         # https://bugzilla.gnome.org/show_bug.cgi?id=689277
         #


### PR DESCRIPTION
Was introduced in 265353af21f306e5b6316110c8b4d3e0a9e21b07 and does not seem to serve a purpose.