### PR TITLE
Display activity instance title in join requests

### DIFF
--- a/src/jarabe/frame/activitiestray.py
+++ b/src/jarabe/frame/activitiestray.py
@@ -221,11 +221,14 @@ class InvitePalette(Palette):
         registry = bundleregistry.get_registry()
         self._bundle = registry.get_bundle(bundle_id)
         if self._bundle:
-            name = self._bundle.get_name()
+            activity_name = self._bundle.get_name()
         else:
-            name = bundle_id
+            activity_name = bundle_id
+        self.set_primary_text(activity_name)
 
-        self.set_primary_text(name)
+        title = self._invite.get_activity_title()
+        if title is not None:
+            self.set_secondary_text(title)
 
     def __join_activate_cb(self, menu_item):
         self._invite.join()

--- a/src/jarabe/model/invites.py
+++ b/src/jarabe/model/invites.py
@@ -58,6 +58,9 @@ class BaseInvite(object):
         else:
             return None
 
+    def get_activity_title(self):
+        return None
+
     def _call_handle_with(self):
         bus = dbus.Bus()
         obj = bus.get_object(CHANNEL_DISPATCHER, self.dispatch_operation_path)
@@ -97,6 +100,9 @@ class ActivityInvite(BaseInvite):
         if color is not None:
             color = str(color)
         return XoColor(color)
+
+    def get_activity_title(self):
+        return self._activity_properties.get('name')
 
     def join(self):
         logging.error('ActivityInvite.join handler %r', self._handler)


### PR DESCRIPTION
Currently, only the activity name is displayed.  This could be
confusing - "what is this write activity that you just invited me
to?  is it the kangaroo project, or the dolphin project?"

This commit displays the title as the palette secondary text, which
is consistent with how running activities are displayed in the frame.

After:

![screenshot from 2016-06-11 14-01-43](https://cloud.githubusercontent.com/assets/6022042/15983004/5462c272-2f89-11e6-8e24-6528c23757f6.png)

Before... the same, but it didn't say "Kangaroo Project Chat"