### PR TITLE
Remove Dari and Guarani languages workaround

### DIFF
--- a/extensions/cpsection/language/model.py
+++ b/extensions/cpsection/language/model.py
@@ -57,11 +57,6 @@ def read_all_languages():
             if locale_str.endswith('utf8') and len(lang):
                 locales.append((lang, territory, locale_str))
 
-    # FIXME: This is a temporary workaround for locales that are essential to
-    # OLPC, but are not in Glibc yet.
-    locales.append(('Dari', 'Afghanistan', 'fa_AF.utf8'))
-    locales.append(('Guarani', 'Paraguay', 'gn.utf8'))
-
     locales.sort()
     return locales
 


### PR DESCRIPTION
Sugar should not misrepresent the system language list.

Will be added back as a packaging patch by OLPC OS if required for any future release.

References:
 * http://lists.sugarlabs.org/archive/sugar-devel/2016-July/053245.html by @icarito 
 * https://github.com/sugarlabs/sugar/pull/550#issuecomment-118431549