### PR TITLE
Resume Activity Gsettings

### DIFF
--- a/data/org.sugarlabs.gschema.xml
+++ b/data/org.sugarlabs.gschema.xml
@@ -87,6 +87,13 @@
             <summary>Group Label</summary>
             <description>Label associated with age, e.g., '2nd Grade'</description>
         </key>
+        <key name="resume-activity" type="b">
+            <default>true</default>
+            <summary>Resume Activity</summary>
+            <description>If TRUE, Sugar will set default launch of activities in home view to 'resumable' mode. 
+                         If FALSE, Sugar will set default launch of activities in home view to 'start-new' mode.
+            </description>
+        </key>
         <child name="background" schema="org.sugarlabs.user.background" />
     </schema>
     <schema id="org.sugarlabs.user.background" path="/org/sugarlabs/user/background/">

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -149,7 +149,8 @@ class FavoritesView(ViewContainer):
         self._last_clicked_icon = None
 
         self._alert = None
-        self._resume_mode = True
+        self._resume_mode = Gio.Settings(
+            'org.sugarlabs.user').get_boolean('resume-activity')
 
         GLib.idle_add(self.__connect_to_bundle_registry_cb)
 
@@ -417,7 +418,8 @@ class ActivityIcon(CanvasIcon):
 
         self._activity_info = activity_info
         self._journal_entries = []
-        self._resume_mode = True
+        self._resume_mode = Gio.Settings(
+            'org.sugarlabs.user').get_boolean('resume-activity')
 
         self.connect_after('activate', self.__button_activate_cb)
 

--- a/src/jarabe/desktop/homebox.py
+++ b/src/jarabe/desktop/homebox.py
@@ -17,6 +17,7 @@ import logging
 
 from gi.repository import Gtk
 from gi.repository import Gdk
+from gi.repository import Gio
 
 from jarabe.desktop import favoritesview
 from jarabe.desktop.activitieslist import ActivitiesList
@@ -58,7 +59,8 @@ class HomeBox(Gtk.VBox):
 
         self._set_view(self._favorites_views_indicies[0])
         self._query = ''
-        self._resume_mode = True
+        self._resume_mode = Gio.Settings(
+            'org.sugarlabs.user').get_boolean('resume-activity')
 
     def __desktop_view_icons_changed_cb(self, model):
         number_of_views = desktop.get_number_of_views()
@@ -116,7 +118,7 @@ class HomeBox(Gtk.VBox):
             self._list_view.run_activity(entry._icon_selected[0]['bundle_id'],
                                          self._resume_mode)
             entry._icon_selected = []
-            self.set_resume_mode(True)
+            self.set_resume_mode(self._resume_mode)
 
     def __activitylist_clear_clicked_cb(self, widget, toolbar):
         toolbar.clear_query()

--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -19,6 +19,7 @@ import logging
 from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Gdk
+from gi.repository import Gio
 from gi.repository import GdkX11
 
 from sugar3.graphics import style
@@ -90,6 +91,11 @@ class HomeWindow(Gtk.Window):
         self._home_box.show()
         self._toolbar.show_view_buttons()
 
+        # Loads the Gsettings value for activity 'resume-mode'
+        setting = Gio.Settings('org.sugarlabs.user')
+        self._resume_mode = setting.get_boolean('resume-activity')
+        self._home_box.set_resume_mode(self._resume_mode)
+
         self._group_box = GroupBox(self._toolbar)
         self._mesh_box = MeshBox(self._toolbar)
         self._transition_box = TransitionBox()
@@ -160,7 +166,7 @@ class HomeWindow(Gtk.Window):
 
     def __key_press_event_cb(self, window, event):
         if self.__is_alt(event) and not self._alt_timeout_sid:
-            self._home_box.set_resume_mode(False)
+            self._home_box.set_resume_mode(not self._resume_mode)
             self._alt_timeout_sid = GObject.timeout_add(100,
                                                         self.__alt_timeout_cb)
 
@@ -171,7 +177,7 @@ class HomeWindow(Gtk.Window):
 
     def __key_release_event_cb(self, window, event):
         if self.__is_alt(event) and self._alt_timeout_sid:
-            self._home_box.set_resume_mode(True)
+            self._home_box.set_resume_mode(self._resume_mode)
             GObject.source_remove(self._alt_timeout_sid)
             self._alt_timeout_sid = None
 
@@ -183,7 +189,7 @@ class HomeWindow(Gtk.Window):
         if modmask & Gdk.ModifierType.MOD1_MASK:
             return True
 
-        self._home_box.set_resume_mode(True)
+        self._home_box.set_resume_mode(self._resume_mode)
 
         if self._alt_timeout_sid:
             GObject.source_remove(self._alt_timeout_sid)


### PR DESCRIPTION
A new boolean value is now added to gsettings to toggle the default start mode of an activity from home view-
1) If the value is TRUE- Resumed instance opens
2) the value is FALSE - New instance starts


This GSetting value can be toggled from terminal by the following command - 
**$ gsettings set org.sugarlabs.user resume-activity false** (This sets the home view to start the new instance of every activity)

**$ gsettings set org.sugarlabs.user resume-activity true**  (This sets the home view to resume the instance by default)
