### PR TITLE
Brightness: make frame device more responsive

### DIFF
--- a/extensions/deviceicon/display.py
+++ b/extensions/deviceicon/display.py
@@ -81,7 +81,7 @@ class DeviceView(TrayIcon):
 
 class BrightnessManagerWidget(Gtk.VBox):
 
-    TIMEOUT_DELAY = 100
+    TIMEOUT_DELAY = 10
 
     def __init__(self, text, icon_name):
         Gtk.VBox.__init__(self)


### PR DESCRIPTION
Moving the brightness slider in the display frame device did not change
the brightness promptly, so it was difficult for the user to choose a
brightness.

Decrease the timeout, therefore increasing the responsiveness.

OLPC note: has been sent to manufacturing of SKU400.