### PR TITLE
Wireless password fixes

### DIFF
--- a/src/jarabe/desktop/keydialog.py
+++ b/src/jarabe/desktop/keydialog.py
@@ -110,7 +110,6 @@ class KeyDialog(Gtk.Dialog):
         button.props.draw_indicator = True
         button.props.active = self._entry.get_visibility()
         button.connect("toggled", self._button_toggled_cb)
-        button.show()
         self.vbox.pack_start(button, True, True, 0)
 
         self.vbox.show_all()

--- a/src/jarabe/desktop/keydialog.py
+++ b/src/jarabe/desktop/keydialog.py
@@ -100,7 +100,7 @@ class KeyDialog(Gtk.Dialog):
         self.set_default_response(Gtk.ResponseType.OK)
 
     def add_key_entry(self):
-        self._entry = Gtk.Entry(visibility=False)
+        self._entry = Gtk.Entry(visibility=True)
         self._entry.connect('changed', self._update_response_sensitivity)
         self._entry.connect('activate', self._entry_activate_cb)
         self.vbox.pack_start(self._entry, True, True, 0)
@@ -108,7 +108,7 @@ class KeyDialog(Gtk.Dialog):
 
         self._show_pass_toggle = Gtk.CheckButton(_("Show Password"))
         self._show_pass_toggle.props.draw_indicator = True
-        self._show_pass_toggle.props.active = False
+        self._show_pass_toggle.props.active = self._entry.get_visibility()
         self._show_pass_toggle.connect("toggled", self._toggle_visibility_cb)
         self._show_pass_toggle.show()
         self.vbox.pack_start(self._show_pass_toggle, True, True, 0)

--- a/src/jarabe/desktop/keydialog.py
+++ b/src/jarabe/desktop/keydialog.py
@@ -106,7 +106,7 @@ class KeyDialog(Gtk.Dialog):
         self.vbox.pack_start(self._entry, True, True, 0)
         self.vbox.set_spacing(6)
 
-        self._show_pass_toggle = Gtk.CheckButton("Show Password")
+        self._show_pass_toggle = Gtk.CheckButton(_("Show Password"))
         self._show_pass_toggle.props.draw_indicator = True
         self._show_pass_toggle.props.active = False
         self._show_pass_toggle.connect("toggled", self._toggle_visibility_cb)

--- a/src/jarabe/desktop/keydialog.py
+++ b/src/jarabe/desktop/keydialog.py
@@ -102,14 +102,14 @@ class KeyDialog(Gtk.Dialog):
     def add_key_entry(self):
         self._entry = Gtk.Entry(visibility=True)
         self._entry.connect('changed', self._update_response_sensitivity)
-        self._entry.connect('activate', self._entry_activate_cb)
+        self._entry.connect('activate', self.__entry_activate_cb)
         self.vbox.pack_start(self._entry, True, True, 0)
         self.vbox.set_spacing(6)
 
         button = Gtk.CheckButton(_("Show Password"))
         button.props.draw_indicator = True
         button.props.active = self._entry.get_visibility()
-        button.connect("toggled", self._button_toggled_cb)
+        button.connect("toggled", self.__button_toggled_cb)
         self.vbox.pack_start(button, True, True, 0)
 
         self.vbox.show_all()
@@ -117,7 +117,7 @@ class KeyDialog(Gtk.Dialog):
         self._update_response_sensitivity()
         self._entry.grab_focus()
 
-    def _entry_activate_cb(self, entry):
+    def __entry_activate_cb(self, entry):
         self.response(Gtk.ResponseType.OK)
 
     def create_security(self):
@@ -126,7 +126,7 @@ class KeyDialog(Gtk.Dialog):
     def get_response_object(self):
         return self._response
 
-    def _button_toggled_cb(self, button):
+    def __button_toggled_cb(self, button):
         self._entry.set_visibility(button.get_active())
 
 
@@ -147,7 +147,7 @@ class WEPKeyDialog(KeyDialog):
         self.key_combo.pack_start(cell, True)
         self.key_combo.add_attribute(cell, 'text', 0)
         self.key_combo.set_active(0)
-        self.key_combo.connect('changed', self._key_combo_changed_cb)
+        self.key_combo.connect('changed', self.__key_combo_changed_cb)
 
         hbox = Gtk.HBox()
         hbox.pack_start(Gtk.Label(_('Key Type:')), True, True, 0)
@@ -176,7 +176,7 @@ class WEPKeyDialog(KeyDialog):
 
         self.vbox.pack_start(hbox, True, True, 0)
 
-    def _key_combo_changed_cb(self, widget):
+    def __key_combo_changed_cb(self, widget):
         self._update_response_sensitivity()
 
     def _get_security(self):

--- a/src/jarabe/desktop/keydialog.py
+++ b/src/jarabe/desktop/keydialog.py
@@ -106,12 +106,12 @@ class KeyDialog(Gtk.Dialog):
         self.vbox.pack_start(self._entry, True, True, 0)
         self.vbox.set_spacing(6)
 
-        self._show_pass_toggle = Gtk.CheckButton(_("Show Password"))
-        self._show_pass_toggle.props.draw_indicator = True
-        self._show_pass_toggle.props.active = self._entry.get_visibility()
-        self._show_pass_toggle.connect("toggled", self._toggle_visibility_cb)
-        self._show_pass_toggle.show()
-        self.vbox.pack_start(self._show_pass_toggle, True, True, 0)
+        button = Gtk.CheckButton(_("Show Password"))
+        button.props.draw_indicator = True
+        button.props.active = self._entry.get_visibility()
+        button.connect("toggled", self._button_toggled_cb)
+        button.show()
+        self.vbox.pack_start(button, True, True, 0)
 
         self.vbox.show_all()
 
@@ -127,8 +127,8 @@ class KeyDialog(Gtk.Dialog):
     def get_response_object(self):
         return self._response
 
-    def _toggle_visibility_cb(self, entry):
-        self._entry.set_visibility(self._show_pass_toggle.get_active())
+    def _button_toggled_cb(self, button):
+        self._entry.set_visibility(button.get_active())
 
 
 class WEPKeyDialog(KeyDialog):

--- a/src/jarabe/desktop/keydialog.py
+++ b/src/jarabe/desktop/keydialog.py
@@ -127,7 +127,7 @@ class KeyDialog(Gtk.Dialog):
     def get_response_object(self):
         return self._response
 
-    def __toggle_visibility_cb(self, entry):
+    def _toggle_visibility_cb(self, entry):
         self._entry.set_visibility(self._show_pass_toggle.get_active())
 
 


### PR DESCRIPTION
Sugar 0.109.0.1 and 0.109.0.2 cannot connect to new secured networks.  The wireless password prompt does not appear.  Saved passwords made with 0.109.0.0 and earlier continue to work.

This regression was introduced in #693 commit dca2f17b8dd16adcff0ec98dc0ee63f8c8dce38b, and was apparently not tested in the form it was committed.

Also in this pull request;
- ensure "Show Password" can be translated,
- default to show the password, as per consensus in #693 and the default in 0.108,
- simplify and improve code style,
- remove an unnecessary call to the Gtk.Widget.show() method.

See individual commits for full details.