### PR TITLE
Wireless icon badge consistency

### DIFF
--- a/extensions/cpsection/network/model.py
+++ b/extensions/cpsection/network/model.py
@@ -17,7 +17,6 @@
 
 import logging
 
-import dbus
 from gettext import gettext as _
 from gi.repository import Gio
 from gi.repository import NMClient
@@ -116,63 +115,12 @@ def clear_registration():
     return 1
 
 
-wifi_whitelist = ('Sugar Ad-hoc Network 1',
-                  'Sugar Ad-hoc Network 6',
-                  'Sugar Ad-hoc Network 11')
-mesh_whitelist = ('OLPC Mesh Network 1',
-                  'OLPC Mesh Network 6',
-                  'OLPC Mesh Network 11',
-                  'OLPC XS Mesh Network 1',
-                  'OLPC XS Mesh Network 6',
-                  'OLPC XS Mesh Network 11')
-
-
-def is_wireless(connection):
-    """Check for wireless connection not whitelisted by Sugar.
-    """
-    wifi_settings = connection.get_settings(
-        network.NM_CONNECTION_TYPE_802_11_WIRELESS)
-    if wifi_settings:
-        return not (wifi_settings['mode'] == 'adhoc' and
-                    connection.get_id() in wifi_whitelist)
-
-    mesh_settings = connection.get_settings(
-        network.NM_CONNECTION_TYPE_802_11_OLPC_MESH)
-    if mesh_settings:
-        return not connection.get_id() in mesh_whitelist
-
-
 def clear_wireless_networks():
-    """Remove all wireless connections except Sugar-internal ones.
-    """
-    try:
-        connections = network.get_connections()
-    except dbus.DBusException:
-        logging.debug('NetworkManager not available')
-    else:
-        wireless_connections = \
-            (connection for connection in
-             connections.get_list() if is_wireless(connection))
-
-        for connection in wireless_connections:
-            try:
-                connection.delete()
-            except dbus.DBusException:
-                logging.debug("Could not remove connection %s",
-                              connection.get_id())
+    network.clear_wireless_networks()
 
 
 def have_wireless_networks():
-    """Check that there are non-Sugar-internal wireless connections.
-    """
-    try:
-        connections = network.get_connections()
-    except dbus.DBusException:
-        logging.debug('NetworkManager not available')
-        return False
-    else:
-        return any(is_wireless(connection)
-                   for connection in connections.get_list())
+    return network.have_wireless_networks()
 
 
 def get_publish_information():

--- a/src/jarabe/desktop/networkviews.py
+++ b/src/jarabe/desktop/networkviews.py
@@ -220,19 +220,18 @@ class WirelessNetworkView(EventPulsingIcon):
                 icon.props.icon_name = icon_name
 
     def _update_badge(self):
+        badge = None
         if self._mode != network.NM_802_11_MODE_ADHOC:
-            if network.find_connection_by_ssid(self._ssid) is not None:
-                self.props.badge_name = 'emblem-favorite'
-                self._palette_icon.props.badge_name = 'emblem-favorite'
-            elif self._flags == network.NM_802_11_AP_FLAGS_PRIVACY:
-                self.props.badge_name = 'emblem-locked'
-                self._palette_icon.props.badge_name = 'emblem-locked'
-            else:
-                self.props.badge_name = None
-                self._palette_icon.props.badge_name = None
-        else:
-            self.props.badge_name = None
-            self._palette_icon.props.badge_name = None
+            locked = (self._flags == network.NM_802_11_AP_FLAGS_PRIVACY)
+            connection = network.find_connection_by_ssid(self._ssid)
+            if connection is not None:
+                if locked:
+                    badge = 'emblem-favorite-locked'
+                else:
+                    badge = 'emblem-favorite'
+            elif locked:
+                badge = 'emblem-locked'
+        self.props.badge_name = self._palette_icon.props.badge_name = badge
 
     def _update_state(self):
         if self._active_ap is not None:


### PR DESCRIPTION
The neighbourhood view uses icon badges to mark networks that are either locked or have been connected to.

The locked badge is lost when a network is connected to.  Fix is to add a new badge for locked and connected to.  Requires https://github.com/sugarlabs/sugar-artwork/pull/92.

The connected to badge is not removed promptly when the connections are discarded using the control panel.  Fix is to connect a removed signal and update the icon badge.

p.s. a patch for making discard testing faster by adding it to the buddy menu can be found at http://dev.laptop.org/~quozl/z/1bPOj7.txt