### PR TITLE
Enhanced favourites: hidden bundles

### DIFF
--- a/data/activities.hidden
+++ b/data/activities.hidden
@@ -1,2 +1,17 @@
 org.laptop.Terminal
 org.laptop.Log
+org.laptop.ImageViewerActivity
+org.laptop.sugar.Jukebox
+org.laptop.sugar.ReadActivity
+org.laptop.TamTamEdit
+org.laptop.TamTamJam
+org.laptop.TamTamSynthLab
+org.laptop.biology
+org.icdlbooks.icdl
+org.jamendo.music
+org.laptop.wp-nature-images
+info.dicts.dictionary-ml
+org.laptop.wikibooks
+info.dicts.wikislice-chemistry
+gov.loc.wdl
+info.dicts.worldfactbook.small


### PR DESCRIPTION
The OLPC library bundles and several activities appear in the activity
ring as favourites; they did not appear previously.

The OLPC library bundles have not changed for several years, and are
effectively a deprecated feature.  They are not included in our Ubuntu
builds, where we use the Wikipedia activity instead.  Adding them to the
list should have no impact on Ubuntu or Fedora SoaS.

ImageViewer, Jukebox, and Read activities were originally hidden.  Sugar
recently exposed them as a result of the enhanced favourites
patches (#4841).  Adding them to the list will hide them.

TamTamEdit, TamTamJam, and TamTamSynthLab were originally hidden.