### PR TITLE
IEC 80000-13:2008 and IEEE 1541-2002 compliance

### DIFF
--- a/extensions/cpsection/updater/view.py
+++ b/extensions/cpsection/updater/view.py
@@ -423,10 +423,10 @@ def _format_size(size):
         return _('None')
     elif size < 1024:
         # TRANS: download size of very small updates
-        return _('1 KB')
+        return _('1 KiB')
     elif size < 1024 * 1024:
-        # TRANS: download size of small updates, e.g. '250 KB'
-        return locale.format_string(_('%.0f KB'), size / 1024.0)
+        # TRANS: download size of small updates, e.g. '250 KiB'
+        return locale.format_string(_('%.0f KiB'), size / 1024.0)
     else:
-        # TRANS: download size of updates, e.g. '2.3 MB'
-        return locale.format_string(_('%.1f MB'), size / 1024.0 / 1024)
+        # TRANS: download size of updates, e.g. '2.3 MiB'
+        return locale.format_string(_('%.1f MiB'), size / 1024.0 / 1024)

--- a/extensions/deviceicon/network.py
+++ b/extensions/deviceicon/network.py
@@ -343,10 +343,8 @@ class GsmPalette(Palette):
         self.props.secondary_text = _('Connected for %s') % (formatted_time, )
 
     def update_stats(self, in_bytes, out_bytes):
-        in_KBytes = in_bytes / 1024
-        out_KBytes = out_bytes / 1024
-        self._data_label_up.set_text(_('%d KB') % (out_KBytes))
-        self._data_label_down.set_text(_('%d KB') % (in_KBytes))
+        self._data_label_up.set_text(_('%d KiB') % (out_bytes / 1024))
+        self._data_label_down.set_text(_('%d KiB') % (in_bytes / 1024))
 
     def _get_error_by_nm_reason(self, reason):
         if reason in [network.NM_DEVICE_STATE_REASON_NO_SECRETS,

--- a/src/jarabe/frame/activitiestray.py
+++ b/src/jarabe/frame/activitiestray.py
@@ -602,11 +602,11 @@ class BaseTransferPalette(Palette):
 
     def _format_size(self, size):
         if size < 1024:
-            return _('%dB') % size
+            return _('%d B') % size
         elif size < 1048576:
-            return _('%dKB') % (size / 1024)
+            return _('%d KiB') % (size / 1024)
         else:
-            return _('%dMB') % (size / 1048576)
+            return _('%d MiB') % (size / 1048576)
 
     def update_progress(self):
         logging.debug('update_progress: %r',

--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -59,7 +59,7 @@ J_DBUS_SERVICE = 'org.laptop.Journal'
 J_DBUS_INTERFACE = 'org.laptop.Journal'
 J_DBUS_PATH = '/org/laptop/Journal'
 
-_SPACE_TRESHOLD = 52428800
+_SPACE_THRESHOLD = 50  # MiB
 _BUNDLE_ID = 'org.laptop.JournalActivity'
 SCOPE_PRIVATE = 'private'
 _journal = None
@@ -558,15 +558,15 @@ class JournalActivity(JournalWindow):
     def _check_available_space(self):
         """Check available space on device
 
-            If the available space is below 50MB an alert will be
-            shown which encourages to delete old journal entries.
+            If the available space is below threshold an alert will be
+            shown which suggests deleting old journal entries.
         """
 
         if self._critical_space_alert:
             return
         stat = os.statvfs(env.get_profile_path())
         free_space = stat[statvfs.F_BSIZE] * stat[statvfs.F_BAVAIL]
-        if free_space < _SPACE_TRESHOLD:
+        if free_space < (_SPACE_THRESHOLD * 1024 * 1024):
             self._critical_space_alert = ModalAlert()
             self._critical_space_alert.connect('destroy',
                                                self.__alert_closed_cb)

--- a/src/jarabe/journal/volumestoolbar.py
+++ b/src/jarabe/journal/volumestoolbar.py
@@ -373,7 +373,7 @@ class JournalButtonPalette(Palette):
 
         fraction = (total_space - free_space) / float(total_space)
         self._progress_bar.props.fraction = fraction
-        self._free_space_label.props.label = _('%(free_space)d MB Free') % \
+        self._free_space_label.props.label = _('%(free_space)d MiB Free') % \
             {'free_space': free_space / (1024 * 1024)}
 
 

--- a/src/jarabe/view/palettes.py
+++ b/src/jarabe/view/palettes.py
@@ -249,7 +249,7 @@ class JournalPalette(BasePalette):
 
         fraction = (total_space - free_space) / float(total_space)
         self._progress_bar.props.fraction = fraction
-        self._free_space_label.props.label = _('%(free_space)d MB Free') % \
+        self._free_space_label.props.label = _('%(free_space)d MiB Free') % \
             {'free_space': free_space / (1024 * 1024)}
 
 
@@ -316,5 +316,5 @@ class VolumePalette(Palette):
 
         fraction = (total_space - free_space) / float(total_space)
         self._progress_bar.props.fraction = fraction
-        self._free_space_label.props.label = _('%(free_space)d MB Free') % \
+        self._free_space_label.props.label = _('%(free_space)d MiB Free') % \
             {'free_space': free_space / (1024 * 1024)}


### PR DESCRIPTION
Sugar used ambiguous units for number of bytes.  Since then, the units have been standardised internationally.

- change MB to MiB,

- change KB to KiB,

- separate quantity and units for activities tray transfer palette,

- fix spelling of _SPACE_TRESHOLD, to be _SPACE_THRESHOLD,

- change units of _SPACE_THRESHOLD to MiB.

References:

- https://en.wikipedia.org/wiki/IEEE_1541-2002
- http://physics.nist.gov/cuu/Units/binary.html
- https://en.wikipedia.org/wiki/ISO/IEC_80000