### PR TITLE
Fix ObjectChooser without parent

### DIFF
--- a/src/jarabe/journal/objectchooser.py
+++ b/src/jarabe/journal/objectchooser.py
@@ -45,7 +45,14 @@ class ObjectChooser(PopWindow):
 
     def __init__(self, parent=None, what_filter='', filter_type=None,
                  show_preview=False):
-        PopWindow.__init__(self, window_xid=parent.get_xid())
+        if parent is None:
+            parent_xid = 0
+        elif hasattr(parent, 'get_window') and hasattr(parent.get_window(),
+                                                       'get_xid'):
+            parent_xid = parent.get_window().get_xid()
+        else:
+            parent_xid = parent
+        PopWindow.__init__(self, window_xid=parent_xid)
 
         self._selected_object_id = None
         self._show_preview = show_preview


### PR DESCRIPTION
With Sugar 0.109.0.2 several activities can no longer use the ObjectChooser; it does not appear, and logs show;
```
Traceback (most recent call last):
  File "/usr/share/sugar/activities/Labyrinth.activity/src/MMapArea.py", line 323, in button_release
    if not obj.process_button_release(event, coords):
  File "/usr/share/sugar/activities/Labyrinth.activity/src/ImageThought.py", line 139, in process_button_release
    if not self.journal_open_image():
  File "/usr/share/sugar/activities/Labyrinth.activity/src/ImageThought.py", line 65, in journal_open_image
    result = chooser.run()
  File "/usr/lib/python2.7/dist-packages/sugar/graphics/objectchooser.py", line 87, in run
    self._chooser_id = journal.ChooseObject(self._parent_xid, what_filter)
  File "/usr/lib/python2.7/dist-packages/dbus/proxies.py", line 70, in __call__
    return self._proxy_method(*args, **keywords)
  File "/usr/lib/python2.7/dist-packages/dbus/proxies.py", line 145, in __call__
    **keywords)
  File "/usr/lib/python2.7/dist-packages/dbus/connection.py", line 651, in call_blocking
    message, timeout)
dbus.exceptions.DBusException: org.freedesktop.DBus.Python.AttributeError: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/dbus/service.py", line 707, in _message_cb
    retval = candidate_method(self, *args, **keywords)
  File "/usr/lib/python2.7/dist-packages/jarabe/journal/journalactivity.py", line 145, in ChooseObject
    chooser = ObjectChooser(parent, what_filter)
  File "/usr/lib/python2.7/dist-packages/jarabe/journal/objectchooser.py", line 48, in __init__
    PopWindow.__init__(self, window_xid=parent.get_xid())
AttributeError: 'NoneType' object has no attribute 'get_xid'
```

Regression was introduced by cadac88.  The parent argument was always optional, but it was being treated as mandatory.

Changing all affected activities is impractical because of off-net repositories.  So let's make the argument optional again, restoring the original API.

Code was copied from `ObjectChooser.__init__` in the toolkit
https://github.com/sugarlabs/sugar-toolkit-gtk3/blob/master/src/sugar3/graphics/objectchooser.py#L164