### PR TITLE
Wireless right-to-forget #2264

### DIFF
--- a/src/jarabe/desktop/networkviews.py
+++ b/src/jarabe/desktop/networkviews.py
@@ -139,6 +139,12 @@ class WirelessNetworkView(EventPulsingIcon):
             'activate', self.__disconnect_activate_cb)
         self.menu_box.add(self._disconnect_item)
 
+        self._forget_item = PaletteMenuItem(_('Forget'))
+        icon = Icon(pixel_size=style.SMALL_ICON_SIZE, icon_name='list-remove')
+        self._forget_item.set_image(icon)
+        self._forget_item.connect('activate', self.__forget_activate_cb)
+        self.menu_box.add(self._forget_item)
+
         p.set_content(self.menu_box)
         self.menu_box.show_all()
 
@@ -222,10 +228,12 @@ class WirelessNetworkView(EventPulsingIcon):
 
     def _update_badge(self):
         badge = None
+        favorite = False
         if self._mode != network.NM_802_11_MODE_ADHOC:
             locked = (self._flags == network.NM_802_11_AP_FLAGS_PRIVACY)
             connection = network.find_connection_by_ssid(self._ssid)
             if connection is not None:
+                favorite = True
                 self._connect_removed(connection)
                 if locked:
                     badge = 'emblem-favorite-locked'
@@ -234,6 +242,7 @@ class WirelessNetworkView(EventPulsingIcon):
             elif locked:
                 badge = 'emblem-locked'
         self.props.badge_name = self._palette_icon.props.badge_name = badge
+        self._forget_item.set_visible(favorite)
 
     def _connect_removed(self, connection):
         if self._removed_hid is not None:
@@ -290,6 +299,9 @@ class WirelessNetworkView(EventPulsingIcon):
     def __disconnect_activate_cb(self, item):
         ap_paths = self._access_points.keys()
         network.disconnect_access_points(ap_paths)
+
+    def __forget_activate_cb(self, item):
+        network.forget_wireless_network(self._ssid)
 
     def _add_ciphers_from_flags(self, flags, pairwise):
         ciphers = []

--- a/src/jarabe/model/network.py
+++ b/src/jarabe/model/network.py
@@ -1085,6 +1085,12 @@ def disconnect_access_points(ap_paths):
             dev.Disconnect()
 
 
+def forget_wireless_network(ssid):
+    connection = find_connection_by_ssid(ssid)
+    if connection:
+        connection.delete()
+
+
 def _is_non_printable(char):
     """
     Return True if char is a non-printable unicode character, False otherwise


### PR DESCRIPTION
_(Apologies, but this pull request was held up waiting for #704 to merge.)_

Once a wireless network is connected to, Sugar persists in trying to connect next time it starts.  Workaround is to "Discard wireless connections" in network control panel.

Add a forget menu item to the wireless network icons.

----

After this patch was written, an alternate implementation was found in https://bugs.sugarlabs.org/ticket/2264 written by Ezequiel Pereira (@ezequielpereira) during Google Code-in 2014, that had not been merged:

https://bugs.sugarlabs.org/attachment/ticket/2264/0001-Added-Forget-option-to-network-menu.patch

Ezequiel's patch seems to go a bit further than necessary, and brings the connection deletion into networkviews.py.  It may also need rebasing.

