### PR TITLE
Homewindow desktop component

### DIFF
--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -48,6 +48,7 @@ from jarabe.model import shell
 from jarabe.model import bundleregistry
 from jarabe.model import desktop
 from jarabe.journal import misc
+from jarabe.journal import journalactivity
 
 from jarabe.desktop import schoolserver
 from jarabe.desktop.schoolserver import RegisterError
@@ -604,6 +605,8 @@ class CurrentActivityIcon(CanvasIcon):
 
         if self._home_activity is not None:
             self._update()
+        else:
+            self._home_activity = journalactivity.get_journal()
 
         self._home_model.connect('active-activity-changed',
                                  self.__active_activity_changed_cb)

--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -62,6 +62,8 @@ class HomeWindow(Gtk.Window):
         self.set_default_size(screen.get_width(),
                               screen.get_height())
 
+        self.__screen_size_change_cb(None)
+
         self.realize()
         self._busy_count = 0
         self.busy()
@@ -138,7 +140,21 @@ class HomeWindow(Gtk.Window):
             self._mesh_box.suspend()
 
     def __screen_size_change_cb(self, screen):
-        self.resize(screen.get_width(), screen.get_height())
+        screen = Gdk.Screen.get_default()
+        workarea = screen.get_monitor_workarea(screen.get_number())
+        geometry = Gdk.Geometry()
+        geometry.max_width = geometry.base_width = geometry.min_width = \
+            workarea.width
+        geometry.max_height = geometry.base_height = geometry.min_height = \
+            workarea.height
+        geometry.width_inc = geometry.height_inc = geometry.min_aspect = \
+            geometry.max_aspect = 1
+        hints = Gdk.WindowHints(Gdk.WindowHints.ASPECT |
+                                Gdk.WindowHints.BASE_SIZE |
+                                Gdk.WindowHints.MAX_SIZE |
+                                Gdk.WindowHints.MIN_SIZE)
+        self.move(workarea.x, workarea.y)
+        self.set_geometry_hints(None, geometry, hints)
 
     def _activate_view(self, level):
         if level == ShellModel.ZOOM_HOME:

--- a/src/jarabe/journal/journalwindow.py
+++ b/src/jarabe/journal/journalwindow.py
@@ -16,6 +16,8 @@
 
 from sugar3.graphics.window import Window
 
+from gettext import gettext as _
+
 _journal_window = None
 
 
@@ -26,6 +28,8 @@ class JournalWindow(Window):
         global _journal_window
         Window.__init__(self)
         _journal_window = self
+        self.set_icon_name('activity-journal')
+        self.set_title(_('Journal'))
 
 
 def get_journal_window():

--- a/src/jarabe/journal/journalwindow.py
+++ b/src/jarabe/journal/journalwindow.py
@@ -31,6 +31,9 @@ class JournalWindow(Window):
         self.set_icon_name('activity-journal')
         self.set_title(_('Journal'))
 
+        # Stop the user from closing the journal window.
+        self.connect('delete-event', lambda widget, event: True)
+
 
 def get_journal_window():
     return _journal_window


### PR DESCRIPTION
This patch set allows to run Sugar as a root window handler.

To try using osbuild, first apply patch then:
```
$ ./osbuild shell
$ build
$ sugar
```
You should see the Sugar home window use your desktop workarea, like this:
![captura de pantalla de 2016-08-03 00-03-48](https://cloud.githubusercontent.com/assets/199755/17354394/ce32c590-590d-11e6-90e6-4be49993585b.png)
