### PR TITLE
Project view fixes

### DIFF
--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -377,6 +377,7 @@ class JournalActivity(JournalWindow):
                                       bundle_id=PROJECT_BUNDLE_ID,
                                       activity_id=None,
                                       project_metadata=None)
+            entry.props.text = ''
         elif self.project_metadata is not None:
             chooser = ActivityChooser()
             text = _("Choose an activity to start '%s' with"

--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -276,7 +276,7 @@ class JournalActivity(JournalWindow):
         self._edit_toolbox = EditToolbox(self)
         self._main_view = Gtk.VBox()
 
-        self._add_new_box = AddNewBar()
+        self._add_new_box = AddNewBar(_('Add new project'))
         add_new_button = self._add_new_box.get_button()
         add_new_button.connect('button-press-event',
                                self.__add_new_button_clicked_cb)
@@ -339,7 +339,6 @@ class JournalActivity(JournalWindow):
         self._project_view.connect('go-back-clicked',
                                    self.__go_back_clicked_cb)
         self._main_view_active = False
-        self.get_list_view().set_projects_view_active(False)
         logging.debug('project_view_activate signal handler')
         self.set_canvas(self._project_view)
         self._toolbox = self._main_toolbox
@@ -458,6 +457,8 @@ class JournalActivity(JournalWindow):
     def _query_changed_cb(self, toolbar, query):
         self._list_view.update_with_query(query)
         self.show_main_view()
+        self._add_new_box.props.visible = \
+            query.get('activity') == PROJECT_BUNDLE_ID
 
     def __search_icon_pressed_cb(self, entry, icon_pos, event):
         self._main_view.grab_focus()

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -1092,16 +1092,21 @@ def set_palette_list(palette_list):
 
 class AddNewBar(Gtk.Box):
 
+    activate = GObject.Signal('activate', arg_types=[str])
+
     def __init__(self, placeholder=None):
-        Gtk.Box.__init__(self)
-        self.props.orientation = Gtk.Orientation.HORIZONTAL
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL)
+
         self._button = EventIcon(icon_name='list-add')
+        self._button.connect('button-release-event',
+                             self.__button_release_event_cb)
         self._button.fill_color = style.COLOR_TOOLBAR_GREY.get_svg()
         self._button.set_tooltip(_('Add New'))
         self.pack_start(self._button, False, True, 0)
         self._button.show()
 
         self._entry = iconentry.IconEntry()
+        self._entry.connect('key-press-event', self.__key_press_cb)
         if placeholder is None:
             placeholder = _('Add new entry')
         self._entry.set_placeholder_text(placeholder)
@@ -1114,3 +1119,15 @@ class AddNewBar(Gtk.Box):
 
     def get_button(self):
         return self._button
+
+    def __key_press_cb(self, window, event):
+        if event.keyval == Gdk.KEY_Return:
+            return self._maybe_activate()
+
+    def __button_release_event_cb(self, button, event):
+        self._maybe_activate()
+
+    def _maybe_activate(self):
+        self.activate.emit(self._entry.props.text)
+        self._entry.props.text = ''
+        return True

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -1128,6 +1128,7 @@ class AddNewBar(Gtk.Box):
         self._maybe_activate()
 
     def _maybe_activate(self):
-        self.activate.emit(self._entry.props.text)
-        self._entry.props.text = ''
-        return True
+        if self._entry.props.text:
+            self.activate.emit(self._entry.props.text)
+            self._entry.props.text = ''
+            return True

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -1092,7 +1092,7 @@ def set_palette_list(palette_list):
 
 class AddNewBar(Gtk.Box):
 
-    def __init__(self):
+    def __init__(self, placeholder=None):
         Gtk.Box.__init__(self)
         self.props.orientation = Gtk.Orientation.HORIZONTAL
         self._button = EventIcon(icon_name='list-add')
@@ -1102,8 +1102,9 @@ class AddNewBar(Gtk.Box):
         self._button.show()
 
         self._entry = iconentry.IconEntry()
-        text = _('Add new entry')
-        self._entry.set_placeholder_text(text)
+        if placeholder is None:
+            placeholder = _('Add new entry')
+        self._entry.set_placeholder_text(placeholder)
         self._entry.add_clear_button()
         self.pack_start(self._entry, True, True, 0)
         self._entry.show()

--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -493,7 +493,6 @@ class BaseListView(Gtk.Bin):
             self.tree_view.get_bin_window().show()
 
         if len(tree_model) == 0:
-            logging.debug('Buraah!!')
             if self._query.get('project_id', None):
                 self._show_message(_('Your project is empty'))
             else:

--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -426,12 +426,6 @@ class BaseListView(Gtk.Bin):
     def update_with_query(self, query_dict):
         logging.debug('ListView.update_with_query')
 
-        if 'activity' in query_dict \
-                and query_dict['activity'] == PROJECT_BUNDLE_ID:
-            self.set_projects_view_active(True)
-        elif self._projects_view_active:
-            self.set_projects_view_active(False)
-
         if 'order_by' not in query_dict:
             query_dict['order_by'] = ['+timestamp']
         if query_dict['order_by'] != self._query.get('order_by'):
@@ -706,22 +700,8 @@ class BaseListView(Gtk.Bin):
     def __volume_error_cb(self, palette, message, severity):
         self.emit('volume-error', message, severity)
 
-    def set_projects_view_active(self, projects_view_active):
-        self._projects_view_active = projects_view_active
-        text = _('Add new entry')
-        if self._journalactivity:
-            if self._projects_view_active:
-                logging.debug('set_projects_view_active')
-                text = _('Add new project')
-                entry = self._journalactivity.get_add_proj_entry()
-                entry.set_placeholder_text(text)
-                self._journalactivity.get_add_new_box().show_all()
-            else:
-                logging.debug('set_projects_view_active false')
-                self._journalactivity.get_add_new_box().hide()
-
     def get_projects_view_active(self):
-        return self._projects_view_active
+        return self._query.get('activity') == PROJECT_BUNDLE_ID
 
 
 class ListView(BaseListView):

--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -235,6 +235,11 @@ class BaseListView(Gtk.Bin):
 
     def _is_new_item_visible(self, object_id):
         """Check if the created item is part of the currently selected view"""
+        if 'project_id' in self._query:
+            # TODO:  Would be best to check if the object_id is in the project.
+            #        But there is only ever 1 project listview, so it should
+            #        not be very costly.
+            return True
         if not self._query.get('mountpoints', None):
             return None
         if self._query['mountpoints'] == ['/']:

--- a/src/jarabe/journal/projectview.py
+++ b/src/jarabe/journal/projectview.py
@@ -80,7 +80,7 @@ class ProjectView(Gtk.EventBox, BaseExpandedEntry):
         return self._vbox
 
     def create_list_view_project(self):
-        self._list_view_project = ListView(self, enable_multi_operations=True)
+        self._list_view_project = ListView(self)
         return self._list_view_project
 
     def get_list_view(self):
@@ -99,10 +99,6 @@ class ProjectView(Gtk.EventBox, BaseExpandedEntry):
         description = project_metadata.get('description', '')
         self._description.get_buffer().set_text(description)
         self._title.set_text(project_metadata.get('title', ''))
-
-    def _add_buddy_button_clicked_cb(self, button):
-        #TODO: TO be implemented
-        pass
 
     def _title_focus_out_event_cb(self, entry, event):
         self._update_entry()


### PR DESCRIPTION
## commit fdbb93ca783f08cbc7653a087655f29f29f5cb8c

 Empty new project entry after creating new project
    
   Currently, there is no direct feedback that the creation has succeeded,
   so the user might create the project too many times.

## commit 907ef0fa2aadf47b73e6231f8627081205ae9a5e

   Fix projects list view add new bar hiding
    
   Steps to reproduce:
    
   1.  Go to the projects list view
   2.  Go to the details view for a project
   3.  Click the back button
   4.  Notice that the "add new project" bar has disappeared

## commit bbe62f09c1304722ce66fc6dc380e7e25e4656ed

   Move AddNewBar logic for activation into the class
    
   Previously, it was copied throughout the users of the class code.

## commit c4341d864ac1f5e6635b4594905f1a01df0b3023

  Only activate add new bar with title typed in
    
   Currently, the add new bar will always activate if the user presses
   enter, even if there is no title typed in yet.  This makes it easy to
   accidentally press enter twice and create 2 new projects.

## commit 8be8b2a63d28930cf756de1d5cd53bd766565c52

   Bind project list view to auto refresh
    
   The _main_view_active boolean was refactored into an enum to better
   accommodate how there is 3 views now (main, details and project).
   
   Multi-selection was disabled in the project view.  It did not work
   properly before this patch, due to the show_main_view call.
   
   The show_main_view call from __selection_changed_cb was removed, as
   this resulted in the main view being re-shown every refresh.  This call
   did not appear to serve a purpose - selection changed would only be
   called when the main view was focused (prior to adding the project
   view).
