### PR TITLE
About me - fix age picker spacing

### DIFF
--- a/src/jarabe/intro/agepicker.py
+++ b/src/jarabe/intro/agepicker.py
@@ -158,7 +158,8 @@ class Picker(Gtk.Grid):
         self.attach(self._button, 0, 0, 1, 1)
         self._button.hide()
 
-        self._label = Gtk.Label(label)
+        self._label = Gtk.Label(label.replace(' ', '\n'))
+        self._label.props.justify = Gtk.Justification.CENTER
         self.attach(self._label, 0, 1, 1, 1)
         self._label.hide()
 


### PR DESCRIPTION
When language is set to Spanish, the icons do not appear evenly spaced.

Each age is a Gtk.Grid containing an EventIcon and a Gtk.Label, but the array of grids is held in a Gtk.Fixed with spacing set by `_configure` method.  The design depends on the label fitting within the large icon size of the style.

Wrap and centre the label.  This increases the chance that it will fit within the large icon size.

Reported in https://bugs.sugarlabs.org/ticket/4967