### PR TITLE
Fix require_version messages in shell.log

### DIFF
--- a/extensions/deviceicon/battery.py
+++ b/extensions/deviceicon/battery.py
@@ -15,6 +15,9 @@
 
 from gettext import gettext as _
 
+import gi
+gi.require_version('UPowerGlib', '1.0')
+
 from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gtk

--- a/extensions/deviceicon/frame.py
+++ b/extensions/deviceicon/frame.py
@@ -30,9 +30,8 @@ import gi
 try:
     gi.require_version('Maliit', '1.0')
     from gi.repository import Maliit
-except ImportError:
+except (ValueError, ImportError):
     logging.debug('Frame: can not create OSK icon: Maliit is not installed.')
-    _HAS_MALIIT = False
 else:
     _HAS_MALIIT = True
 


### PR DESCRIPTION
- new version warning caused by new dependency on UPowerGlib in 495b216,

- new traceback caused by 171cddb, an unhandled exception.