### PR TITLE
View source: remove warning

### DIFF
--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -686,6 +686,8 @@ class FileViewer(Gtk.ScrolledWindow):
 
     def __cursor_changed_cb(self, treeview):
         selection = treeview.get_selection()
+        if selection is None:
+            return
         store, iter_ = selection.get_selected()
         if iter_ is None:
             # Nothing selected. This happens at startup


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/jarabe/view/viewsource.py", line 689, in __cursor_changed_cb
    store, iter_ = selection.get_selected()
AttributeError: 'NoneType' object has no attribute 'get_selected'

No translation impact.