### PR TITLE
Fix for journal batch operations

### DIFF
--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -418,6 +418,7 @@ class JournalActivity(JournalWindow):
         self._editing_mode = selected_items != 0
         self._edit_toolbox.set_selected_entries(selected_items)
         self._edit_toolbox.display_selected_entries_status()
+        self.show_main_view()
 
     def update_selected_items_ui(self):
         selected_items = \


### PR DESCRIPTION
In 0.108 and earlier, the edit toolbar is shown when journal items are selected.

In 0.110 the edit toolbar does not appear, so operations such as batch erase are not available.

Regression was probably introduced by 8be8b2a ('Bind project list view to auto refresh') and other patches since 0.108.

References:

https://wiki.sugarlabs.org/go/Features/Multi_selection (2013)