### PR TITLE
Journal batch erase: fix traceback

### DIFF
--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -511,12 +511,12 @@ class BaseListView(Gtk.Bin):
                     else:
                         self._show_message(_('The device is empty'))
                 else:
-                    show_message_text = 'No matching entries'
+                    show_message_text = _('No matching entries')
                     if self.get_projects_view_active():
-                        show_message_text = 'No Projects'
+                        show_message_text = _('No Projects')
 
-                self._show_message(_(show_message_text),
-                                   show_clear_query=self._can_clear_query())
+                    self._show_message(show_message_text,
+                        show_clear_query=self._can_clear_query())
         else:
             self._clear_message()
 


### PR DESCRIPTION
When erasing all items in the journal using multi selection feature, "Your Journal is empty" is correctly displayed, but a traceback is in shell.log;

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/jarabe/journal/listview.py", line 515, in __model_ready_cb
    self._show_message(_(show_message_text),
UnboundLocalError: local variable 'show_message_text' referenced before assignment
```

Indentation was wrong; caused by 92f7af4.

Use of gettext was wrong; cf648ef and 92f7af4 added string constants that were not wrapped, instead a variable was wrapped.

@leonardcj, note internationalisation impact, because two new strings are added.
