### PR TITLE
Control Panel - Network, remove warning

### DIFF
--- a/extensions/cpsection/network/model.py
+++ b/extensions/cpsection/network/model.py
@@ -17,6 +17,8 @@
 
 import logging
 
+import gi
+gi.require_version('NMClient', '1.0')
 from gettext import gettext as _
 from gi.repository import Gio
 from gi.repository import NMClient


### PR DESCRIPTION
```
/usr/share/sugar/extensions/cpsection/network/model.py:22:
 PyGIWarning: NMClient was imported without specifying a version first.
 Use gi.require_version('NMClient', '1.0') before import to ensure that the
 right version gets loaded.
  from gi.repository import NMClient
```