### PR TITLE
Add missing POTFILES.in reference

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -66,6 +66,7 @@ src/jarabe/journal/detailview.py
 src/jarabe/journal/expandedentry.py
 src/jarabe/journal/journalactivity.py
 src/jarabe/journal/journaltoolbox.py
+src/jarabe/journal/journalwindow.py
 src/jarabe/journal/listmodel.py
 src/jarabe/journal/listview.py
 src/jarabe/journal/misc.py


### PR DESCRIPTION
This did cause `make distcheck` to fail, causing RPM build to fail.

@leonardcj, take note.

@samdroid-apps, please use the `distcheck` target, and abort if exit status is non-zero.

References:
 * https://wiki.sugarlabs.org/go/Development_Team/Release
 * https://wiki.sugarlabs.org/go/Development_Team/Code_guidelines#Tools

