### PR TITLE
View Help - Backport to WebKit and WebKit2

### DIFF
--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -58,7 +58,6 @@ gi.require_version('Gst', '1.0')
 gi.require_version('Wnck', '3.0')
 gi.require_version('SugarExt', '1.0')
 gi.require_version('GdkX11', '3.0')
-gi.require_version('WebKit', '3.0')
 
 from gi.repository import GObject
 from gi.repository import Gio

--- a/src/jarabe/view/Makefile.am
+++ b/src/jarabe/view/Makefile.am
@@ -14,4 +14,6 @@ sugar_PYTHON =				\
 	service.py			\
 	tabbinghandler.py		\
 	viewsource.py			\
-	viewhelp.py
+	viewhelp.py			\
+	viewhelp_webkit1.py		\
+	viewhelp_webkit2.py

--- a/src/jarabe/view/viewhelp_webkit1.py
+++ b/src/jarabe/view/viewhelp_webkit1.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2013 Kalpa Welivitigoda
+# Copyright (C) 2015-2016 Sam Parkinson
+# Copyright (C) 2016 James Cameron <quozl@laptop.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+import gi
+gi.require_version('WebKit', '3.0')
+gi.require_version('SoupGNOME', '2.4')
+
+from gi.repository import WebKit
+from gi.repository import SoupGNOME
+
+from sugar3 import env
+
+
+def _get_current_language():
+    locale = os.environ.get('LANG')
+    return locale.split('.')[0].split('_')[0].lower()
+
+
+class Browser():
+
+    def __init__(self, toolbar):
+        self._toolbar = toolbar
+
+        session = WebKit.get_default_session()
+        cookie_jar = SoupGNOME.CookieJarSqlite(
+            filename=os.path.join(env.get_profile_path(),
+                                  'social-help.cookies'),
+            read_only=False)
+        session.add_feature(cookie_jar)
+
+        self._webview = WebKit.WebView()
+        self._webview.set_full_content_zoom(True)
+        self._webview.connect('resource-request-starting',
+                              self.__resource_request_starting_cb)
+
+        self._webview.connect('notify::uri', self.__load_changed_cb)
+        toolbar.update_back_forward(False, False)
+        toolbar.connect('back-clicked', self.__back_cb)
+        toolbar.connect('forward-clicked', self.__forward_cb)
+        self._webview.show()
+
+    def __resource_request_starting_cb(self, webview, web_frame, web_resource,
+                                       request, response):
+        uri = web_resource.get_uri()
+        if uri.startswith('file://') and uri.find('_images') > -1:
+            if uri.find('/%s/_images/' % _get_current_language()) > -1:
+                new_uri = uri.replace('/html/%s/_images/' %
+                                      _get_current_language(),
+                                      '/images/')
+            else:
+                new_uri = uri.replace('/html/_images/', '/images/')
+            request.set_uri(new_uri)
+
+    def __load_changed_cb(self, widget, event):
+        self._toolbar.update_back_forward(self._webview.can_go_back(),
+                                          self._webview.can_go_forward())
+
+    def __back_cb(self, widget):
+        self._webview.go_back()
+
+    def __forward_cb(self, widget):
+        self._webview.go_forward()
+
+    def save_state(self):
+        back_forward_list = self._webview.get_back_forward_list()
+        items_list = self._items_history_as_list(back_forward_list)
+        curr = back_forward_list.get_current_item()
+
+        return ([item.get_uri() for item in items_list],
+                items_list.index(curr))
+
+    def load_state(self, state, url):
+        if state is None:
+            state = ([url], 0)
+        history, index = state
+
+        back_forward_list = self._webview.get_back_forward_list()
+        back_forward_list.clear()
+        for i, uri in enumerate(history):
+            history_item = WebKit.WebHistoryItem.new_with_data(uri, '')
+            back_forward_list.add_item(history_item)
+            if i == index:
+                self._webview.go_to_back_forward_item(history_item)
+
+        self._toolbar.update_back_forward(self._webview.can_go_back(),
+                                          self._webview.can_go_forward())
+
+    def _items_history_as_list(self, history):
+        back_items = []
+        for n in reversed(range(1, history.get_back_length() + 1)):
+            item = history.get_nth_item(n * -1)
+            back_items.append(item)
+
+        current_item = [history.get_current_item()]
+
+        forward_items = []
+        for n in range(1, history.get_forward_length() + 1):
+            item = history.get_nth_item(n)
+            forward_items.append(item)
+
+        all_items = back_items + current_item + forward_items
+        return all_items
+
+    def get_widget(self):
+        return self._webview
+
+    def get_local_method(self):
+        return 'file://'

--- a/src/jarabe/view/viewhelp_webkit2.py
+++ b/src/jarabe/view/viewhelp_webkit2.py
@@ -1,0 +1,101 @@
+# Copyright (C) 2013 Kalpa Welivitigoda
+# Copyright (C) 2015-2016 Sam Parkinson
+# Copyright (C) 2016 James Cameron <quozl@laptop.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+import gi
+gi.require_version('WebKit2', '4.0')
+
+from gi.repository import WebKit2
+from gi.repository import Gio
+
+from sugar3 import env
+
+
+def _get_current_language():
+    locale = os.environ.get('LANG')
+    return locale.split('.')[0].split('_')[0].lower()
+
+
+class Browser():
+
+    def __init__(self, toolbar):
+        self._toolbar = toolbar
+
+        context = WebKit2.WebContext.get_default()
+        cookie_manager = context.get_cookie_manager()
+        cookie_manager.set_persistent_storage(
+            os.path.join(env.get_profile_path(), 'social-help.cookies'),
+            WebKit2.CookiePersistentStorage.SQLITE)
+
+        self._webview = WebKit2.WebView()
+        self._webview.get_context().register_uri_scheme(
+            'help', self.__app_scheme_cb, None)
+
+        self._webview.connect('load-changed', self.__load_changed_cb)
+        toolbar.update_back_forward(False, False)
+        toolbar.connect('back-clicked', self.__back_cb)
+        toolbar.connect('forward-clicked', self.__forward_cb)
+        self._webview.show()
+
+    def __app_scheme_cb(self, request, user_data):
+        path = request.get_path()
+        if path.find('_images') > -1:
+            if path.find('/%s/_images/' % _get_current_language()) > -1:
+                path = path.replace('/html/%s/_images/' %
+                                    _get_current_language(),
+                                    '/images/')
+            else:
+                path = path.replace('/html/_images/', '/images/')
+
+        request.finish(Gio.File.new_for_path(path).read(None),
+                       -1, Gio.content_type_guess(path, None)[0])
+
+    def __load_changed_cb(self, widget, event):
+        self._toolbar.update_back_forward(self._webview.can_go_back(),
+                                          self._webview.can_go_forward())
+
+    def __back_cb(self, widget):
+        self._webview.go_back()
+
+    def __forward_cb(self, widget):
+        self._webview.go_forward()
+
+    def save_state(self):
+        return self._webview.get_session_state()
+
+    def load_state(self, state, url):
+        if state is None:
+            self._webview.load_uri(url)
+        else:
+            self._webview.restore_session_state(state)
+            # this is what epiphany does:
+            # https://github.com/GNOME/epiphany/blob/
+            # 04e7811c32ba8a2c980a77aac1316b77f0969057/src/ephy-session.c#L280
+            bf_list = self._webview.get_back_forward_list()
+            item = bf_list.get_current_item()
+            if item is not None:
+                self._webview.go_to_back_forward_list_item(item)
+
+        self._toolbar.update_back_forward(self._webview.can_go_back(),
+                                          self._webview.can_go_forward())
+
+    def get_widget(self):
+        return self._webview
+
+    def get_local_method(self):
+        return 'help://'


### PR DESCRIPTION
Always we see a warning about JavaScriptCore not being right version, caused by `main.py` requiring WebKit yet `viewhelp.py` requiring WebKit2.

Seems to be no reason not to support WebKit in addition to WebKit2 in the same code base.  Toolkit already supports both.
- remove `gi.require_version` from `main.py`,
- strip browser specific code from `viewhelp.py`,
- add new Browser base classes, one for WebKit, one for WebKit2,
- avoid `GdkX11.X11Window.foreign_new_for_display` if _xid_ unknown,
- recognise which browser class to use based on OLPC OS release.
