### PR TITLE
Fix for datastore.log noise

### DIFF
--- a/src/jarabe/journal/model.py
+++ b/src/jarabe/journal/model.py
@@ -231,7 +231,9 @@ class DatastoreResultSet(BaseResultSet):
         return entries, total_count
 
     def find_ids(self, query):
-        return _get_datastore().find_ids(query)
+        copy = query.copy()
+        copy.pop('mountpoints', '/')
+        return _get_datastore().find_ids(copy)
 
 
 class InplaceResultSet(BaseResultSet):


### PR DESCRIPTION
Since 0.106.0 and possibly earlier, `datastore.log` always contains

```
1476242752.500065 WARNING root: Unknown term: 
  dbus.String(u'mountpoints')=dbus.Array([dbus.String(u'/')],
  signature=dbus.Signature('s'), variant_level=1)
```

The datastore does not deal with the term mountpoints.  So filter the query before sending it.
