### PR TITLE
Fix screen resize race

### DIFF
--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -141,18 +141,20 @@ class HomeWindow(Gtk.Window):
 
     def __screen_size_changed_cb(self, screen):
         screen = Gdk.Screen.get_default()
-        workarea = screen.get_monitor_workarea(screen.get_number())
+        n = screen.get_number()
+        rect = screen.get_monitor_geometry(n)
         geometry = Gdk.Geometry()
         geometry.max_width = geometry.base_width = geometry.min_width = \
-            workarea.width
+            rect.width
         geometry.max_height = geometry.base_height = geometry.min_height = \
-            workarea.height
+            rect.height
         geometry.width_inc = geometry.height_inc = geometry.min_aspect = \
             geometry.max_aspect = 1
         hints = Gdk.WindowHints(Gdk.WindowHints.ASPECT |
                                 Gdk.WindowHints.BASE_SIZE |
                                 Gdk.WindowHints.MAX_SIZE |
                                 Gdk.WindowHints.MIN_SIZE)
+        workarea = screen.get_monitor_workarea(n)
         self.move(workarea.x, workarea.y)
         self.set_geometry_hints(None, geometry, hints)
 

--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -58,11 +58,11 @@ class HomeWindow(Gtk.Window):
         self._fully_obscured = True
 
         screen = self.get_screen()
-        screen.connect('size-changed', self.__screen_size_change_cb)
+        screen.connect('size-changed', self.__screen_size_changed_cb)
         self.set_default_size(screen.get_width(),
                               screen.get_height())
 
-        self.__screen_size_change_cb(None)
+        self.__screen_size_changed_cb(None)
 
         self.realize()
         self._busy_count = 0
@@ -139,7 +139,7 @@ class HomeWindow(Gtk.Window):
         elif level == ShellModel.ZOOM_MESH:
             self._mesh_box.suspend()
 
-    def __screen_size_change_cb(self, screen):
+    def __screen_size_changed_cb(self, screen):
         screen = Gdk.Screen.get_default()
         workarea = screen.get_monitor_workarea(screen.get_number())
         geometry = Gdk.Geometry()


### PR DESCRIPTION
When an external monitor is connected or disconnected, about 25% of the time the Sugar shell does not resize correctly; a `size-changed` signal occurs but the workarea geometry has not changed.

Underlying problem is an update race in `get_monitor_workarea`, so the fix is to call `get_monitor_geometry` for obtaining the width and height, but continue to use the workarea offset for the later call to `self.move()`.

Can be reproduced easily without an external monitor by switching display panel resolution repeatedly;
```
    xrandr --output eDP1 --mode 1024x768
    xrandr --output eDP1 --mode 1366x768
```
Part of a fix for https://bugs.sugarlabs.org/ticket/4968

----

Rename size changed callback.  Callbacks are to be named according to the signal, or the purpose to which we put the signal.  This callback was nearly named according to the signal.  A similar callback is in sugar-toolkit-gtk3 and is correctly named.

----

Related pull request https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/343 can be merged in any order with this pull request; the patches are independent but solve the same problem in two different contexts.