### PR TITLE
Fix collision resolution in random view

### DIFF
--- a/src/jarabe/desktop/favoriteslayout.py
+++ b/src/jarabe/desktop/favoriteslayout.py
@@ -61,7 +61,7 @@ class ViewLayout(Layout):
         self._height = allocation.height
         self._grid = Grid(int(allocation.width / _CELL_SIZE),
                           int(allocation.height / _CELL_SIZE))
-        self._grid.connect('child-changed', self.__grid_child_changed_cb)
+        self._grid.connect('child-changed', self.__grid_child_changed_cb, allocation)
         self._allocate_owner_icon(allocation, owner_icon, activity_icon)
 
     def _allocate_owner_icon(self, allocation, owner_icon, activity_icon):
@@ -145,12 +145,12 @@ class ViewLayout(Layout):
         height = math.ceil(request.height / _CELL_SIZE)
         return int(width), int(height)
 
-    def __grid_child_changed_cb(self, grid, child):
+    def __grid_child_changed_cb(self, grid, child, allocation):
         request = child.size_request()
         rect = self._grid.get_child_rect(child)
         child_allocation = Gdk.Rectangle()
         child_allocation.x = int(round(rect.x * _CELL_SIZE))
-        child_allocation.y = int(round(rect.y * _CELL_SIZE))
+        child_allocation.y = int(round(rect.y * _CELL_SIZE)) + allocation.y
         child_allocation.width = request.width
         child_allocation.height = request.height
         child.size_allocate(child_allocation)


### PR DESCRIPTION
In network neighbourhood and activity random view, the icons did sometimes move into a collision with another icon.

Cause was resolution of collision was not offset by the vertical allocation.

Fix is to add the vertical allocation.

----

A useful test case is to select the activity random view, then move the Browse icon by drag and drop so that it collides with another icon.  Expected result with the patch is that the other icon will move out of the way, using the shortest escape path.  Observed result without the patch is that the other icon will move somewhat unpredictably and may end up in collision with the Browse icon, especially if the shortest escape path would have been downward.