### PR TITLE
Fix radio off button

### DIFF
--- a/extensions/cpsection/network/model.py
+++ b/extensions/cpsection/network/model.py
@@ -82,7 +82,6 @@ def set_jabber(server):
 
 def get_radio():
     try:
-        nm_client = NMClient.Client()
         return nm_client.wireless_get_enabled()
     except:
         raise ReadError(_('State is unknown.'))
@@ -98,7 +97,6 @@ def set_radio(state):
     """
     try:
         state = state or state == 'on' or state == 1
-        nm_client = NMClient.Client()
         nm_client.wireless_set_enabled(state)
     except:
         raise ValueError(_('Error in specified radio argument use on/off.'))
@@ -148,3 +146,5 @@ def set_publish_information(value):
     settings = Gio.Settings('org.sugarlabs.collaboration')
     settings.set_boolean('publish-gadget', value)
     return 0
+
+nm_client = NMClient.Client()


### PR DESCRIPTION
The control panel network radio button does nothing.  Occurs on Ubuntu 16.04 with NetworkManager 1.2.2.  Does not occur on Fedora 18.

Using the same API in a Python shell works fine.  The difference is that the object is rapidly discarded within the function.

Retaining the NMClient object fixes the problem.  Perhaps the NM API has changed to an asynchronous thread.