### PR TITLE
Revert "Refactor journal.objectChooser according to popup module in toolkit-gtk"

### DIFF
--- a/src/jarabe/journal/objectchooser.py
+++ b/src/jarabe/journal/objectchooser.py
@@ -24,7 +24,6 @@ from gi.repository import Wnck
 from sugar3.graphics import style
 from sugar3.graphics.toolbutton import ToolButton
 from sugar3.graphics.objectchooser import FILTER_TYPE_MIME_BY_ACTIVITY
-from sugar3.graphics.popwindow import PopWindow
 
 from jarabe.journal.listview import BaseListView
 from jarabe.journal.listmodel import ListModel
@@ -35,7 +34,7 @@ from jarabe.model import bundleregistry
 from jarabe.journal.iconview import IconView
 
 
-class ObjectChooser(PopWindow):
+class ObjectChooser(Gtk.Window):
 
     __gtype_name__ = 'ObjectChooser'
 
@@ -45,16 +44,12 @@ class ObjectChooser(PopWindow):
 
     def __init__(self, parent=None, what_filter='', filter_type=None,
                  show_preview=False):
-        if parent is None:
-            parent_xid = 0
-        elif hasattr(parent, 'get_xid'):
-            parent_xid = parent.get_xid()
-        elif hasattr(parent, 'get_window') and hasattr(parent.get_window(),
-                                                       'get_xid'):
-            parent_xid = parent.get_window().get_xid()
-        else:
-            parent_xid = parent
-        PopWindow.__init__(self, window_xid=parent_xid)
+        Gtk.Window.__init__(self)
+        self.set_type_hint(Gdk.WindowTypeHint.DIALOG)
+        self.set_decorated(False)
+        self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
+        self.set_border_width(style.LINE_WIDTH)
+        self.set_has_resize_grip(False)
 
         self._selected_object_id = None
         self._show_preview = show_preview
@@ -65,27 +60,20 @@ class ObjectChooser(PopWindow):
         self.connect('delete-event', self.__delete_event_cb)
         self.connect('key-press-event', self.__key_press_event_cb)
 
-        vbox = self.get_vbox()
+        if parent is None:
+            logging.warning('ObjectChooser: No parent window specified')
+        else:
+            self.connect('realize', self.__realize_cb, parent)
 
-        title_box = self.get_title_box()
+            screen = Wnck.Screen.get_default()
+            screen.connect('window-closed', self.__window_closed_cb, parent)
 
-        volumes_toolbar = VolumesToolbar()
-        tool_item = Gtk.ToolItem()
-        tool_item.set_expand(True)
-        tool_item.add(volumes_toolbar)
-        title_box.insert(tool_item, 0)
-        tool_item.show()
+        vbox = Gtk.VBox()
+        self.add(vbox)
+        vbox.show()
 
-        title = _('Choose an object')
-        if filter_type == FILTER_TYPE_MIME_BY_ACTIVITY:
-            registry = bundleregistry.get_registry()
-            bundle = registry.get_bundle(what_filter)
-            if bundle is not None:
-                title = _('Choose an object to open with %s activity') % \
-                    bundle.get_name()
-        title_box.set_title(title)
-
-        volumes_toolbar.connect('volume-changed', self.__volume_changed_cb)
+        title_box = TitleBox(what_filter, filter_type)
+        title_box.connect('volume-changed', self.__volume_changed_cb)
         title_box.close_button.connect('clicked',
                                        self.__close_button_clicked_cb)
         title_box.set_size_request(-1, style.GRID_CELL_SIZE)
@@ -123,6 +111,14 @@ class ObjectChooser(PopWindow):
         self.set_size_request(width, height)
 
         self._toolbar.update_filters('/', what_filter, filter_type)
+
+    def __realize_cb(self, chooser, parent):
+        self.get_window().set_transient_for(parent)
+        # TODO: Should we disconnect the signal here?
+
+    def __window_closed_cb(self, screen, window, parent):
+        if window.get_xid() == parent.get_xid():
+            self.destroy()
 
     def __entry_activated_cb(self, list_view, uid):
         self._selected_object_id = uid
@@ -162,6 +158,41 @@ class ObjectChooser(PopWindow):
 
     def __clear_clicked_cb(self, list_view):
         self._toolbar.clear_query()
+
+
+class TitleBox(VolumesToolbar):
+    __gtype_name__ = 'TitleBox'
+
+    def __init__(self, what_filter='', filter_type=None):
+        VolumesToolbar.__init__(self)
+
+        label = Gtk.Label()
+        title = _('Choose an object')
+        if filter_type == FILTER_TYPE_MIME_BY_ACTIVITY:
+            registry = bundleregistry.get_registry()
+            bundle = registry.get_bundle(what_filter)
+            if bundle is not None:
+                title = _('Choose an object to open with %s activity') % \
+                    bundle.get_name()
+
+        label.set_markup('<b>%s</b>' % title)
+        label.set_alignment(0, 0.5)
+        self._add_widget(label, expand=True)
+
+        self.close_button = ToolButton(icon_name='dialog-cancel')
+        self.close_button.set_tooltip(_('Close'))
+        self.insert(self.close_button, -1)
+        self.close_button.show()
+
+    def _add_widget(self, widget, expand=False):
+        tool_item = Gtk.ToolItem()
+        tool_item.set_expand(expand)
+
+        tool_item.add(widget)
+        widget.show()
+
+        self.insert(tool_item, -1)
+        tool_item.show()
 
 
 class ChooserListView(BaseListView):


### PR DESCRIPTION
This reverts a series of three commits;

* cadac88c1c880708bd2afe0e82a2c2356c4bd9df
* 0ba3171a3a5c92698a89553bdfa541c83e520694
* 739993b2c4e12faa33e6714a42e500c5d80fbb9f

On both Fedora 18 and Ubuntu 16.04, the series renders classroom laptops useless in minutes or hours, because any activity that opens the object chooser does fail to exit on quit, and processes leak and build-up on the system until memory is depleted. Evidence of the problem is shown by ps(1). Workaround is to reboot.

Reverting the series fixes the problem.

Handling the `Wnck.Screen` `window-close` signal in the same way as the original code does not fix the problem.

Commit cadac88 doesn't say why the change was made, and doesn't appear to add any functionality, so reverting seems the safest option.
