### PR TITLE
Fixed: Selected entry count in journal could not be updated after erasing a selected entry from the palette.

### DIFF
--- a/src/jarabe/journal/palettes.py
+++ b/src/jarabe/journal/palettes.py
@@ -150,11 +150,11 @@ class ObjectPalette(Palette):
             menu_item.connect('activate', self.__detail_activate_cb)
             self.menu.append(menu_item)
             menu_item.show()
-
-        menu_item = MenuItem(_('Erase'), 'list-remove')
-        menu_item.connect('activate', self.__erase_activate_cb)
-        self.menu.append(menu_item)
-        menu_item.show()
+        if not self._journalactivity._editing_mode:
+            menu_item = MenuItem(_('Erase'), 'list-remove')
+            menu_item.connect('activate', self.__erase_activate_cb)
+            self.menu.append(menu_item)
+            menu_item.show()
 
     def __get_uid_list_cb(self):
         return [self._metadata['uid']]


### PR DESCRIPTION
This is the link to the bug, https://bugs.sugarlabs.org/ticket/4972#comment:1
When we select multiple files in the journal and if we try to remove a single file by double clicking on the file icon and selecting "erase" option from the palette then the file will be erased but the selected entry count could not get updated. Selecting multiple files and trying to remove a single file from the palette, it does not make any sense and also we have an "erase" option in the toolbar which can be used for erasing multiple files. So when multiple files are selected the palette should not display any "erase" option in the palette, when we double click on the file icon, but it will show the erase option in the palette when no file is selected so that we can remove a single file from the palette only.
There will be no issue of the selected entry count, the count will be updated correctly.