### PR TITLE
GSettings for SaveAs functionality

### DIFF
--- a/data/org.sugarlabs.gschema.xml
+++ b/data/org.sugarlabs.gschema.xml
@@ -114,6 +114,12 @@
             <summary>Mimetype registry</summary>
             <description>Consists of key-value pairs mimetypes and their corresponding activity</description>
         </key>
+        <key name="save-as" type="b">
+            <default>false</default>
+            <summary>Save-As Alert</summary>
+            <description>If TRUE, Sugar will show a Save-As alert on activity close.
+            </description>
+        </key>
     </schema>
     <schema id="org.sugarlabs.sound" path="/org/sugarlabs/sound/">
         <key name="volume" type="i">


### PR DESCRIPTION
A new boolean value is now added to gsettings to toggle the ``Save-As`` functionality on activity close-

1) If the value is TRUE- Save As popup appears
2) the value is FALSE - Default jobjects write to journal (without Save As)

This GSetting value can be toggled from terminal by the following command - 
`$ gsettings set org.sugarlabs.journal save-as false`(To enable Save-As)

`$ gsettings set org.sugarlabs.journal save-as true`  (To disable Save-As)
