### PR TITLE
GConf value for SaveAs functionality

### DIFF
--- a/data/sugar.schemas.in
+++ b/data/sugar.schemas.in
@@ -37,6 +37,18 @@
 	</long>
       </locale>
     </schema>
+    <schema>
+      <key>/schemas/desktop/sugar/journal/save_as</key>
+      <applyto>/desktop/sugar/journal/save_as</applyto>
+      <owner>sugar</owner>
+      <type>bool</type>
+      <default>false</default>
+      <locale name="C">
+        <short>Save-As Alert</short>
+        <long>If TRUE, Sugar will show a Save-As alert on activity close.
+        </long>
+      </locale>
+    </schema>
 
     <schema>
       <key>/schemas/desktop/sugar/sound/volume</key>


### PR DESCRIPTION
A new boolean value is now added to `GConf` value to toggle the ``Save-As`` functionality on activity close-

1) If the value is TRUE- Save As popup appears
2) the value is FALSE - Default jobjects write to journal (without Save As)

This GSetting value can be toggled from terminal by the following command - 
`$ gconftool-2 --type Boolean --set /desktop/sugar/journal/save_as  true` (To enable Save-As)

`$ gconftool-2 --type Boolean --set /desktop/sugar/journal/save_as  true`  (To disable Save-As)

Feature page - https://wiki.sugarlabs.org/go/Features/Save-As
