### PR TITLE
Revert "Fixed Issue: #4940 Journal entries name can be renamed to blank"

### DIFF
--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -802,9 +802,7 @@ class ListView(BaseListView):
 
     def __cell_title_edited_cb(self, cell, path, new_text):
         iterator = self._model.get_iter(path)
-        if not new_text.isspace() and not new_text == '':
-            self._model[iterator][ListModel.COLUMN_TITLE] = new_text
-
+        self._model[iterator][ListModel.COLUMN_TITLE] = new_text
         self.emit('title-edit-finished')
 
     def __editing_canceled_cb(self, cell):


### PR DESCRIPTION
This reverts commit e05452a571ef9366b2e44d3c9c28d1b6182c4b50 as the current behaviour is inconsistent across Sugar.

An journal entry title does not need to be non-blank; the learner should be allowed to use a blank or empty title.  The title can always be changed again.

The default title is never blank.  The title does not need to be unique; it is not a file name.

Reference:
https://bugs.sugarlabs.org/ticket/4940