### PR TITLE
[Fix]: #785 Home view unaffected by show_launcher value

### DIFF
--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -310,6 +310,10 @@ class FavoritesView(ViewContainer):
     def _add_activity(self, activity_info):
         if activity_info.get_bundle_id() == 'org.laptop.JournalActivity':
             return
+
+        if not activity_info.get_show_launcher():
+            return
+
         icon = ActivityIcon(activity_info)
         icon.props.pixel_size = style.STANDARD_ICON_SIZE
         # icon.set_resume_mode(self._resume_mode)


### PR DESCRIPTION
**Fixed in this PR:** #785  Home view still shows Browse if show_launcher = no 

**Reason of issue:**
 - Due to difference in implementation in `_add_activity` function of favorites view and list view

**Tested on:**
 1. Sugar 0.112, rdesktop, Ubuntu 16.04
 2. Sugar 0.112 Desktop (no virtualEnv)
