### PR TITLE
Fix: Toggle Favorite star when there is only one entry

### DIFF
--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -415,6 +415,11 @@ class BaseListView(Gtk.Bin):
         self.tree_view.queue_draw_area(cell_rect.x, cell_rect.y,
                                        cell_rect.width, cell_rect.height)
 
+        # HACK for https://bugs.sugarlabs.org/ticket/4944
+        # Icon does not update automatically if there is only one journal entry
+        if len(self._model.get_all_ids()) == 1:
+            self._do_refresh()
+
     def __select_set_data_cb(self, column, cell, tree_model, tree_iter,
                              data):
         uid = tree_model[tree_iter][ListModel.COLUMN_UID]


### PR DESCRIPTION
**Fixed in this PR:** 
 - star state does not toggle when the window has only one entry [#4944](https://bugs.sugarlabs.org/ticket/4944)

**Explanation of the issue:**
 - For only one entry, on clicking the favorite icon, `clicked` signal was emitted, `_favorite_clicked_cb` was called, and `self._model` was updated, but the display was not updated

**Changes made:**
 - If there is only one entry in the journal, call `_do_refresh` from `_favorite_clicked_cb`

**Investigation:**
 - `_favorite_clicked_cb` is called
 - The `cell_rect` values are correct
 - `Triple clicking`(odd clicks) updates the icon. Essentially, more than one simultaneous click updates the display. Could be similar to what @quozl explained [here](https://bugs.sugarlabs.org/ticket/4904#comment:6)