### PR TITLE
[Feature]: Add accessibility keys to Journal

### DIFF
--- a/src/jarabe/desktop/meshbox.py
+++ b/src/jarabe/desktop/meshbox.py
@@ -509,7 +509,8 @@ class MeshBox(ViewContainer):
         hash_value = ap.network_hash()
         if old_hash_value == hash_value:
             # no change in network identity, so just update signal strengths
-            self.wireless_networks[hash_value].update_strength()
+            if hash_value in self.wireless_networks:
+                self.wireless_networks[hash_value].update_strength()
             return
 
         # properties change includes a change of the identity of the network

--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -388,10 +388,8 @@ class JournalActivity(JournalWindow):
 
         if self._active_view == JournalViews.MAIN:
             if keyname == 'Up' or keyname == 'Down':
-                path, col = self._list_view.tree_view.get_cursor()
                 if not self._list_view.tree_view.has_focus():
                     self._list_view.tree_view.grab_focus()
-                self._list_view.tree_view.set_cursor_on_cell(path, col, None, True)
 
             elif keyname == 'Escape':
                 self._main_toolbox.clear_query()
@@ -407,7 +405,7 @@ class JournalActivity(JournalWindow):
                     path, col = self._list_view.tree_view.get_cursor()
                     self.show_main_view()
                     self._list_view.tree_view.grab_focus()
-                    column = self._list_view.tree_view.get_column(1)
+                    column = self._list_view.tree_view.get_column(5)
                     self._list_view.tree_view.set_cursor_on_cell(path, column, None, True)
 
                 if keyname == 'Return':

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -579,6 +579,9 @@ class DetailToolbox(ToolbarBox):
         self._refresh_refresh_palette()
         self._refresh_resume_palette()
 
+    def get_metadata(self):
+        return self._metadata
+
     def _resume_clicked_cb(self, button):
         if not misc.can_resume(self._metadata):
             palette = self._resume.get_palette()


### PR DESCRIPTION
**Feature:** https://bugs.sugarlabs.org/ticket/4891

This is an update to the existing PR #667

**Updates done (requested in #667):**
 - [X] Pressing `Return` in detail view resumes the activity
 - [X] Use `ctrl + f` to focus on search
 - [X] Search does not lose focus after a timeout

**Other Updates:**
 - [X] Press `ctrl + F2` to rename an entry
 - [X] Pressing `enter` key in title editing in detail view removes the focus from it.
 - [X] 22382d6 (Unrelated to the PR - fixes errors shown in logs)

**Could not be fixed:**
 - [x] Rename an entry, press `enter`, arrow keys need to be pressed twice to start scrolling.
        This issue ocurrs only the first time we try to rename. Further renaming works as expected
 - [ ] `Ctrl + 1`, `Ctrl + 2` ... to switch between Journal, Documents and mounts:
      **Attempts:**
      - emitted `toggled` signal. The connected function is called but no change is observed. Logs didn't show anything unexpected
      - emitted `clicked` signal. Same output as with `toggled`
      - called `__volume_changed_cb` directly with appropriate checks and arguments. Same output as above

@quozl, Kindly review