### PR TITLE
Fix harmless traceback of sugar-control-panel

### DIFF
--- a/bin/sugar-control-panel
+++ b/bin/sugar-control-panel
@@ -15,6 +15,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+import gi
+gi.require_version('Xkl', '1.0')
+gi.require_version('SugarExt', '1.0')
+gi.require_version('Wnck', '3.0')
+gi.require_version('Gtk', '3.0')
 
 from jarabe import config
 

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -42,7 +42,6 @@ from jarabe.view.palettes import JournalPalette
 from jarabe.view.palettes import CurrentActivityPalette
 from jarabe.view.palettes import ActivityPalette
 from jarabe.view.buddyicon import BuddyIcon
-from jarabe.view.buddymenu import BuddyMenu
 from jarabe.model.buddy import get_owner_instance
 from jarabe.model import shell
 from jarabe.model import bundleregistry
@@ -677,6 +676,9 @@ class OwnerIcon(BuddyIcon):
                                               __enter_notify_event_cb)
 
     def create_palette(self):
+        # import BuddyMenu here to avoid recursive import
+        # See ticket https://github.com/sugarlabs/sugar/issues/793
+        from jarabe.view.buddymenu import BuddyMenu
         palette = BuddyMenu(get_owner_instance())
 
         settings = Gio.Settings('org.sugarlabs')

--- a/src/jarabe/view/buddyicon.py
+++ b/src/jarabe/view/buddyicon.py
@@ -16,7 +16,6 @@
 from sugar3.graphics import style
 from sugar3.graphics.icon import CanvasIcon
 
-from jarabe.view.buddymenu import BuddyMenu
 from jarabe.util.normalize import normalize_string
 
 
@@ -40,6 +39,9 @@ class BuddyIcon(CanvasIcon):
         self._update_color()
 
     def create_palette(self):
+        # import BuddyMenu here to avoid recursive import
+        # See ticket https://github.com/sugarlabs/sugar/issues/793
+        from jarabe.view.buddymenu import BuddyMenu
         palette = BuddyMenu(self._buddy)
         self.connect_to_palette_pop_events(palette)
         return palette


### PR DESCRIPTION
Fixes #793

Tested on: Ubuntu 16.04, Sugar 0.112