### PR TITLE
Fix syntax error

### DIFF
--- a/src/jarabe/view/alerts.py
+++ b/src/jarabe/view/alerts.py
@@ -36,7 +36,7 @@ class MultipleInstanceAlert(BaseErrorAlert):
             self,
             _('Activity launcher'),
             _('%(activity)s is already running. \
-Please stop %(activity)s before launching it again.' % ({'activity':name})
+Please stop %(activity)s before launching it again.' % ({'activity':name})))
 
 
 class MaxOpenActivitiesAlert(BaseErrorAlert):


### PR DESCRIPTION
After building, sugar fails to run with error

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/usr/local/lib/python2.7/dist-packages/jarabe/main.py", line 73, in <module>
    from jarabe.view import keyhandler
  File "/usr/local/lib/python2.7/dist-packages/jarabe/view/keyhandler.py", line 32, in <module>
    from jarabe.journal import journalactivity
  File "/usr/local/lib/python2.7/dist-packages/jarabe/journal/journalactivity.py", line 37, in <module>
    from jarabe.journal.journaltoolbox import MainToolbox
  File "/usr/local/lib/python2.7/dist-packages/jarabe/journal/journaltoolbox.py", line 49, in <module>
    from jarabe.journal import misc
  File "/usr/local/lib/python2.7/dist-packages/jarabe/journal/misc.py", line 42, in <module>
    from jarabe.view import alerts
  File "/usr/local/lib/python2.7/dist-packages/jarabe/view/alerts.py", line 42
    class MaxOpenActivitiesAlert(BaseErrorAlert):
        ^
SyntaxError: invalid syntax
```

Error introduced at e4e2d87 

@quozl kindly review.