### PR TITLE
updated_main.py

### DIFF
--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -213,6 +213,8 @@ def _start_window_manager():
 
 
 def _stop_window_manager():
+    settings = Gio.Settings.new('org.gnome.desktop.interface')
+    settings.set_string('cursor-theme', 'default')
     _metacity_process.terminate()
 
 


### PR DESCRIPTION
When you log out from your Ubuntu and login with Sugar, GNOME desktop cursor theme is changed to the Sugar theme. Hence when you log back to Ubuntu your cursor theme is of Sugar. 
However now it will come back to the default theme which you have set earlier in your Ubuntu.

To change cursor : **sudo update-alternatives --config x-cursor-theme**

To see the changes : **/usr/share/icons/default** 

Hence getting back to default before stopping the window manager helps!! :)