### PR TITLE
Build for either python 2 or python 3

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -87,12 +87,21 @@ On Fedora, use [dnf builddep](http://dnf-plugins-core.readthedocs.io/en/latest/b
         sudo dnf builddep $module
     done
 
-Autogen, configure, make, and install each module;
+Autogen, configure, make, and install each module for Python 2;
 
     for module in sugar{-datastore,-artwork,-toolkit,-toolkit-gtk3,}; do
         cd $module
         ./autogen.sh
-        ./configure
+        make
+        sudo make install
+        cd ..
+    done
+
+When support is required for both versions of Python, build the `sugar-toolkit-gtk3` module again with the `--with-python3` option;
+
+    for module in sugar-toolkit-gtk3; do
+        cd $module
+        ./autogen.sh --with-python3
         make
         sudo make install
         cd ..

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -73,19 +73,23 @@ Clone each of the module repositories;
         git clone https://github.com/sugarlabs/$module.git
     done
 
-Install the build dependencies. There are many, and their package names vary by distribution. A good list is in the Debian or Fedora packaging files.
+Install the build dependencies. There are many, and their package
+names vary by distribution. A first start is in the Debian or Fedora
+packaging files. From 0.113, add Six.
 
 On Debian or Ubuntu;
 
     for module in sugar{-datastore,-artwork,-toolkit,-toolkit-gtk3,}; do
         sudo apt build-dep $module
     done
+    sudo apt install python{,3}-six
 
 On Fedora, use [dnf builddep](http://dnf-plugins-core.readthedocs.io/en/latest/builddep.html), like this; (If you are using GNOME's desktop environment, make sure you are using GNOME Xorg before moving forward!)
 
     for module in sugar{-datastore,-artwork,-toolkit,-toolkit-gtk3,}; do
         sudo dnf builddep $module
     done
+    sudo dnf install python{2,3}-six
 
 Autogen, configure, make, and install each module for Python 2;
 


### PR DESCRIPTION
Explain how to build a development environment for both versions of Python.

Depends on patch
https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/411/commits/bf057be3baefc99325678113b2d889e1dbdf83fa

and pull request
https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/411

Signed-off-by: James Cameron <quozl@laptop.org>

@Aniket21mathur, please review.