### PR TITLE
Adding code for enabling deb-src.

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -77,9 +77,14 @@ Install the build dependencies. There are many, and their package
 names vary by distribution. A first start is in the Debian or Fedora
 packaging files. From 0.113, add Six.
 
-On Debian or Ubuntu, ensure `deb-src` lines are enabled in `/etc/apt/sources.list`, and then;
+On Debian or Ubuntu, ensure `deb-src` lines are enabled in `/etc/apt/sources.list`,or simply do;
 
-    sudo apt update
+```
+sudo sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
+sudo apt-get update
+```
+and then;
+
     for module in sugar{-datastore,-artwork,-toolkit,-toolkit-gtk3,}; do
         sudo apt build-dep $module
     done


### PR DESCRIPTION
A simple code snippet will make it easy for the new developers to enable deb
sources, as compared to the most general approach of manually doing it with a
text editor, in which there are chances of missing a line or two.