### PR TITLE
make dist command will now add docs folder and README.md file in the output zip

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,9 @@ EXTRA_DIST =                    \
 	$(bin_SCRIPTS)		\
 	intltool-merge.in       \
 	intltool-update.in      \
-	intltool-extract.in
+	intltool-extract.in	\
+	docs			\
+	README.md
 
 DISTCHECK_CONFIGURE_FLAGS = --disable-update-mimedb
 


### PR DESCRIPTION
I've edited the _Makefile.am_ to add **docs** folder and **README.md** file in zip that is created after `make dist` command.  