### PR TITLE
Dash in signal names

### DIFF
--- a/extensions/cpsection/backup/view.py
+++ b/extensions/cpsection/backup/view.py
@@ -131,7 +131,7 @@ class SelectBackupRestorePanel(Gtk.VBox):
             icon_name='backup-backup',
             title=_('Save the contents of your Journal'),
             pixel_size=style.GRID_CELL_SIZE)
-        self.backup_btn.connect('button_press_event',
+        self.backup_btn.connect('button-press-event',
                                 self.__backup_button_press_cb)
         hbox.pack_start(self.backup_btn, False, False, style.DEFAULT_SPACING)
 
@@ -139,7 +139,7 @@ class SelectBackupRestorePanel(Gtk.VBox):
             icon_name='backup-restore',
             title=_('Restore the contents of your Journal'),
             pixel_size=style.GRID_CELL_SIZE)
-        self.restore_btn.connect('button_press_event',
+        self.restore_btn.connect('button-press-event',
                                  self.__restore_button_press_cb)
         hbox.pack_start(self.restore_btn, False, False, style.DEFAULT_SPACING)
 

--- a/extensions/deviceicon/audio.py
+++ b/extensions/deviceicon/audio.py
@@ -162,7 +162,7 @@ class AudioManagerWidget(Gtk.VBox):
         self.add(alignment)
 
         self._adjustment_hid = \
-            self._adjustment.connect('value_changed',
+            self._adjustment.connect('value-changed',
                                      self.__level_adjusted_cb)
 
     def update_level(self):

--- a/extensions/deviceicon/display.py
+++ b/extensions/deviceicon/display.py
@@ -130,7 +130,7 @@ class BrightnessManagerWidget(Gtk.VBox):
 
             self._adjustment_timeout_id = None
             self._adjustment_hid = \
-                self._adjustment.connect('value_changed', self.__adjusted_cb)
+                self._adjustment.connect('value-changed', self.__adjusted_cb)
 
             hscale = Gtk.HScale()
             hscale.props.draw_value = False

--- a/extensions/deviceicon/speech.py
+++ b/extensions/deviceicon/speech.py
@@ -115,8 +115,8 @@ class SpeechPalette(Palette):
         box.append_item(hscale_rate, vertical_padding=0)
         hscale_rate.show()
 
-        self._adj_pitch.connect('value_changed', self.__adj_pitch_changed_cb)
-        self._adj_rate.connect('value_changed', self.__adj_rate_changed_cb)
+        self._adj_pitch.connect('value-changed', self.__adj_pitch_changed_cb)
+        self._adj_rate.connect('value-changed', self.__adj_rate_changed_cb)
 
     def __adj_pitch_changed_cb(self, adjustment):
         self._manager.set_pitch(int(adjustment.get_value()))

--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -205,7 +205,7 @@ class ControlPanel(Gtk.Window):
                                        title=self._options[option]['title'],
                                        xo_color=self._options[option]['color'],
                                        pixel_size=style.GRID_CELL_SIZE)
-            sectionicon.connect('button_press_event',
+            sectionicon.connect('button-press-event',
                                 self.__select_option_cb, option)
             sectionicon.show()
 

--- a/src/jarabe/desktop/activitieslist.py
+++ b/src/jarabe/desktop/activitieslist.py
@@ -690,7 +690,7 @@ class ActivityListPalette(ActivityPalette):
         self._activity_changed_sid = []
         for i in range(desktop.get_number_of_views()):
             self._activity_changed_sid.append(
-                registry.connect('bundle_changed',
+                registry.connect('bundle-changed',
                                  self.__activity_changed_cb, i))
             self._update_favorite_item(i)
 

--- a/src/jarabe/frame/clipboardicon.py
+++ b/src/jarabe/frame/clipboardicon.py
@@ -62,7 +62,7 @@ class ClipboardIcon(RadioToolButton):
         cb_service.connect('object-selected', self._object_selected_cb)
 
         child = self.get_child()
-        child.connect('drag_data_get', self._drag_data_get_cb)
+        child.connect('drag-data-get', self._drag_data_get_cb)
         self.connect('notify::active', self._notify_active_cb)
 
     def create_palette(self):
@@ -174,7 +174,7 @@ class ClipboardIcon(RadioToolButton):
         frame = jarabe.frame.get_view()
         self._timeout_id = frame.add_notification(
             self._notif_icon, Gtk.CornerType.BOTTOM_LEFT)
-        self._notif_icon.connect('drag_data_get', self._drag_data_get_cb)
+        self._notif_icon.connect('drag-data-get', self._drag_data_get_cb)
         self._notif_icon.connect('drag-begin', self._drag_begin_cb)
         self._notif_icon.drag_source_set(Gdk.ModifierType.BUTTON1_MASK,
                                          self._get_targets(),

--- a/src/jarabe/frame/clipboardpanelwindow.py
+++ b/src/jarabe/frame/clipboardpanelwindow.py
@@ -45,10 +45,10 @@ class ClipboardPanelWindow(FrameWindow):
 
         # Receiving dnd drops
         self.drag_dest_set(0, [], 0)
-        self.connect('drag_motion', self._clipboard_tray.drag_motion_cb)
-        self.connect('drag_leave', self._clipboard_tray.drag_leave_cb)
-        self.connect('drag_drop', self._clipboard_tray.drag_drop_cb)
-        self.connect('drag_data_received',
+        self.connect('drag-motion', self._clipboard_tray.drag_motion_cb)
+        self.connect('drag-leave', self._clipboard_tray.drag_leave_cb)
+        self.connect('drag-drop', self._clipboard_tray.drag_drop_cb)
+        self.connect('drag-data-received',
                      self._clipboard_tray.drag_data_received_cb)
 
     def _owner_change_cb(self, x_clipboard, event):

--- a/src/jarabe/frame/eventarea.py
+++ b/src/jarabe/frame/eventarea.py
@@ -60,8 +60,8 @@ class EventArea(GObject.GObject):
         box.connect('enter-notify-event', self._enter_notify_cb)
         box.connect('leave-notify-event', self._leave_notify_cb)
         box.drag_dest_set(0, [], 0)
-        box.connect('drag_motion', self._drag_motion_cb)
-        box.connect('drag_leave', self._drag_leave_cb)
+        box.connect('drag-motion', self._drag_motion_cb)
+        box.connect('drag-leave', self._drag_leave_cb)
         box.realize()
         return box
 

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -149,7 +149,7 @@ class MainToolbox(ToolbarBox):
 
         self.refresh_filters()
 
-        self.connect('size_allocate', self.__size_allocate_cb)
+        self.connect('size-allocate', self.__size_allocate_cb)
 
     def __size_allocate_cb(self, widget, allocation):
         GLib.idle_add(self._update_buttons, allocation.width)

--- a/src/jarabe/model/session.py
+++ b/src/jarabe/model/session.py
@@ -56,7 +56,7 @@ class SessionManager(GObject.GObject):
 
     def start(self):
         self.session.start()
-        self.session.connect('shutdown_completed',
+        self.session.connect('shutdown-completed',
                              self.__shutdown_completed_cb)
 
     def initiate_shutdown(self, logout_mode):


### PR DESCRIPTION
GLib accepts signal names with dash or underscore, and documents the
signals with a dash.

Use of GLib signal names in Sugar was mixed.

Change to using the dash.

No functional change.

Not tested.