### PR TITLE
Add missing dependency in README python3-empy

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ Standards](https://www.gnu.org/prep/standards/).
 Install all dependencies, especially `sugar-artwork`, `sugar-datastore`,
 and `sugar-toolkit-gtk3`.
 
+Install `python3-empy` by running the following command:
+
+On Ubuntu
+```
+$ sudo apt install python3-empy
+```
+On Fedora 
+```
+$ sudo dnf install python3-empy
+```
+
 Clone the repository, run `autogen.sh`, then `make` and `make
 install`.
 


### PR DESCRIPTION
`python3-empy` was not added as depencency. This is either not installed by the apt package also.
~ wrt Google CodeIn

If not added, will raise an Error:
```
ss@ss-srevinsaju:~/repo/sugar$ ./autogen.sh
You should update your 'aclocal.m4' by running aclocal.
configure.ac:28: warning: macro 'AM_GLIB_GNU_GETTEXT' not found in library
configure.ac:28: error: possibly undefined macro: AM_GLIB_GNU_GETTEXT
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /usr/bin/autoconf failed with exit status: 1
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether to enable maintainer-specific portions of Makefiles... yes
checking for python version... 3.7
checking for python platform... linux
checking for python script directory... ${prefix}/lib/python3.7/site-packages
checking for python extension module directory... ${exec_prefix}/lib/python3.7/site-packages
checking for empy... no
checking for empy3... no
configure: error: empy is required

```