### PR TITLE
Depend on empy python module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,10 +15,7 @@ AM_MAINTAINER_MODE
 PYTHON=python3
 AM_PATH_PYTHON
 
-AC_PATH_PROGS([EMPY], [empy empy3])
-if test -z "$EMPY"; then
-	AC_MSG_ERROR([empy is required])
-fi
+AS_IF([$PYTHON -m em >/dev/null 2>&1], AC_MSG_RESULT([empy found]), AC_MSG_ERROR([empy not found]))
 
 PKG_CHECK_MODULES(SHELL, gtk+-3.0)
 

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,12 +1,12 @@
 SUBDIRS = icons
 
 sugar-72.gtkrc: gtkrc.em
-	$(PYTHON) - -D scaling=\'72\' $(srcdir)/gtkrc.em > \
-		$(top_builddir)/data/sugar-72.gtkrc < $(EMPY)
+	$(PYTHON) -m em - -D scaling=\'72\' $(srcdir)/gtkrc.em > \
+		$(top_builddir)/data/sugar-72.gtkrc
 
 sugar-100.gtkrc: gtkrc.em
-	$(PYTHON) - -D scaling=\'100\' $(srcdir)/gtkrc.em > \
-		$(top_builddir)/data/sugar-100.gtkrc < $(EMPY)
+	$(PYTHON) -m em - -D scaling=\'100\' $(srcdir)/gtkrc.em > \
+		$(top_builddir)/data/sugar-100.gtkrc
 
 sugardir = $(pkgdatadir)/data
 sugar_DATA =			\


### PR DESCRIPTION
Fixes #882 
Fixes #896
Fix makefile dependency on /usr/bin/empy for Linux distributions which do not package a empy binary executable.

In comparison to @aperezbios 's patch on #896, I have tried to call 
`python3 -m em` so that the
* the `em` wherever located should be called
* Fixes the dependency on Linux distros that doesn't have the `x` flag set on the python files.

I am not sure if what I have attempted to fix is with regards in the Coding guidelines. The semantics seems correct, I have tested it. Works satisfactorily. 
Please review @quozl @aperezbios @tchx84 