### PR TITLE
Fixed Python3 TypeError

### DIFF
--- a/src/jarabe/apisocket.py
+++ b/src/jarabe/apisocket.py
@@ -211,7 +211,7 @@ class DatastoreAPI(API):
             self._client.send_error(info["close_request"], error)
 
         def on_data(data):
-            file_object.write(data[1:])
+            file_object.write(data[1:].decode("utf-8"))
 
         def on_close(close_request):
             file_object.close()
@@ -320,7 +320,7 @@ class APIServer(object):
 
     def _message_received_cb(self, session, message, client):
         if message.message_type == Message.TYPE_BINARY:
-            stream_id = ord(message.data[0])
+            stream_id = message.data[0]
             stream_monitor = client.stream_monitors[stream_id]
             stream_monitor.on_data(message.data)
             return

--- a/src/jarabe/apisocket.py
+++ b/src/jarabe/apisocket.py
@@ -121,7 +121,7 @@ class DatastoreAPI(API):
         instance_path = os.path.join(activity_root, "instance")
 
         file_path = os.path.join(instance_path, "%i" % time.time())
-        file_object = open(file_path, "w")
+        file_object = open(file_path, 'wb')
 
         return file_path, file_object
 
@@ -152,7 +152,7 @@ class DatastoreAPI(API):
 
     def load(self, request):
         def get_filename_reply_handler(file_name):
-            file_object = open(file_name)
+            file_object = open(file_name, 'rb')
             info["file_object"] = file_object
 
             if "requested_size" in info:
@@ -168,7 +168,7 @@ class DatastoreAPI(API):
             self._client.send_error(request, error)
 
         def send_binary(data):
-            self._client.send_binary(chr(stream_id) + data)
+            self._client.send_binary(bytes([stream_id]) + data)
 
         def on_data(data):
             size = struct.unpack("ii", data)[1]
@@ -211,7 +211,7 @@ class DatastoreAPI(API):
             self._client.send_error(info["close_request"], error)
 
         def on_data(data):
-            file_object.write(data[1:].decode("utf-8"))
+            file_object.write(data[1:])
 
         def on_close(close_request):
             file_object.close()

--- a/src/jarabe/apisocket.py
+++ b/src/jarabe/apisocket.py
@@ -261,6 +261,10 @@ class APIClient(object):
         self._session.send_message(json.dumps(response))
 
     def send_error(self, request, error):
+        if(type(error) == dbus.exceptions.DBusException):
+            dbus_error = error.get_dbus_name() + " " + error.get_dbus_message()
+            error = dbus_error
+
         response = {"result": None,
                     "error": error,
                     "id": request["id"]}


### PR DESCRIPTION
For TypeError: ord() expected string of length 1, but int found
In Python3 indexing a `bytes` object returns an integer, `ord()` is not required.
`stream_id = ord(message.data[0])` -> `stream_id = message.data[0]`

For TypeError: must be str, not bytes
`file_object.write(data[1:])` -> `file_object.write(data[1:].decode("utf-8"))`