### PR TITLE
Update debian.md

### DIFF
--- a/docs/debian.md
+++ b/docs/debian.md
@@ -44,8 +44,9 @@ Packaging
 
 Packaging of Sugar on Debian is done by a team:
 
--   [pkg-sugar-team project](https://https://salsa.debian.org/pkg-sugar-team),
+-   [pkg-sugar-team project](https://salsa.debian.org/pkg-sugar-team),
 -   [pkg-sugar-devel mailing list](https://lists.alioth.debian.org/mailman/listinfo/pkg-sugar-devel),
+-   [pkg-sugar git repositories](https://salsa.debian.org/pkg-sugar-team/sugar)
 -   [package archive of Jonas Smedegaard](http://debian.jones.dk/pkg/sugar_/),
 
 Sucrose packages are usually updated in the unstable release. These packages migrate to the testing release after a while. You can see the current package versions [here](http://packages.debian.org/search?keywords=sugar&searchon=names&suite=all&section=all).

--- a/docs/debian.md
+++ b/docs/debian.md
@@ -44,10 +44,8 @@ Packaging
 
 Packaging of Sugar on Debian is done by a team:
 
--   [pkg-sugar project](https://alioth.debian.org/projects/pkg-sugar/),
+-   [pkg-sugar-team project](https://https://salsa.debian.org/pkg-sugar-team),
 -   [pkg-sugar-devel mailing list](https://lists.alioth.debian.org/mailman/listinfo/pkg-sugar-devel),
--   [pkg-sugar-commit mailing list](https://lists.alioth.debian.org/mailman/listinfo/pkg-sugar-commit),
--   [pkg-sugar git repositories](https://anonscm.debian.org/cgit/pkg-sugar/),
 -   [package archive of Jonas Smedegaard](http://debian.jones.dk/pkg/sugar_/),
 
 Sucrose packages are usually updated in the unstable release. These packages migrate to the testing release after a while. You can see the current package versions [here](http://packages.debian.org/search?keywords=sugar&searchon=names&suite=all&section=all).


### PR DESCRIPTION
* https://alioth.debian.org/projects/pkg-sugar/ is no longer available. The alioth.debian.org service is discontinued. Its replacement is a GitLab instance at salsa.debian.org.
* `pkg-sugar-commit` mailing list is not found

__TODO__
- [x] find the equivalent of `pkg-sugar git repositories` as the given address redirects to a webpage displaying error 404 not found.

Please verify @quozl 