### PR TITLE
Add links to 'Sugar logging in' tutorial

### DIFF
--- a/docs/debian.md
+++ b/docs/debian.md
@@ -18,7 +18,7 @@ sudo apt install sucrose lightdm
 exec sudo reboot
 ```
 
--   in the graphical login screen, change from the default X session to Sugar,
+-   in the graphical login screen, [change from the default X session to Sugar](https://github.com/sugarlabs/sugar-docs/blob/master/src/sugar-logging-in.md),
 -   log in as the non-root user, which you will have created during install.
 
 Known bugs include;
@@ -41,7 +41,7 @@ sudo apt install sucrose lightdm
 exec sudo reboot
 ```
 
--   in the graphical login screen, change from the default X session to Sugar,
+-   in the graphical login screen, [change from the default X session to Sugar](https://github.com/sugarlabs/sugar-docs/blob/master/src/sugar-logging-in.md),
 -   log in as your non-root user, created during install.
 
 Known bugs include;

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -49,7 +49,7 @@ Install the `sucrose` package;
 
     sudo apt install sucrose
 
-Log out, then log in with the Sugar desktop selected.
+Log out, then [log in with the Sugar desktop selected](https://github.com/sugarlabs/sugar-docs/blob/master/src/sugar-logging-in.md).
 
 Once Sugar is installed, development of activities can begin.
 
@@ -144,7 +144,7 @@ Clone the Browse and Terminal activities;
     git clone https://github.com/sugarlabs/browse-activity.git Browse.activity
     git clone https://github.com/sugarlabs/terminal-activity.git Terminal.activity
 
-Log out and log in again with the Sugar desktop selected, or use the remote desktop feature described earlier on this page.
+Log out and [log in again with the Sugar desktop selected](https://github.com/sugarlabs/sugar-docs/blob/master/src/sugar-logging-in.md), or use the remote desktop feature described earlier on this page.
 
 After making changes in a Sugar module, repeat the `sudo make install` step, and log in again.
 

--- a/docs/fedora.md
+++ b/docs/fedora.md
@@ -12,7 +12,7 @@ Install Fedora. Then, in a Terminal, type:
 
     sudo dnf groupinstall sugar-desktop
 
-Then restart your computer. At the *Sign in* select the *Sugar* desktop.
+Then restart your computer. At the *Sign in* select the *Sugar* desktop (Fedora uses GDM by default, tutorial to login to Sugar using GDM can be viewed in [the Sugar Docs](https://github.com/sugarlabs/sugar-docs/blob/master/src/sugar-logging-in.md)).
 
 Using Sugar with another Desktop Environment
 --------------------------------------------

--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -14,7 +14,7 @@ Sugar 0.112 can be installed with the following commands:
     sudo apt install sucrose
 
 -   log out,
--   log in with the Sugar desktop selected,
+-   [log in with the Sugar desktop selected](https://github.com/sugarlabs/sugar-docs/blob/master/src/sugar-logging-in.md),
 
 Known Problems:
 
@@ -31,7 +31,7 @@ Sugar 0.112 is in the universe repository, and can be installed with the followi
     sudo apt install sucrose
 
 -   log out,
--   log in with the Sugar desktop selected,
+-   [log in with the Sugar desktop selected](https://github.com/sugarlabs/sugar-docs/blob/master/src/sugar-logging-in.md),
 
 Ubuntu 18.04 (Bionic Beaver) and 18.10 (Cosmic Cuttlefish)
 -------------------
@@ -44,7 +44,7 @@ Sugar 0.112 is in the universe repository, and can be installed with the followi
     sudo apt install sucrose
 
 -   log out,
--   log in with the Sugar desktop selected,
+-   [log in with the Sugar desktop selected](https://github.com/sugarlabs/sugar-docs/blob/master/src/sugar-logging-in.md),
 -   press the F3 key to switch to the home view, see below.
 
 Known problems


### PR DESCRIPTION
Add links to Sugar login tutorial available at [sugar-docs](https://github.com/sugarlabs/sugar-docs/blob/master/src/sugar-logging-in.md) 

Fixes #892 