### PR TITLE
use Soup.Session instead of Soup.AsyncSession

### DIFF
--- a/src/jarabe/util/downloader.py
+++ b/src/jarabe/util/downloader.py
@@ -41,7 +41,7 @@ def soup_status_is_successful(status):
 def get_soup_session():
     global _session
     if _session is None:
-        _session = Soup.SessionAsync()
+        _session = Soup.Session()
         _session.set_property("timeout", 60)
         _session.set_property("idle-timeout", 60)
         _session.set_property("user-agent", "Sugar/%s" % config.version)


### PR DESCRIPTION
According to developer.gnome.org

> In the past, SoupSession was an abstract class, and users needed to choose between SoupSessionAsync (which always uses GMainLoop-based I/O), or SoupSessionSync (which always uses blocking I/O and can be used from multiple threads simultaneously). This is no longer necessary; you can (and should) use a plain SoupSession, which supports both synchronous and asynchronous use. (When using a plain SoupSession, soup_session_queue_message() behaves like it traditionally did on a SoupSessionAsync, and soup_session_send_message() behaves like it traditionally did on a SoupSessionSync.)