### PR TITLE
Possible fix to #941

### DIFF
--- a/extensions/cpsection/language/model.py
+++ b/extensions/cpsection/language/model.py
@@ -30,7 +30,7 @@ _standard_msg = _('Could not access ~/.i18n. Create standard settings.')
 
 def read_all_languages():
     fdp = subprocess.Popen(['locale', '-av'], stdout=subprocess.PIPE)
-    lines = fdp.stdout.read().decode().split('\n')
+    lines = fdp.stdout.read().decode('utf-8', 'ignore').split('\n')
     locales = []
 
     for line in lines:


### PR DESCRIPTION
There was a decode() error:

UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 7862: invalid continuation byte

Fixed by adding 'utf-8' and 'ignore' args to decode()

Not 100% sure that this is the only thing causing #941 but it is certainly part of the problem.