### PR TITLE
notifications: Fix signature of GetServerInformation

### DIFF
--- a/src/jarabe/model/notifications.py
+++ b/src/jarabe/model/notifications.py
@@ -104,9 +104,9 @@ class NotificationService(dbus.service.Object):
     def GetCapabilities(self):
         return []
 
-    @dbus.service.method(_DBUS_IFACE, in_signature='', out_signature='sss')
-    def GetServerInformation(self, name, vendor, version):
-        return 'Sugar Shell', 'Sugar', config.version
+    @dbus.service.method(_DBUS_IFACE, in_signature='', out_signature='ssss')
+    def GetServerInformation(self):
+        return 'Sugar Shell', 'Sugar', config.version, '1.2'
 
     @dbus.service.signal(_DBUS_IFACE, signature='uu')
     def NotificationClosed(self, notification_id, reason):


### PR DESCRIPTION
See https://specifications.freedesktop.org/notification-spec/latest/index.html, specifically the [GetServerInformation signature](https://specifications.freedesktop.org/notification-spec/latest/ar01s09.html).

I didn't test this myself as I only found this by accident while reviewing different notification daemons. You can test it using `dbus-send --session --print-reply --dest=org.freedesktop.Notifications /org/freedesktop/Notifications org.freedesktop.Notifications.GetServerInformation` which will show a `TypeError` without this change.