### PR TITLE
Fixed issue:Journal Entries can be renamed to blank via DetailView

### DIFF
--- a/src/jarabe/journal/expandedentry.py
+++ b/src/jarabe/journal/expandedentry.py
@@ -512,7 +512,19 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
 
         old_title = self._metadata.get('title', None)
         new_title = self._title.get_text()
-        if old_title != new_title:
+        if new_title == '' or new_title.isspace():
+            alert = Alert()
+            alert.props.title = _('Empty title')
+            alert.props.msg = _('The title cannot be empty')
+            ok_icon = Icon(icon_name='dialog-ok')
+            alert.add_button(Gtk.ResponseType.OK, _('Ok'), ok_icon)
+            ok_icon.show()
+            alert.connect('response', self._title_alert_response_cb)
+            journalwindow.get_journal_window().add_alert(alert)
+            alert.show()
+            new_title = self._title.set_text(old_title)
+
+        elif old_title != new_title:
             self._icon.palette.props.primary_text = new_title
             self._metadata['title'] = new_title
             self._metadata['title_set_by_user'] = '1'
@@ -539,6 +551,9 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
             self._write_entry()
 
         self._update_title_sid = None
+
+    def _title_alert_response_cb(self, alert, response_id):
+        journalwindow.get_journal_window().remove_alert(alert)
 
     def _write_entry(self):
         if self._metadata.get('mountpoint', '/') == '/':

--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -40,6 +40,7 @@ from jarabe.journal.journaltoolbox import EditToolbox
 from jarabe.journal.projectview import ProjectView
 
 from jarabe.journal.listview import ListView
+from jarabe.journal.listmodel import ListModel
 from jarabe.journal.detailview import DetailView
 from jarabe.journal.volumestoolbar import VolumesToolbar
 from jarabe.journal import misc
@@ -449,8 +450,10 @@ class JournalActivity(JournalWindow):
     def __title_edit_started_cb(self, list_view):
         self.disconnect_by_func(self.__key_press_event_cb)
 
-    def __title_edit_finished_cb(self, list_view):
-        self.connect('key-press-event', self.__key_press_event_cb)
+    def __title_edit_finished_cb(self, list_view, new_text, path):
+        list_view_model = list_view.get_model()
+        iterator = list_view_model.get_iter(path)
+        list_view_model[iterator][ListModel.COLUMN_TITLE] = new_text
 
     def show_main_view(self):
         self._active_view = JournalViews.MAIN


### PR DESCRIPTION
@srevinsaju @quozl can you test?

This was moved from #663.

The comment made by @i5o here https://github.com/sugarlabs/sugar/pull/663#issuecomment-260526997 isn't a blocker as the `entry` doesn't handle when the `enter` key is pressed and I don't think it needs to, so pressing the `enter` key would have no effect.