### PR TITLE
Minimal bringup under GNOME Wayland

### DIFF
--- a/src/jarabe/frame/eventarea.py
+++ b/src/jarabe/frame/eventarea.py
@@ -17,7 +17,6 @@ from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GObject
 from gi.repository import GLib
-from gi.repository import Wnck
 
 from sugar3.graphics import style
 
@@ -50,10 +49,6 @@ class EventArea(GObject.GObject):
 
         settings.connect('changed', self._settings_changed_cb)
         self._settings_changed_cb(settings, None)
-
-        screen = Wnck.Screen.get_default()
-        screen.connect('window-stacking-changed',
-                       self._window_stacking_changed_cb)
 
     def _box(self, tag):
         box = Gtk.Invisible()
@@ -152,7 +147,3 @@ class EventArea(GObject.GObject):
     def hide(self):
         for box in list(self._boxes.values()):
             box.hide()
-
-    def _window_stacking_changed_cb(self, screen):
-        for box in list(self._boxes.values()):
-            box.get_window().raise_()

--- a/src/jarabe/journal/objectchooser.py
+++ b/src/jarabe/journal/objectchooser.py
@@ -19,7 +19,6 @@ import logging
 from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Gdk
-from gi.repository import Wnck
 
 from sugar3.graphics import style
 from sugar3.graphics.toolbutton import ToolButton
@@ -64,9 +63,6 @@ class ObjectChooser(Gtk.Window):
             logging.warning('ObjectChooser: No parent window specified')
         else:
             self.connect('realize', self.__realize_cb, parent)
-
-            screen = Wnck.Screen.get_default()
-            screen.connect('window-closed', self.__window_closed_cb, parent)
 
         vbox = Gtk.VBox()
         self.add(vbox)
@@ -115,10 +111,6 @@ class ObjectChooser(Gtk.Window):
     def __realize_cb(self, chooser, parent):
         self.get_window().set_transient_for(parent)
         # TODO: Should we disconnect the signal here?
-
-    def __window_closed_cb(self, screen, window, parent):
-        if window.get_xid() == parent.get_xid():
-            self.destroy()
 
     def __entry_activated_cb(self, list_view, uid):
         self._selected_object_id = uid

--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -49,16 +49,12 @@ DBusGMainLoop(set_as_default=True)
 # define the versions of used libraries that are required
 import gi
 gi.require_version('Gtk', '3.0')
-gi.require_version('Gst', '1.0')
-gi.require_version('Wnck', '3.0')
 gi.require_version('SugarExt', '1.0')
 gi.require_version('GdkX11', '3.0')
 
 from gi.repository import Gio
 from gi.repository import GLib
 from gi.repository import Gtk
-from gi.repository import Gst
-from gi.repository import Wnck
 
 from sugar3 import env
 
@@ -204,12 +200,6 @@ def _start_window_manager():
 
     _restart_window_manager()
 
-    screen = Wnck.Screen.get_default()
-    screen.connect('window-manager-changed', __window_manager_changed_cb)
-
-    _check_for_window_manager(screen)
-
-
 def _stop_window_manager():
     _cursor_theme_settings.set_string('cursor-theme', _cursor_theme)
     _metacity_process.terminate()
@@ -340,8 +330,6 @@ def _check_group_label():
 
 
 def main():
-    Gst.init(sys.argv)
-
     cleanup_temporary_files()
 
     _start_window_manager()

--- a/src/jarabe/model/keyboard.py
+++ b/src/jarabe/model/keyboard.py
@@ -17,51 +17,13 @@
 import logging
 
 import gi
-gi.require_version('Xkl', '1.0')
 from gi.repository import Gio
 from gi.repository import GdkX11
-from gi.repository import Xkl
 
 
 def setup():
     settings = Gio.Settings.new('org.sugarlabs.peripherals.keyboard')
     have_config = False
 
-    try:
-        display = GdkX11.x11_get_default_xdisplay()
-        if display is not None:
-            engine = Xkl.Engine.get_instance(display)
-        else:
-            logging.debug('setup_keyboard_cb: Could not get default display.')
-            return
-
-        configrec = Xkl.ConfigRec()
-        configrec.get_from_server(engine)
-
-        layouts = settings.get_strv('layouts')
-        layouts_list = []
-        variants_list = []
-        if layouts:
-            for layout in layouts:
-                layouts_list.append(layout.split('(')[0])
-                variants_list.append(layout.split('(')[1][:-1])
-
-            if layouts_list and variants_list:
-                have_config = True
-                configrec.set_layouts(layouts_list)
-                configrec.set_variants(variants_list)
-
-        model = settings.get_string('model')
-        if model:
-            have_config = True
-            configrec.set_model(model)
-
-        options = settings.get_strv('options')
-        if options:
-            have_config = True
-            configrec.set_options(options)
-
-        if have_config:
-            configrec.activate(engine)
-    except Exception:
-        logging.exception('Error during keyboard configuration')
+    logging.debug('setup_keyboard_cb: Could not get default display.')
+    return

--- a/src/jarabe/model/shell.py
+++ b/src/jarabe/model/shell.py
@@ -18,7 +18,6 @@ import logging
 import time
 
 from gi.repository import Gio
-from gi.repository import Wnck
 from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Gdk
@@ -399,12 +398,6 @@ class ShellModel(GObject.GObject):
     def __init__(self):
         GObject.GObject.__init__(self)
 
-        self._screen = Wnck.Screen.get_default()
-        self._screen.connect('window-opened', self._window_opened_cb)
-        self._screen.connect('window-closed', self._window_closed_cb)
-        self._screen.connect('active-window-changed',
-                             self._active_window_changed_cb)
-
         self.zoom_level_changed = dispatch.Signal()
 
         self._desktop_level = self.ZOOM_HOME
@@ -416,8 +409,6 @@ class ShellModel(GObject.GObject):
         self._tabbing_activity = None
         self._launchers = {}
         self._modal_dialogs_counter = 0
-
-        self._screen.toggle_showing_desktop(True)
 
         settings = Gio.Settings.new('org.sugarlabs')
         self._maximum_open_activities = settings.get_int(
@@ -462,7 +453,6 @@ class ShellModel(GObject.GObject):
                                      new_level=new_level)
 
         show_desktop = new_level is not self.ZOOM_ACTIVITY
-        self._screen.toggle_showing_desktop(show_desktop)
 
         if new_level is self.ZOOM_ACTIVITY:
             # activate the window, in case it was iconified

--- a/src/jarabe/model/speech.py
+++ b/src/jarabe/model/speech.py
@@ -13,17 +13,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from sugar3.speech import SpeechManager
-
-
 _speech_manager = None
 
 
 def get_speech_manager():
     global _speech_manager
 
-    if _speech_manager is None:
-        _speech_manager = SpeechManager()
-        if not _speech_manager.enabled():
-            _speech_manager = None
     return _speech_manager

--- a/src/jarabe/view/cursortracker.py
+++ b/src/jarabe/view/cursortracker.py
@@ -17,8 +17,6 @@ import logging
 
 from gi.repository import Gdk
 
-from gi.repository import SugarExt
-
 _instance = None
 
 
@@ -42,7 +40,6 @@ def setup():
         if device.get_source() == Gdk.InputSource.TOUCHSCREEN:
             logging.debug('Cursor Tracker: found touchscreen, '
                           'will track input.')
-            _instance = SugarExt.CursorTracker()
             break
 
     if not _instance:


### PR DESCRIPTION
Not for merging.

Demonstration of what is required to start the Sugar Home View from
within a GNOME Terminal on a Wayland session.

* fix a silent fail to start with a premature exit status 1 by removing
  all calls to the Wnck library; this breaks window switching to
  Neighbourhood View, Group View, or Journal, and detection of activity
  startup completion,

* fix a segmentation fault in XQueryExtension by removing the
  CursorTracker initialisation; this breaks The Frame,

* fix a segmentation fault in libxklavier by removing keyboard
  configuration,

* fix failure to redraw home view by removing GStreamer, both the thread
  initialisation and the toolkit SpeechManager; this breaks speech in
  the shell only.

Other regresssions;

- mouse pointer is "busy",

- not fullscreen, has title bar,

- view switching keys don't work,

- right-click and mouse-over menus are incorrectly positioned,

- My Settings, Keyboard does segmentation fault in libxklavier,

- Journal is not shown.

Things that work;

- new user dialog,

- home view, favourites view, list view,

- my settings; everything except Keyboard,

- the Log and Calculate activities.