### PR TITLE
Add drag from clipboard to journal to store data 

### DIFF
--- a/src/jarabe/frame/activitiestray.py
+++ b/src/jarabe/frame/activitiestray.py
@@ -24,7 +24,6 @@ from gi.repository import GObject
 from gi.repository import Gio
 from gi.repository import Gtk
 from gi.repository import Gdk
-from gi.repository import GLib
 
 from sugar3.graphics import style
 from sugar3.graphics.tray import HTray
@@ -53,7 +52,7 @@ from jarabe.frame.notification import NotificationButton
 from jarabe.frame.notification import NotificationPulsingIcon
 from jarabe.frame.clipboardmenu import ClipboardMenu
 from jarabe.frame.clipboardobject import ClipboardObject
-from jarabe.frame.clipboardtray import _ContextMap
+from jarabe.frame.clipboardtray import ContextMap
 from jarabe.frame.clipboardobject import Format
 import jarabe.frame
 from jarabe.frame import clipboard
@@ -70,7 +69,7 @@ class ActivityButton(RadioToolButton):
         self._home_activity = home_activity
         self._notify_launch_hid = None
 
-        self._context_map = _ContextMap()
+        self._context_map = ContextMap()
         self._cb_object = None
         self._icon = NotificationPulsingIcon()
         self._icon.props.base_color = home_activity.get_icon_color()
@@ -131,7 +130,6 @@ class ActivityButton(RadioToolButton):
             data = selection.get_pixbuf()
         if len(selection.get_uris()) != 0:
             data = selection.get_uris()[0].encode()
-            GLib.strfreev(data)
         if selection.get_text() is not None:
             data = selection.get_text().encode()
         if data is None:

--- a/src/jarabe/frame/activitiestray.py
+++ b/src/jarabe/frame/activitiestray.py
@@ -137,8 +137,7 @@ class ActivityButton(RadioToolButton):
         if data is None:
             data = selection.get_data()
 
-        if self._cb_object is None:
-            self._cb_object = ClipboardObject(0, "")
+        self._cb_object = ClipboardObject(0, "")
 
         mime_type = selection.get_data_type().name()
         cb_format = Format(mime_type, data, on_disk=False)

--- a/src/jarabe/frame/activitiestray.py
+++ b/src/jarabe/frame/activitiestray.py
@@ -23,6 +23,7 @@ import os
 from gi.repository import GObject
 from gi.repository import Gio
 from gi.repository import Gtk
+from gi.repository import Gdk
 
 from sugar3.graphics import style
 from sugar3.graphics.tray import HTray
@@ -49,6 +50,10 @@ from jarabe.frame.frameinvoker import FrameWidgetInvoker
 from jarabe.frame.notification import NotificationIcon
 from jarabe.frame.notification import NotificationButton
 from jarabe.frame.notification import NotificationPulsingIcon
+from jarabe.frame.clipboardmenu import ClipboardMenu
+from jarabe.frame.clipboardobject import ClipboardObject
+from jarabe.frame.clipboardtray import _ContextMap
+from jarabe.frame.clipboardobject import Format
 import jarabe.frame
 
 
@@ -63,11 +68,23 @@ class ActivityButton(RadioToolButton):
         self._home_activity = home_activity
         self._notify_launch_hid = None
 
+        self._context_map = _ContextMap()
+        self._cb_object = None
         self._icon = NotificationPulsingIcon()
         self._icon.props.base_color = home_activity.get_icon_color()
         self._icon.props.pulse_color = \
             XoColor('%s,%s' % (style.COLOR_BUTTON_GREY.get_svg(),
                                style.COLOR_TOOLBAR_GREY.get_svg()))
+        if self._home_activity.is_journal():
+            self._icon.drag_dest_set(Gtk.DestDefaults.ALL,
+                                     [], Gdk.DragAction.COPY)
+            self._icon.drag_dest_add_text_targets()
+            self._icon.drag_dest_add_image_targets()
+            self._icon.drag_dest_add_uri_targets()
+            self._icon.connect('drag_drop', self.__drag_drop_cb)
+            self._icon.connect('drag_data_received',
+                               self.__journal_drag_data_received_cb)
+
         if home_activity.get_icon_path():
             self._icon.props.file = home_activity.get_icon_path()
         else:
@@ -89,6 +106,49 @@ class ActivityButton(RadioToolButton):
                 'notify::launch-status', self.__notify_launch_status_cb)
         elif home_activity.props.launch_status == shell.Activity.LAUNCH_FAILED:
             self._on_failed_launch()
+
+    def __drag_drop_cb(self, widget, context, x, y, time):
+        context_targets = context.list_targets()
+
+        self._context_map = _ContextMap()
+        self._context_map.add_context(context, 0, len(context_targets))
+
+        self._cb_object = ClipboardObject(0, "")
+
+        for target in context_targets:
+            if str(target) not in ('TIMESTAMP', 'TARGETS', 'MULTIPLE'):
+                widget.drag_get_data(context, target, time)
+
+        Gdk.drop_finish(context, True, Gtk.get_current_event_time())
+        if hasattr(self, "_cb_object") and self._cb_object is not None:
+            cb_menu = ClipboardMenu(self._cb_object)
+            cb_menu._copy_to_journal()
+            self._cb_object = None
+            self._context_map = None
+            logging.debug('Saved to Journal')
+
+        return True
+
+    def __journal_drag_data_received_cb(self, widget, context, x, y, selection,
+                                        targetType, time):
+        data = None
+        if selection.get_pixbuf() is not None:
+            data = selection.get_pixbuf()
+        if len(selection.get_uris()) != 0:
+            data = selection.get_uris()[0]
+        if selection.get_text() is not None:
+            data = selection.get_text()
+        if data is None:
+            data = selection.get_data()
+
+        if (data is not None and hasattr(self, "_cb_object") and
+                self._cb_object is not None):
+            mime_type = selection.get_data_type().name()
+            cb_format = Format(mime_type, data, on_disk=False)
+            self._cb_object.add_format(cb_format)
+
+        logging.debug('ActivityTray: got data for target')
+        Gdk.drop_finish(context, True, Gtk.get_current_event_time())
 
     def create_palette(self):
         if self._home_activity.is_journal():

--- a/src/jarabe/frame/activitiestray.py
+++ b/src/jarabe/frame/activitiestray.py
@@ -110,12 +110,9 @@ class ActivityButton(RadioToolButton):
             self._on_failed_launch()
 
     def __drag_drop_cb(self, widget, context, x, y, time):
-        cb_service = clipboard.get_instance()
-        object_id = cb_service.add_object(name="")
-
         context_targets = context.list_targets()
         if not self._context_map.has_context(context):
-            self._context_map.add_context(context, object_id, len(context_targets))
+            self._context_map.add_context(context, 0, len(context_targets))
 
         for target in context_targets:
             if str(target) not in ('TIMESTAMP', 'TARGETS', 'MULTIPLE'):
@@ -141,9 +138,7 @@ class ActivityButton(RadioToolButton):
             data = selection.get_data()
 
         if self._cb_object is None:
-            cb_service = clipboard.get_instance()
-            object_id = cb_service.add_object(name="")
-            self._cb_object = ClipboardObject(object_id, "")
+            self._cb_object = ClipboardObject(0, "")
 
         mime_type = selection.get_data_type().name()
         cb_format = Format(mime_type, data, on_disk=False)

--- a/src/jarabe/frame/clipboardicon.py
+++ b/src/jarabe/frame/clipboardicon.py
@@ -75,10 +75,7 @@ class ClipboardIcon(RadioToolButton):
 
     def _drag_data_get_cb(self, widget, context, selection, target_type,
                           event_time):
-        frame = jarabe.frame.get_view()
-        self._timeout_id = GLib.timeout_add(
-            jarabe.frame.frame.NOTIFICATION_DURATION,
-            lambda: frame.remove_notification(self._notif_icon))
+        GLib.source_remove(self._timeout_id)
         target_atom = selection.get_target()
         target_name = target_atom.name()
         logging.debug('_drag_data_get_cb: requested target %s', target_name)
@@ -183,7 +180,10 @@ class ClipboardIcon(RadioToolButton):
 
     def _drag_begin_cb(self, widget, context):
         # TODO: We should get the pixbuf from the icon, with colors, etc.
-        GLib.source_remove(self._timeout_id)
+        frame = jarabe.frame.get_view()
+        self._timeout_id = GLib.timeout_add(
+            jarabe.frame.frame.NOTIFICATION_DURATION,
+            lambda: frame.remove_notification(self._notif_icon))
         icon_theme = Gtk.IconTheme.get_default()
         pixbuf = icon_theme.load_icon(self._icon.props.icon_name,
                                       style.STANDARD_ICON_SIZE, 0)

--- a/src/jarabe/frame/clipboardicon.py
+++ b/src/jarabe/frame/clipboardicon.py
@@ -75,12 +75,12 @@ class ClipboardIcon(RadioToolButton):
 
     def _drag_data_get_cb(self, widget, context, selection, target_type,
                           event_time):
-        GLib.source_remove(self._timeout_id)
         target_atom = selection.get_target()
         target_name = target_atom.name()
         logging.debug('_drag_data_get_cb: requested target %s', target_name)
         data = self._cb_object.get_formats()[target_name].get_data()
         selection.set(target_atom, 8, data)
+        GLib.source_remove(self._timeout_id)
 
     def _put_in_clipboard(self):
         logging.debug('ClipboardIcon._put_in_clipboard')

--- a/src/jarabe/frame/clipboardmenu.py
+++ b/src/jarabe/frame/clipboardmenu.py
@@ -176,13 +176,19 @@ class ClipboardMenu(Palette):
         jobject = self._copy_to_journal()
         jobject.destroy()
 
-    def _write_to_temp_file(self, data):
+    def _write_to_temp_file(self, data, is_pixbuf):
         tmp_dir = os.path.join(env.get_profile_path(), 'data')
         f, file_path = tempfile.mkstemp(dir=tmp_dir)
+
         try:
-            os.write(f, data)
+            if not is_pixbuf:
+                os.write(f, data)
+            else:
+                options = {}
+                data.savev(file_path, 'bmp', options.keys(), options.values())
         finally:
-            os.close(f)
+            if not is_pixbuf:
+                os.close(f)
         return file_path
 
     def _copy_to_journal(self):
@@ -199,7 +205,7 @@ class ClipboardMenu(Palette):
                 transfer_ownership = False
                 mime_type = mime.get_for_file(file_path)
             else:
-                file_path = self._write_to_temp_file(format_.get_data())
+                file_path = self._write_to_temp_file(format_.get_data(), False)
                 transfer_ownership = True
                 mime_type = 'text/uri-list'
         else:
@@ -209,7 +215,10 @@ class ClipboardMenu(Palette):
                 transfer_ownership = False
                 mime_type = mime.get_for_file(file_path)
             else:
-                file_path = self._write_to_temp_file(format_.get_data())
+                if most_significant_mime_type == 'image/x-MS-bmp':
+                    file_path = self._write_to_temp_file(format_.get_data(), True)
+                else:
+                    file_path = self._write_to_temp_file(format_.get_data(), False)
                 transfer_ownership = True
                 sniffed_mime_type = mime.get_for_file(file_path)
                 if sniffed_mime_type == 'application/octet-stream':

--- a/src/jarabe/frame/clipboardmenu.py
+++ b/src/jarabe/frame/clipboardmenu.py
@@ -184,11 +184,10 @@ class ClipboardMenu(Palette):
             if not is_pixbuf:
                 os.write(f, data)
             else:
-                options = {}
-                data.savev(file_path, 'bmp', options.keys(), options.values())
+                _type = self._cb_object.get_mime_type().split('/').pop()
+                data.savev(file_path, _type, [], [])
         finally:
-            if not is_pixbuf:
-                os.close(f)
+            os.close(f)
         return file_path
 
     def _copy_to_journal(self):
@@ -215,7 +214,7 @@ class ClipboardMenu(Palette):
                 transfer_ownership = False
                 mime_type = mime.get_for_file(file_path)
             else:
-                if most_significant_mime_type == 'image/x-MS-bmp':
+                if most_significant_mime_type.startswith('image'):
                     file_path = self._write_to_temp_file(format_.get_data(), True)
                 else:
                     file_path = self._write_to_temp_file(format_.get_data(), False)

--- a/src/jarabe/frame/clipboardtray.py
+++ b/src/jarabe/frame/clipboardtray.py
@@ -25,7 +25,7 @@ from jarabe.frame import clipboard
 from jarabe.frame.clipboardicon import ClipboardIcon
 
 
-class _ContextMap(object):
+class ContextMap(object):
     """Maps a drag context to the clipboard object involved in the dragging."""
 
     def __init__(self):
@@ -63,7 +63,7 @@ class ClipboardTray(tray.VTray):
     def __init__(self):
         tray.VTray.__init__(self, align=tray.ALIGN_TO_END)
         self._icons = {}
-        self._context_map = _ContextMap()
+        self._context_map = ContextMap()
 
         cb_service = clipboard.get_instance()
         cb_service.connect('object-added', self._object_added_cb)


### PR DESCRIPTION
@quozl @srevinsaju kindly test and review.

Will fix object recopying to the clipboard after it's dragged and saved to the journal in another PR.

> It seems to have some weird conditions with drags from browse. If I drag an image from browse to the journal, it fails [1]. But if I go browse->clipboard then clipboard->browse it works.

This is still the case and I don't think it should change.

Seeing as this is a feature, would one commit be preferred? 