### PR TITLE
Fix Issue #856 with Emit Function Parameter Datatype during Object Deletion Signal.

### DIFF
--- a/src/jarabe/frame/clipboard.py
+++ b/src/jarabe/frame/clipboard.py
@@ -37,7 +37,7 @@ class Clipboard(GObject.GObject):
         'object-added': (GObject.SignalFlags.RUN_FIRST, None,
                          ([object])),
         'object-deleted': (GObject.SignalFlags.RUN_FIRST, None,
-                           ([int])),
+                           ([GObject.TYPE_INT64])),
         'object-selected': (GObject.SignalFlags.RUN_FIRST, None,
                             ([int])),
         'object-state-changed': (GObject.SignalFlags.RUN_FIRST, None,


### PR DESCRIPTION
@chimosky @quozl  Fix Issue #856 with Emit Function Parameter Datatype during Object Deletion signal.

Root Cause: Previously, the 'int' datatype was used as an argument for the emit function when an object was deleted. This meant that the Python interpreter was responsible for deciding whether to use int32 or int64 based on the type of input initially passed in. Initially, the interpreter was selecting int32, but when larger input values were used, a 'typeerror' occurred because it could not convert int64 to int32 (gint).

Furthermore, the object_id was deleted from the _objects dictionary before this 'typeerror', leading to a 'keyerror' in the next iteration of the code.

Fix Provided:  I have changed the datatype of the function parameter to int64, ensuring that integer input is stored as int64 regardless of its range.