### PR TITLE
Introducing continuous integration...

### DIFF
--- a/.github/workflows/sugar-ci.yml
+++ b/.github/workflows/sugar-ci.yml
@@ -1,0 +1,66 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: sugar ci
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build-fedora:
+
+    runs-on: ubuntu-latest
+    container: fedora
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies for OS
+        run: dnf install -y autoconf make intltool glib2-devel gtk3-devel gcc
+      - name: Install dependencies for python
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          pip install empy
+      - name: Run autoconf
+        run: ./autogen.sh
+      - name: Make
+        run: make
+      - name: Install
+        run: make install
+  
+  build-ubuntu:
+
+    runs-on: ubuntu-latest
+    container: ubuntu 
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies for OS
+        run: |
+          apt-get update
+          apt-get install -y autoconf make intltool libglib2.0-dev libgtk-3-dev build-essential
+      - name: Install dependencies for python
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          pip install empy
+      - name: Run autoconf
+        run: ./autogen.sh
+      - name: Make
+        run: make
+      - name: Install
+        run: make install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Sugar
 =====
 
+[![sugar ci](https://github.com/sugarlabs/sugar/actions/workflows/sugar-ci.yml/badge.svg)](https://github.com/sugarlabs/sugar/actions/workflows/sugar-ci.yml)
+
 Sugar is the desktop environment component of a worldwide effort to
 provide every child with an equal opportunity for a quality
 education. Available in more than twenty-five languages, Sugar

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -44,7 +44,6 @@ hus
 hy
 ibo
 id
-ig
 is
 it
 ja


### PR DESCRIPTION
which builds sugar on both fedora and ubuntu.
There is also a tiny patch to po/LINGUAS to
address a file that was removed upstream in
[ca6c6d2](https://github.com/sugarlabs/sugar/commit/ca6c6d27c0c323ee0e7f1ac4e8d4cf900afb110a).