### PR TITLE
Fix incomplete port to python3

### DIFF
--- a/src/jarabe/journal/model.py
+++ b/src/jarabe/journal/model.py
@@ -941,6 +941,7 @@ def get_documents_path():
         return _documents_path
 
     try:
+        subprocess.run(['xdg-user-dirs-update'])
         pipe = subprocess.Popen(['xdg-user-dir', 'DOCUMENTS'],
                                 stdout=subprocess.PIPE)
         documents_path = os.path.normpath(

--- a/src/jarabe/view/customizebundle.py
+++ b/src/jarabe/view/customizebundle.py
@@ -51,7 +51,7 @@ def generate_unique_id():
     nick = profile.get_nick_name()
     pubkey = profile.get_pubkey()
     m = hashlib.sha1()
-    m.update(pubkey)
+    m.update(pubkey.encode())
     hexhash = m.hexdigest()
 
     nick_letters = "".join([x for x in nick if x.isalpha()])


### PR DESCRIPTION
Call xdg-user-dirs-update to update xdg directories before looking for any user directory.

@kshitijdshah99 kindly test and review, you can test with Pippy activity, you'll need to build sugar
with this branch to test.

Before this change `ActivityToolbarButton -> Create a Sugar activity Bundle` threw an error, this fixes that.