### PR TITLE
Detects Python 2 Activities_ fixes #991

### DIFF
--- a/po/sugar.pot
+++ b/po/sugar.pot
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Invite to %s"
 msgstr ""
 
-#: src/jarabe/view/launcher.py:158
+#: src/jarabe/view/launcher.py:162
 #, python-format
 msgid "<b>%s</b> failed to start."
 msgstr ""
@@ -2004,4 +2004,9 @@ msgstr ""
 
 #: src/jarabe/view/viewsource.py:814
 msgid "Please select a file in the left panel."
+msgstr ""
+
+#: ../src/jarabe/view/launcher.py:159
+#, python-format
+msgid "<b>%s</b> cannot start because it was made for an older version."
 msgstr ""

--- a/src/jarabe/view/launcher.py
+++ b/src/jarabe/view/launcher.py
@@ -155,15 +155,19 @@ def __launch_failed_cb(home_model, home_activity):
     if launcher is None:
         logging.error('Launcher for %s is missing', activity_id)
     else:
-        launcher.error_text.props.label = _('<b>%s</b> failed to start.') % \
-            home_activity.get_activity_name()
+        if hasattr(home_activity, 'is_python2_activity') and home_activity.is_python2_activity:
+            launcher.error_text.props.label = _('<b>%s</b> cannot start because it was made for an older version.') % \
+                home_activity.get_activity_name()
+        else:
+            launcher.error_text.props.label = _('<b>%s</b> failed to start.') % \
+                home_activity.get_activity_name()
+            
         launcher.error_text.show()
 
         launcher.cancel_button.connect('clicked',
                                        __cancel_button_clicked_cb,
                                        home_activity)
         launcher.cancel_button.show()
-
 
 def __cancel_button_clicked_cb(button, home_activity):
     _destroy_launcher(home_activity)


### PR DESCRIPTION
**Issue**:  https://github.com/sugarlabs/sugar/issues/991
Launcher animation running for 90 seconds minute before reporting "failed to start"
No meaningful error in the activity log.
A FileNotFoundError for sugar-activity in shell.log.

**The requirements included:**
Reduce the launcher animation timeout to 10 seconds.
Display custom message in launcher.
Ensure the activity log reflects the failure (handled in sugar-toolkit-gtk3).

**Changes in This PR**
Launcher Animation Timeout Reduction: Adjusted the launcher timeout from 90 seconds to 10.
Display of custom Error Message in Launcher due to Python2 activity. 
Translation Support: Added the new error message to the translation catalog in sugar.pot. (Currently only in sugar.pot; additional language files pending.)

The following requirements are addressed in a separate PR in sugar-toolkit-gtk3:

Handling the FileNotFoundError exception in activityfactory.py.
Logging the error to the activity log when "sugar-activity" is detected in the exception.

**Testing**
Tested on Fedora 41 with Sugar 0.121.
Used the Calculate activity (version 44) to verify:
The launcher animation stops after 10 seconds.
The custom error message is displayed in the launcher when the activity fails due to a missing sugar-activity.

**Notes**
Please review the companion PR in the sugar-toolkit-gtk3 repo https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/487 .

![Screenshot 2025-04-03 at 4 01 46 AM](https://github.com/user-attachments/assets/817f363b-2dc1-4b0f-b5ee-3d7b266a7394)
![Screenshot 2025-04-03 at 4 02 06 AM](https://github.com/user-attachments/assets/4d3c0c15-67bf-4f99-af66-db0f4807541f)

@quozl, @chimosky, would really appreciate if you could review this.