### PR TITLE
Don't raise error when country name not found

### DIFF
--- a/extensions/cpsection/modemconfiguration/model.py
+++ b/extensions/cpsection/modemconfiguration/model.py
@@ -206,8 +206,9 @@ class CountryCodeParser(object):
         try:
             return self._data[country_code]
         except KeyError:
-            raise KeyError('Not found country name for code "%s"'
-                           % country_code)
+            logging.warning('Not found country name for code "%s"'
+                            % country_code)
+            return country_code
 
 
 class ServiceProvidersParser(object):


### PR DESCRIPTION
Recently, a provider from Kosovo was added to mobile-broadband-provider-info, but Kosovo is missing from `iso3166.tab`, causing an exception:
```python
Traceback (most recent call last):
  File "/usr/share/sugar/extensions/cpsection/modemconfiguration/model.py", line 207, in get
    return self._data[country_code]
           ~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'xk'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/jarabe/controlpanel/gui.py", line 459, in __select_option_cb
    self.show_section_view(option)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/usr/lib/python3.13/site-packages/jarabe/controlpanel/gui.py", line 313, in show_section_view
    self._section_view = view_class(model,
                         ~~~~~~~~~~^^^^^^^
                                    self._options[option]['alerts'])
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/sugar/extensions/cpsection/modemconfiguration/view.py", line 125, in __init__
    self.service_providers = self._model.ServiceProviders()
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/share/sugar/extensions/cpsection/modemconfiguration/model.py", line 275, in __init__
    self._db = ServiceProvidersParser()
               ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/share/sugar/extensions/cpsection/modemconfiguration/model.py", line 235, in __init__
    self._countries.sort(key=lambda x: names.get(x.attrib['code']))
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/sugar/extensions/cpsection/modemconfiguration/model.py", line 235, in <lambda>
    self._countries.sort(key=lambda x: names.get(x.attrib['code']))
                                       ~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/usr/share/sugar/extensions/cpsection/modemconfiguration/model.py", line 209, in get
    raise KeyError('Not found country name for code "%s"'
                   % country_code)
KeyError: 'Not found country name for code "xk"'
```
Instead of that, just show the country code and log a warning, so the modemconfiguration will be still usable in this case.