### PR TITLE
Port to GtkSource 4

### DIFF
--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -23,7 +23,7 @@ import logging
 from gettext import gettext as _
 
 import gi
-gi.require_version('GtkSource', '3.0')
+gi.require_version('GtkSource', '4')
 from gi.repository import GObject
 from gi.repository import GLib
 from gi.repository import Pango


### PR DESCRIPTION
GtkSourceView 3 is deprecated and unmaintained a long time ago. It seems that changing the version number is enough, it works fine.