### PR TITLE
sove he problem DSA key support was removed in

### DIFF
--- a/src/jarabe/intro/window.py
+++ b/src/jarabe/intro/window.py
@@ -80,7 +80,7 @@ def create_profile(user_profile):
 
     logging.debug("Generating user keypair")
 
-    cmd = "ssh-keygen -q -t dsa -f %s -C '' -N ''" % (keypath, )
+    cmd = "ssh-keygen -q -t rsa -f %s -C '' -N ''" % (keypath, )
     (s, o) = subprocess.getstatusoutput(cmd)
     if s != 0:
         logging.error('Could not generate key pair: %d %s', s, o)


### PR DESCRIPTION
OpenSSH 10.0 #1004

Here is the description of the changes:

What I changed: I updated the SSH key generation command in the relevant Python file to use the RSA algorithm instead of the deprecated DSA algorithm.

How I did it:

Located the file: I found the file src/jarabe/intro/window.py which contained the code for generating SSH keys.
Modified the code: I changed line 83 from: cmd = "ssh-keygen -q -t dsa -f %s -C '' -N ''" % (keypath, ) to: cmd = "ssh-keygen -q -t rsa -f %s -C '' -N ''" % (keypath, )
Refused other changes: I verified that other occurrences of "dsa" in the codebase were only inside translation files (like po/fy.po), so I left them alone as they were not related to the code logic.
This ensures that Sugar will generate keys compatible with OpenSSH 10.0.