### PR TITLE
docs: clarify Sugar Shell limitations on WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,36 @@ install`.
 
 See also [Setup a development
 environment](docs/development-environment.md).
+
+
+## Running Sugar Shell on WSL / Ubuntu (Important Note)
+
+Developers attempting to run Sugar Shell (`jarabe`) from source on **Ubuntu under WSL (Windows Subsystem for Linux)** may encounter a situation where the process exits silently without error output or a visible UI.
+
+### Observed behavior
+When running:
+```bash
+dbus-run-session -- python3 ./src/jarabe/main.py
+
+on Ubuntu 20.04 (WSL2):
+No traceback is shown
+No jarabe process remains running
+No Sugar UI window appears
+This can give the impression that the setup is broken, even when all build steps completed successfully.
+
+Explanation
+
+Sugar Shell assumes a full Linux desktop environment with runtime data, session services, and system integration that are not fully available on WSL. While DBus can be started manually, other runtime expectations are unmet, causing Sugar Shell to exit quietly.
+This is a platform limitation rather than a user setup error.
+Recommended approach for contributors on Windows
+
+Contributors working on Windows are encouraged to:
+Focus on Sugar Activities
+Contribute to sugar-toolkit-gtk3
+Work on documentation, tests, or CI improvements
+
+These components run reliably on WSL and do not require the full Sugar desktop runtime.
+To run the Sugar Shell itself, a full Linux environment (for example, a virtual machine or native Linux installation) is recommended.
+
+Why this note exists
+This clarification is intended to save new contributors time and avoid confusion during initial setup.


### PR DESCRIPTION
Fixes  #1015 

### Summary
This PR documents a common setup issue where Sugar Shell exits silently when run on Ubuntu under WSL. The behavior is not currently documented and can mislead new contributors into thinking their setup is broken.

### Motivation
Sugar Shell assumes a full Linux desktop environment, which WSL does not fully provide. This PR adds a clear note explaining the limitation and guides Windows-based contributors toward Activities and sugar-toolkit development, which work reliably on WSL.

### Impact
- Reduces contributor onboarding friction
- Saves time for new contributors on Windows
- Clarifies supported development paths

No functional changes are introduced.


