### PR TITLE
Draft: Warn users when DSA SSH key is detected

### DIFF
--- a/src/test_dsa_warning.py
+++ b/src/test_dsa_warning.py
@@ -1,0 +1,10 @@
+def test_dsa_warning():
+    key_type = "ssh-dss"
+    if key_type == "ssh-dss":
+        print(
+            "WARNING: Your SSH key type (DSA) is unsupported. "
+            "Please generate RSA or ED25519 key."
+        )
+
+if __name__ == "__main__":
+    test_dsa_warning()


### PR DESCRIPTION
Draft PR for issue #1017

This PR demonstrates the detection logic and user-facing warning message
for unsupported DSA SSH keys on systems using OpenSSH ≥10.

Notes:
- This is a draft to validate approach and flow.
- GTK warning integration is not finalized yet due to environment limits.
- No keys are modified or deleted.
- Backward compatibility is preserved.

Requesting feedback before wiring this into:
src/jarabe/intro/window.py
