### PR TITLE
Journal: Fix Select All to respect filtered Journal view

### DIFF
--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -696,9 +696,21 @@ class BaseListView(Gtk.Bin):
         return self._model
 
     def select_all(self):
-        self.get_model().select_all()
+        model = self.get_model()
+        model.select_none()
+
+        tree_model = self.tree_view.get_model()
+        tree_iter = tree_model.get_iter_first()
+
+        while tree_iter:
+            uid = tree_model.get_value(tree_iter, ListModel.COLUMN_UID)
+            if uid is not None:
+                model.set_selected(uid, True)
+            tree_iter = tree_model.iter_next(tree_iter)
+
         self.tree_view.queue_draw()
-        self.emit('selection-changed', len(self._model.get_selected_items()))
+        self.emit('selection-changed', len(model.get_selected_items()))
+
 
     def select_none(self):
         self.get_model().select_none()


### PR DESCRIPTION
Fixes #945

The “Select All” button in Journal did not behave correctly when a
filtered or searched view was active.

Instead of selecting all visible entries, it operated on the full
datastore, which caused selected items to be deselected unexpectedly.

This change updates Select All to iterate only over the entries
currently visible in the Journal list view, matching user expectations
and restoring correct multi-selection behavior.

Tested with partial search terms and filtered Journal views.
