### PR TITLE
frame: fix icon redraw when opening frame palettes

### DIFF
--- a/src/jarabe/frame/framewindow.py
+++ b/src/jarabe/frame/framewindow.py
@@ -148,10 +148,12 @@ class FrameWindow(Gtk.Window):
     def _enter_notify_cb(self, window, event):
         if event.detail != Gdk.NotifyType.INFERIOR:
             self.hover = True
+            self.queue_draw()
 
     def _leave_notify_cb(self, window, event):
         if event.detail != Gdk.NotifyType.INFERIOR:
             self.hover = False
+            self.queue_draw()
 
     def _size_changed_cb(self, screen):
         self._update_size()


### PR DESCRIPTION
Fixes #819

When opening palettes for frame icons, adjacent icons could vanish due to
missing redraws after pointer enter/leave events.

The frame hover state was updated, but no redraw was triggered, leaving
parts of the frame invalidated after palette windows overlapped it.

This change queues a redraw on hover enter and leave, ensuring the frame
is fully repainted and icons remain visible.

Manual testing:
- Open frame
- Hover over frame icons to open palettes
- Move between adjacent icons
- Verified icons no longer disappear
