### PR TITLE
journal: make ActivityChooser modal

### DIFF
--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -370,6 +370,9 @@ class JournalActivity(JournalWindow):
             return
 
         chooser = ActivityChooser()
+        chooser.set_modal(True)
+        chooser.set_transient_for(self.get_window())
+
         activity.push_shell_window(chooser)
         chooser.connect('hide', activity.pop_shell_window)
 


### PR DESCRIPTION
The ActivityChooser window opened from the Journal was not modal, allowing
interaction with the Journal while the chooser was active.

This change makes ActivityChooser modal and transient for the Journal
window, ensuring correct window behavior and preventing unintended
interactions.

Fixes #815
