### PR TITLE
Fix paste failure when multiple clipboard items exist

### DIFF
--- a/src/jarabe/frame/clipboardtray.py
+++ b/src/jarabe/frame/clipboardtray.py
@@ -163,8 +163,9 @@ class ClipboardTray(tray.VTray):
         self._context_map.add_context(context, object_id, len(context_targets))
 
         for target in context_targets:
-            if str(target) not in ('TIMESTAMP', 'TARGETS', 'MULTIPLE'):
-                widget.drag_get_data(context, target, time)
+            if str(target) in ('TIMESTAMP', 'TARGETS'):
+                continue
+            widget.drag_get_data(context, target, time)
 
         cb_service.set_object_percent(object_id, percent=100)
 


### PR DESCRIPTION
This change fixes a paste failure that occurs when multiple clipboard
objects exist in the frame.

The drag-and-drop handler was attempting to process unsupported selection
targets, which caused paste to fail. These targets are now skipped so
valid clipboard data is handled correctly.

Reproducer:
- Copy multiple items so several clipboard entries exist
- Attempt to paste
- Paste now correctly inserts the most recent clipboard item

Fixes #783
