### PR TITLE
journaltoolbox: fix Past Year date filter using 356 instead of 365 days

### DIFF
--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -301,7 +301,7 @@ class MainToolbox(ToolbarBox):
         elif self._when_filter == _ACTION_PAST_MONTH:
             date_range = (today_start - timedelta(30), right_now)
         elif self._when_filter == _ACTION_PAST_YEAR:
-            date_range = (today_start - timedelta(356), right_now)
+            date_range = (today_start - timedelta(365), right_now)
 
         return (time.mktime(date_range[0].timetuple()),
                 time.mktime(date_range[1].timetuple()))


### PR DESCRIPTION
The "Past Year" date filter in `_get_date_range()` uses `timedelta(356)` — a digit transposition of 365. This excludes Journal entries from 357-365 days ago.

Fixes #1040
