### PR TITLE
journal: fix crash in quoted search on external storage

### DIFF
--- a/src/jarabe/journal/model.py
+++ b/src/jarabe/journal/model.py
@@ -251,7 +251,7 @@ class InplaceResultSet(BaseResultSet):
 
         query_text = query.get('query', '')
         if query_text.startswith('"') and query_text.endswith('"'):
-            self._regex = re.compile('*%s*' % query_text.strip(['"']))
+            self._regex = re.compile('.*%s.*' % query_text.strip('"'))
         elif query_text:
             expression = ''
             for word in query_text.split(' '):


### PR DESCRIPTION
Searching the Journal on external storage with a quoted string crashes with two errors:

1. `str.strip()` called with a list argument instead of a string — raises `TypeError`
2. Regex pattern `*text*` is invalid (`*` has nothing to repeat) — raises `re.error`

Fixed by passing a string to `strip()` and using `.*text.*` as the pattern, consistent with the unquoted search branch.
