### PR TITLE
neighborhood: guard against None active activity in buddy update

### DIFF
--- a/src/jarabe/model/neighborhood.py
+++ b/src/jarabe/model/neighborhood.py
@@ -534,7 +534,8 @@ class _Account(GObject.GObject):
                 if buddy_handle == self._self_handle:
                     home_model = shell.get_model()
                     activity = home_model.get_active_activity()
-                    if activity.get_activity_id() == activity_id:
+                    if activity is not None and \
+                            activity.get_activity_id() == activity_id:
                         connection = self._connection[
                             CONNECTION_INTERFACE_BUDDY_INFO]
                         connection.SetCurrentActivity(


### PR DESCRIPTION
`_update_buddy_activities` calls `get_activity_id()` on the result of `get_active_activity()` without a None check. `get_active_activity()` returns `None` when no activity is active (e.g. on the home screen).

When a Telepathy activity callback fires with no active activity, this crashes with `AttributeError: 'NoneType' object has no attribute 'get_activity_id'`.

Added a None guard before the method call.
