### PR TITLE
Add sugar-dev launcher and display manager troubleshooting

### DIFF
--- a/bin/sugar-dev
+++ b/bin/sugar-dev
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Sugar Development Launcher
+# Provides a safe way to run Sugar without display manager integration
+# Addresses issue #978 - display manager freezing problems
+
+set -e
+
+# Setup logging
+LOG_DIR="${HOME}/.sugar/default/logs"
+LOG_FILE="${LOG_DIR}/sugar-dev.log"
+mkdir -p "$LOG_DIR"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+log "=== Sugar Development Session Starting ==="
+
+# Check if running in graphical environment
+if [ -z "$DISPLAY" ]; then
+    echo "ERROR: No DISPLAY environment variable detected."
+    echo "Please run this command from within a graphical desktop session."
+    log "ERROR: No DISPLAY set"
+    exit 1
+fi
+
+log "DISPLAY: $DISPLAY"
+
+# Check for required commands
+check_command() {
+    if ! command -v "$1" &> /dev/null; then
+        echo "ERROR: Required command '$1' not found."
+        echo "Install it with: sudo apt install $2"
+        log "ERROR: Missing $1"
+        return 1
+    fi
+    log "✓ Found: $1"
+    return 0
+}
+
+MISSING=0
+check_command "metacity" "metacity" || MISSING=1
+check_command "sugar-session" "sugar (build from source)" || MISSING=1
+check_command "python3" "python3" || MISSING=1
+
+if [ $MISSING -eq 1 ]; then
+    log "FATAL: Missing dependencies"
+    exit 1
+fi
+
+# Check Python modules
+if ! python3 -c "import gi" 2>/dev/null; then
+    echo "ERROR: Python GI module not found."
+    echo "Install it with: sudo apt install python3-gi"
+    log "ERROR: Missing python3-gi"
+    exit 1
+fi
+log "✓ Python GI available"
+
+# Start window manager in background
+log "Starting metacity window manager..."
+metacity --replace &
+METACITY_PID=$!
+sleep 2
+
+# Display info to user
+echo ""
+echo "=========================================="
+echo "  Sugar Development Session"
+echo "=========================================="
+echo ""
+echo "Running Sugar in windowed mode"
+echo "This avoids display manager integration issues"
+echo ""
+echo "Log file: $LOG_FILE"
+echo "To exit: Close Sugar windows or press Ctrl+C"
+echo ""
+
+# Start Sugar
+log "Launching sugar-session..."
+trap "log 'Received interrupt signal'; kill $METACITY_PID 2>/dev/null || true; exit 0" INT TERM
+
+sugar-session 2>&1 | tee -a "$LOG_FILE"
+
+# Cleanup
+log "Cleaning up..."
+kill $METACITY_PID 2>/dev/null || true
+log "=== Sugar Development Session Ended ==="

--- a/docs/troubleshooting-display-manager.md
+++ b/docs/troubleshooting-display-manager.md
@@ -1,0 +1,140 @@
+# Troubleshooting Display Manager Issues
+
+## Issue #978: Sugar Session Freezes at Loading Screen
+
+### Symptoms
+When attempting to log into Sugar via your system's display manager (GDM, LightDM, SDDM):
+- The screen shows a loading indicator
+- System becomes unresponsive
+- Sugar desktop never appears
+- Must force power off/restart
+
+### Root Causes
+This issue typically occurs due to:
+1. Missing or incompatible dependencies (metacity, python modules)
+2. Display manager compatibility problems
+3. Incorrect session file configuration
+4. Missing error logging/diagnostics
+
+### Recommended Solution: Use Development Mode
+
+Instead of logging in through the display manager, run Sugar within your existing desktop session:
+```bash
+# After building Sugar from source
+sugar-dev
+```
+
+**Benefits:**
+- Avoids display manager integration entirely
+- Provides detailed error logging
+- Safer for development and testing
+- Works on all distributions
+- Easy to debug and recover from issues
+
+### Requirements
+```bash
+# Install dependencies
+sudo apt install metacity python3-gi gir1.2-gtk-3.0 dbus-x11
+
+# Build Sugar from source (if not already done)
+# See docs/development-environment.md
+```
+
+### Running Sugar in Development Mode
+```bash
+# Simple invocation
+sugar-dev
+
+# Check logs if issues occur
+cat ~/.sugar/default/logs/sugar-dev.log
+
+# Debug mode
+SUGAR_LOGGER_LEVEL=debug sugar-dev
+```
+
+### Alternative: Full Session Mode (Advanced)
+
+If you specifically need Sugar as a complete desktop session:
+
+#### 1. Verify Session File
+
+Check `/usr/share/xsessions/sugar.desktop` contains:
+```ini
+[Desktop Entry]
+Name=Sugar
+Comment=Sugar Learning Platform
+Exec=sugar-session
+TryExec=sugar-session
+Icon=sugar-xo
+Type=Application
+DesktopNames=SUGAR
+```
+
+#### 2. Ensure Dependencies Are Installed
+```bash
+sudo apt install metacity python3-gi gir1.2-gtk-3.0 dbus-x11
+```
+
+#### 3. Check Logs
+```bash
+# System journal
+journalctl -b | grep sugar
+
+# X server logs
+cat /var/log/Xorg.0.log | grep -i error
+
+# Sugar logs
+ls -la ~/.sugar/default/logs/
+```
+
+#### 4. Recovery from Frozen Session
+
+If stuck at loading screen:
+
+1. Press `Ctrl + Alt + F3` to switch to text console (TTY3)
+2. Login with your username and password
+3. Restart display manager:
+```bash
+   sudo systemctl restart gdm  # or lightdm, or sddm
+```
+4. Switch back: `Ctrl + Alt + F1` or `Ctrl + Alt + F7`
+
+### Platform-Specific Notes
+
+#### Ubuntu 24.04+
+- Sugar packages not available in repositories
+- Must build from source
+- Use `sugar-dev` recommended over full session mode
+
+#### Fedora
+- Install via: `sudo dnf install sugar`
+- Generally better display manager compatibility
+
+### Getting Help
+
+If issues persist:
+
+1. **Check logs first:**
+   - `~/.sugar/default/logs/sugar-dev.log`
+   - `~/.sugar/default/logs/shell.log`
+
+2. **Run with debug logging:**
+```bash
+   SUGAR_LOGGER_LEVEL=debug sugar-dev
+```
+
+3. **Report issue:**
+   - GitHub: https://github.com/sugarlabs/sugar/issues
+   - Include log files and system information
+
+### Why sugar-dev Instead of Full Session?
+
+For developers and testers, `sugar-dev` is preferred because:
+- ✅ Faster iteration cycle
+- ✅ Easier debugging
+- ✅ No risk of system lockout
+- ✅ Better error visibility
+- ✅ Works across different display managers
+- ✅ Can run alongside other desktop environments
+
+Full session mode is primarily intended for dedicated Sugar systems (like OLPC laptops) rather than development machines.


### PR DESCRIPTION
This commit addresses issue #978 where users experience frozen screens when attempting to log into Sugar via display managers (GDM, LightDM, etc).

Changes:
- Add bin/sugar-dev: Development-mode launcher that runs Sugar within existing desktop session, bypassing display manager integration
- Add comprehensive troubleshooting documentation for display manager issues
- Includes detailed logging and dependency checking

The sugar-dev launcher is now the recommended approach for development and testing, as it:
- Avoids display manager compatibility issues
- Provides better error messages and logging
- Allows easier debugging and recovery
- Works across different distributions and display managers

For users experiencing #978, sugar-dev provides a working alternative to full session mode.

Fixes #978