### PR TITLE
journal: Remove obsolete FAT hidden attribute logic

### DIFF
--- a/src/jarabe/journal/model.py
+++ b/src/jarabe/journal/model.py
@@ -30,8 +30,6 @@ import dbus
 from gi.repository import Gio
 from gi.repository import GLib
 
-from gi.repository import SugarExt
-
 from sugar3 import dispatch
 from sugar3 import mime
 from sugar3 import util
@@ -851,12 +849,6 @@ def _write_entry_on_external_device(metadata, file_path, ready_callback=None):
         metadata_dir_path = os.path.join(metadata_dir_path, subdir)
     os.makedirs(metadata_dir_path, exist_ok=True)
 
-    # Set the HIDDEN attrib even when the metadata directory already
-    # exists for backward compatibility; but don't set it in ~/Documents
-    if not metadata['mountpoint'] == get_documents_path():
-        if not SugarExt.fat_set_hidden_attrib(metadata_dir_path):
-            logging.error('Could not set hidden attribute on %s' %
-                          (metadata_dir_path))
 
     preview = None
     if 'preview' in metadata_copy:


### PR DESCRIPTION
This PR removes the legacy logic in the Journal model that attempted to set FAT hidden attributes on metadata directories.

Analysis:
As noted in the source code comments, this was kept for "backward compatibility." However, on modern systems, this call is redundant and can lead to unnecessary error logging. Removing this call allows for the complete removal of the sugar-fatattr infrastructure in the toolkit.

Changes:

Removed the SugarExt.fat_set_hidden_attrib call block in src/jarabe/journal/model.py.
Removed the SugarExt import from gi.repository as it is no longer required in this module.
Cleaned up the associated error logging block.

Dependencies:
Note to Mentors: This PR should only be merged in coordination with the toolkit changes here: 
[f5c5398](https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/504)