### PR TITLE
Fix: Journal list updates breaking when datastore write fails

### DIFF
--- a/src/jarabe/journal/model.py
+++ b/src/jarabe/journal/model.py
@@ -728,7 +728,9 @@ def write(metadata, file_path='', update_mtime=True, transfer_ownership=True,
             ready_callback(metadata, file_path, metadata['uid'])
 
     def error_handler(error):
-        logging.error('Could not create/update datastore entry')
+        logging.error('Could not create/update datastore entry: %s', error)
+        if ready_callback:
+            ready_callback(metadata, file_path, metadata.get('uid', ''))
 
     logging.debug('model.write %r %r %r', metadata.get('uid', ''), file_path,
                   update_mtime)


### PR DESCRIPTION
## Summary

Fix an issue where the Journal list view could stop receiving datastore update notifications if a datastore write operation failed.

---

## Problem

In `src/jarabe/journal/model.py`, the `error_handler` used by `write()` logged a static error message and returned without invoking `ready_callback`.

However, callers such as `ListModel.set_value()` temporarily disconnect the `model.updated` signal before calling `write()` and rely on `ready_callback` to reconnect it after the operation completes.

If the datastore write fails, `ready_callback` was never called, leaving the signal handler disconnected. As a result, the Journal list view would stop updating for the remainder of the session — new entries, deletions, or metadata changes would not appear until Sugar was restarted.

---

## Fix

Two small changes were made in `write()`:

1. Include the actual error object in the log message so datastore failures are diagnosable:

   ```
   logging.error('Could not create/update datastore entry: %s', error)
   ```

2. Ensure `ready_callback` is invoked even when the write operation fails, allowing callers to restore their state (e.g., reconnect the `model.updated` signal).

---

## Impact

* Prevents the Journal list view from becoming disconnected from datastore updates after a write failure.
* Ensures callers relying on `ready_callback` always restore their state.
* Improves debugging by logging the underlying datastore error.

These changes keep the Journal UI responsive even when datastore operations fail due to conditions such as disk pressure or temporary D-Bus errors.
