### PR TITLE
Port: Replace activityfactory with standard uuid and subprocess

### DIFF
--- a/src/jarabe/desktop/activitychooser.py
+++ b/src/jarabe/desktop/activitychooser.py
@@ -15,6 +15,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 import logging
+import uuid
 
 from gi.repository import GLib
 from gettext import gettext as _
@@ -22,7 +23,6 @@ from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GObject
 
-from sugar4.activity import activityfactory
 from sugar4.graphics import iconentry
 from sugar4.graphics import style
 from sugar4.graphics.toolbutton import ToolButton
@@ -199,7 +199,7 @@ class ActivityChooser(Gtk.Window):
 
                 row = model[0]
                 bundle_id = row[self.tree_view._model.column_bundle_id]
-                activity_id = activityfactory.create_activity_id()
+                activity_id = str(uuid.uuid4())
 
                 self.emit('activity-selected', bundle_id, activity_id)
                 self.destroy()
@@ -213,7 +213,7 @@ class ActivityChooser(Gtk.Window):
 
     def _got_row_tree_view(self, row):
         bundle_id = row[self.tree_view._model.column_bundle_id]
-        activity_id = activityfactory.create_activity_id()
+        activity_id = str(uuid.uuid4())
         self.emit('activity-selected', bundle_id, activity_id)
         self.destroy()
 

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -18,6 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import uuid
 from gettext import gettext as _
 
 from gi.repository import GObject
@@ -34,7 +35,6 @@ from sugar4.graphics.palettemenu import PaletteMenuItem
 from sugar4.graphics.palettemenu import PaletteMenuItemSeparator
 from sugar4.graphics.alert import Alert, ErrorAlert
 from sugar4.graphics.xocolor import XoColor
-from sugar4.activity import activityfactory
 from sugar4 import dispatch
 from sugar4.datastore import datastore
 
@@ -508,7 +508,7 @@ class ActivityIcon(CanvasIcon):
 
     def _resume(self, journal_entry):
         if not journal_entry['activity_id']:
-            journal_entry['activity_id'] = activityfactory.create_activity_id()
+            journal_entry['activity_id'] = str(uuid.uuid4())
         misc.resume(journal_entry, self._activity_info.get_bundle_id())
 
     def _activate(self):

--- a/src/jarabe/journal/bundlelauncher.py
+++ b/src/jarabe/journal/bundlelauncher.py
@@ -14,12 +14,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 
-from sugar4.activity import activityfactory
 from sugar4.activity.activityhandle import ActivityHandle
 from sugar4.datastore import datastore
 
 from jarabe.model import bundleregistry
 from jarabe.journal.misc import get_activities_for_mime
+from jarabe.journal.misc import launch_activity
 
 
 def get_bundle(bundle_id=None, object_id=None):
@@ -70,5 +70,5 @@ def launch_bundle(bundle_id=None, object_id=None):
                                      object_id=object_id,
                                      uri=None,
                                      invited=False)
-    activityfactory.create(bundle, activity_handle)
+    launch_activity(bundle, activity_handle)
     return True

--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -31,7 +31,7 @@ from gi.repository import GObject
 from sugar4.graphics.alert import ErrorAlert
 from sugar4 import env
 from sugar4.datastore import datastore
-from sugar4.activity import activityfactory
+
 
 from jarabe.journal.journaltoolbox import MainToolbox
 from jarabe.journal.journaltoolbox import AddNewBar
@@ -245,7 +245,7 @@ class JournalActivity(JournalWindow):
         self.remove_alert(alert)
 
     def __realize_cb(self, window):
-        activity_id = activityfactory.create_activity_id()
+        activity_id = str(uuid.uuid4())
         data = GObject.GObject()
         settattr(data, 'activity_id', str(activity_id))
         settattr(data, 'bundle_id', _BUNDLE_ID)
@@ -663,7 +663,7 @@ def initialize_journal_object(title=None, bundle_id=None,
         icon_color = settings.get_string('color')
 
     if not activity_id:
-        activity_id = activityfactory.create_activity_id()
+        activity_id = str(uuid.uuid4())
 
     jobject = datastore.create()
     jobject.metadata['title'] = title

--- a/src/jarabe/journal/misc.py
+++ b/src/jarabe/journal/misc.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import uuid
+import subprocess
 import time
 import os
 import hashlib
@@ -24,7 +26,6 @@ from gi.repository import Gio
 from gi.repository import Gtk
 from gi.repository import Gdk
 
-from sugar4.activity import activityfactory
 from sugar4.activity.activityhandle import ActivityHandle
 from sugar4.graphics.icon import get_icon_file_name
 from sugar4.graphics.xocolor import XoColor
@@ -258,13 +259,24 @@ def resume(metadata, bundle_id=None, alert_window=None,
         model.copy(metadata, '/', ready_callback=ready_callback)
 
 
+def launch_activity(bundle, handle):
+    cmd = bundle.get_command().split()
+    if getattr(handle, 'activity_id', None):
+        cmd.extend(['-a', handle.activity_id])
+    if getattr(handle, 'object_id', None):
+        cmd.extend(['-o', handle.object_id])
+    if getattr(handle, 'uri', None):
+        cmd.extend(['-u', handle.uri])
+    subprocess.Popen(cmd, cwd=getattr(bundle, 'path', '/'))
+
+
 def launch(bundle, activity_id=None, object_id=None, uri=None, color=None,
            invited=False, alert_window=None):
 
     bundle_id = bundle.get_bundle_id()
 
     if activity_id is None or not activity_id:
-        activity_id = activityfactory.create_activity_id()
+        activity_id = str(uuid.uuid4())
 
     logging.debug('launch bundle_id=%s activity_id=%s object_id=%s uri=%s',
                   bundle.get_bundle_id(), activity_id, object_id, uri)
@@ -312,7 +324,7 @@ def launch(bundle, activity_id=None, object_id=None, uri=None, color=None,
                                      object_id=object_id,
                                      uri=uri,
                                      invited=invited)
-    activityfactory.create(bundle, activity_handle)
+    launch_activity(bundle, activity_handle)
 
 
 def _downgrade_option_alert(bundle, metadata):


### PR DESCRIPTION
Removes dependency on `sugar4.activity.activityfactory` by replacing:

* `activityfactory.create_activity_id()` → `str(uuid.uuid4())`
* `activityfactory.create(bundle, handle)` → new `launch_activity()` function using `subprocess.Popen`

`sugar-launch` still uses `activityfactory.get_command()` and `activityfactory.get_environment()` which are outside the scope of this change.