### PR TITLE
Fix updator refresh timing

### DIFF
--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -5,6 +5,17 @@ Using Sugar on Ubuntu
 
 In relation to Sugar, Ubuntu is a downstream distribution project that can be used to run Sugar.
 
+Ubuntu 24.04 (Noble Numbat)
+-------------------
+
+Sugar 0.121 can be installed with the following commands:
+
+    sudo apt update
+    sudo apt install sucrose
+
+-   log out,
+-   [log in with the Sugar desktop selected](https://github.com/sugarlabs/sugar-docs/blob/master/src/sugar-logging-in.md).
+
 Ubuntu 23.10 (Mantic Minotaur)
 -------------------
 

--- a/extensions/cpsection/updater/view.py
+++ b/extensions/cpsection/updater/view.py
@@ -22,6 +22,7 @@ import logging
 
 from gi.repository import GObject
 from gi.repository import Gtk
+from gi.repository import GLib
 
 from sugar3.graphics import style
 from sugar3.graphics.icon import Icon, CellRendererIcon
@@ -77,7 +78,7 @@ class ActivityUpdater(SectionView):
 
         state = self._model.get_state()
         if state in (updater.STATE_IDLE, updater.STATE_CHECKED):
-            self._refresh()
+            GLib.idle_add(self._refresh)
         elif state in (updater.STATE_CHECKING, updater.STATE_DOWNLOADING,
                        updater.STATE_UPDATING):
             self._switch_to_progress_pane()


### PR DESCRIPTION
Tested on Ubuntu 24.04 (X11) in a VM.

It does resolve the Software Update UI issue. The section still requires multiple clicks to open, although no traceback is shown.

The problem appears to be caused by _refresh() executing during initialization and interfering with GTK view selection.

Deferring the call using:

    GLib.idle_add(self._refresh)

resolves the issue. Software Update now opens with a single click and no UI freeze.

issue #1055 

PR submitted with this fix.