### PR TITLE
controlpanel: guard modem configuration against invalid country and empty provider/plan

### DIFF
--- a/extensions/cpsection/modemconfiguration/model.py
+++ b/extensions/cpsection/modemconfiguration/model.py
@@ -283,7 +283,13 @@ class ServiceProviders(object):
         self._countries = self._db.get_countries()
         country_idx = 0
         if country_code is not None:
-            country_idx = self._db.get_country_idx_by_code(country_code)
+            try:
+                country_idx = self._db.get_country_idx_by_code(country_code)
+            except ValueError:
+                logging.warning(
+                    'Not found provider country for code "%s"' % country_code
+                )
+                country_idx = 0
         self._current_country = country_idx
         self._providers = self._db.get_providers(self._current_country)
 

--- a/extensions/cpsection/modemconfiguration/view.py
+++ b/extensions/cpsection/modemconfiguration/view.py
@@ -142,10 +142,12 @@ class ModemConfiguration(SectionView):
             self._country_combo.set_active(current_country.idx)
 
             self.provider_combo.set_model(provider_store)
-            self.provider_combo.set_active(current_provider.idx)
+            if current_provider is not None:
+                self.provider_combo.set_active(current_provider.idx)
 
             self.plan_combo.set_model(plan_store)
-            self.plan_combo.set_active(current_plan.idx)
+            if current_plan is not None:
+                self.plan_combo.set_active(current_plan.idx)
 
             self._country_combo.connect("changed", self._country_selected_cb)
             self.provider_combo.connect("changed", self._provider_selected_cb)
@@ -268,7 +270,8 @@ class ModemConfiguration(SectionView):
             store = _create_providers_list_store(providers)
             current = self.service_providers.get_provider()
             self.provider_combo.set_model(store)
-            self.provider_combo.set_active(current.idx)
+            if current is not None:
+                self.provider_combo.set_active(current.idx)
 
     def _provider_selected_cb(self, combo):
         tree_iter = combo.get_active_iter()
@@ -281,7 +284,8 @@ class ModemConfiguration(SectionView):
             store = _create_providers_list_store(plans)
             current = self.service_providers.get_plan()
             self.plan_combo.set_model(store)
-            self.plan_combo.set_active(current.idx)
+            if current is not None:
+                self.plan_combo.set_active(current.idx)
 
     def _plan_selected_cb(self, combo):
         tree_iter = combo.get_active_iter()
@@ -291,7 +295,8 @@ class ModemConfiguration(SectionView):
 
             self.service_providers.set_plan(plan.idx)
             plan = self.service_providers.get_plan()
-            self._username_entry.entry.set_text(plan.username)
-            self._password_entry.entry.set_text(plan.password)
-            self._number_entry.entry.set_text(plan.number)
-            self._apn_entry.entry.set_text(plan.apn)
+            if plan is not None:
+                self._username_entry.entry.set_text(plan.username)
+                self._password_entry.entry.set_text(plan.password)
+                self._number_entry.entry.set_text(plan.number)
+                self._apn_entry.entry.set_text(plan.apn)


### PR DESCRIPTION
This patch fixes a crash in the modem configuration control panel when
a stored GSM country code is not present in the provider database.

Invalid country codes now fall back to the default country index.

Additionally, provider and plan combo activation are guarded to prevent
AttributeError when values are missing.

No behavior change for valid configurations.

Tested on Ubuntu 24.04 (GTK3 environment).

Fixes #1054