### PR TITLE
intro: avoid race with window manager during first-run intro

### DIFF
--- a/src/jarabe/intro/window.py
+++ b/src/jarabe/intro/window.py
@@ -427,7 +427,10 @@ class IntroWindow(Gtk.Window):
         Gtk.Window.__init__(self)
 
         self.props.decorated = False
-        self.maximize()
+
+        screen = self.get_screen()
+        self.set_default_size(screen.get_width(), screen.get_height())
+        self.move(0, 0)
 
         self._intro_box = _IntroBox(start_on_age_page)
         self._intro_box.connect('done', self._done_cb)


### PR DESCRIPTION
### Summary

Fix a race condition during the initial Sugar experience where the **"Click to change color"** window may briefly appear smaller than fullscreen before being redrawn.

### Cause

`IntroWindow` previously relied on `maximize()`, which depends on the window manager being ready.
If the window manager (e.g., metacity) starts later, the window is first drawn at its default size and then maximized, causing a visible flicker.

### Fix

Initialize the window geometry directly using the display dimensions instead of relying on `maximize()`.

```python
screen = self.get_screen()
self.set_default_size(screen.get_width(), screen.get_height())
self.move(0, 0)
```

This ensures the window starts at fullscreen size even if the window manager startup is delayed.

### Testing

Tested using the reproduction method described in the issue by delaying `metacity` startup with a wrapper script.
With this change, the intro window opens fullscreen immediately and the intermediate smaller window no longer appears.

Fixes #1052
