### PR TITLE
Fix updator refresh clean

### DIFF
--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -5,6 +5,17 @@ Using Sugar on Ubuntu
 
 In relation to Sugar, Ubuntu is a downstream distribution project that can be used to run Sugar.
 
+Ubuntu 24.04 (Noble Numbat)
+-------------------
+
+Sugar 0.121 can be installed with the following commands:
+
+    sudo apt update
+    sudo apt install sucrose
+
+-   log out,
+-   [log in with the Sugar desktop selected](https://github.com/sugarlabs/sugar-docs/blob/master/src/sugar-logging-in.md).
+
 Ubuntu 23.10 (Mantic Minotaur)
 -------------------
 

--- a/extensions/cpsection/updater/view.py
+++ b/extensions/cpsection/updater/view.py
@@ -22,6 +22,7 @@ import logging
 
 from gi.repository import GObject
 from gi.repository import Gtk
+from gi.repository import GLib
 
 from sugar3.graphics import style
 from sugar3.graphics.icon import Icon, CellRendererIcon
@@ -77,7 +78,7 @@ class ActivityUpdater(SectionView):
 
         state = self._model.get_state()
         if state in (updater.STATE_IDLE, updater.STATE_CHECKED):
-            self._refresh()
+            GLib.idle_add(self._refresh)
         elif state in (updater.STATE_CHECKING, updater.STATE_DOWNLOADING,
                        updater.STATE_UPDATING):
             self._switch_to_progress_pane()


### PR DESCRIPTION
## Summary

This PR fixes the Software Update section requiring multiple clicks to open on Ubuntu 24.04 (X11).

The issue was caused by `_refresh()` being executed during initialization, which interfered with GTK view selection and caused a temporary UI freeze.

## Fix

The `_refresh()` call is deferred using:

GLib.idle_add(self._refresh)

This ensures the refresh runs after the UI is fully initialized.

## Testing

Tested on Ubuntu 24.04 (X11) in a VM.

Results:
- Software Update now opens with a single click
- No UI freeze
- No traceback in logs

Fixes #1055