### PR TITLE
cpsection: defer _refresh call to avoid UI freeze

### DIFF
--- a/extensions/cpsection/updater/view.py
+++ b/extensions/cpsection/updater/view.py
@@ -22,6 +22,7 @@ import logging
 
 from gi.repository import GObject
 from gi.repository import Gtk
+from gi.repository import GLib
 
 from sugar3.graphics import style
 from sugar3.graphics.icon import Icon, CellRendererIcon
@@ -77,7 +78,7 @@ class ActivityUpdater(SectionView):
 
         state = self._model.get_state()
         if state in (updater.STATE_IDLE, updater.STATE_CHECKED):
-            self._refresh()
+            GLib.idle_add(self._refresh)
         elif state in (updater.STATE_CHECKING, updater.STATE_DOWNLOADING,
                        updater.STATE_UPDATING):
             self._switch_to_progress_pane()


### PR DESCRIPTION
The Software Update section required multiple clicks to open on Ubuntu 24.04 (X11). The issue was caused by _refresh() being executed during initialization, interfering with GTK view selection.

Defer the _refresh() call using GLib.idle_add so it runs after the UI is fully initialized.

Fixes #1055