### PR TITLE
Journal: fix Select All button deselecting entries instead of selecting

### DIFF
--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -696,9 +696,19 @@ class BaseListView(Gtk.Bin):
         return self._model
 
     def select_all(self):
-        self.get_model().select_all()
+        model = self.get_model()
+        model.select_none()
+
+        tree_model = self.tree_view.get_model()
+        if tree_model is not None:
+            for row in range(len(tree_model)):
+                path = Gtk.TreePath(row)
+                uid = tree_model[path][ListModel.COLUMN_UID]
+                if uid is not None:
+                    model.set_selected(uid, True)
+
         self.tree_view.queue_draw()
-        self.emit('selection-changed', len(self._model.get_selected_items()))
+        self.emit('selection-changed', len(model.get_selected_items()))
 
     def select_none(self):
         self.get_model().select_none()


### PR DESCRIPTION
Fixes #945

The "Select All" button in the Journal did not work correctly. Instead of selecting all entries, it deselected them. This happened because `select_all()` relied on `ListModel._all_ids` which is populated via the datastore's `find_ids()` D-Bus method. The returned UIDs could have type mismatches (bytes vs strings) compared to UIDs used by the rest of the selection logic, or could be empty when the datastore index is being rebuilt.

## Changes

- Modified `select_all()` in `BaseListView` to iterate the visible TreeModel entries by path and select each entry using the same `COLUMN_UID` source that individual checkbox toggle uses.
- This ensures consistent UID types and correctly selects only entries in the current filtered/searched view.

## Testing

1. Open Sugar Journal
2. Search for existing files
3. Select one entry using the checkbox
4. Click the "Select All" button
5. All visible entries should now be selected (previously they were deselected)
