### PR TITLE
journal: avoid re-focusing wrong activity when using Resume with

### DIFF
--- a/src/jarabe/journal/misc.py
+++ b/src/jarabe/journal/misc.py
@@ -249,6 +249,17 @@ def resume(metadata, bundle_id=None, alert_window=None,
             return
         bundle_id = activities[0].get_bundle_id()
 
+    # "Resume with" can select a different activity than the one that
+    # originally created the entry. If the saved activity_id is still
+    # running with another bundle, force a new instance for the selected
+    # bundle instead of re-focusing the old activity.
+    if activity_id:
+        shell_model = shell.get_model()
+        running_activity = shell_model.get_activity_by_id(activity_id)
+        if running_activity is not None and \
+                running_activity.get_bundle_id() != bundle_id:
+            activity_id = None
+
     bundle = registry.get_bundle(bundle_id)
 
     if metadata.get('mountpoint', '/') == '/':


### PR DESCRIPTION
Fixes #795

## Summary
When a journal entry is opened via **Resume with** using a different activity than the one that originally created it, Sugar can re-focus an already running activity that shares the saved `activity_id` instead of launching the selected activity.

This patch keeps the existing resume behavior for matching activities, but forces a new instance when the saved `activity_id` currently belongs to a running activity with a different bundle id.

## Reproducer
1. Open Record and take a photo.
2. Open Journal, right-click the photo.
3. Choose **Resume with -> Image Viewer**.

## Before
Record regains focus.

## After
Image Viewer is launched for the selected journal entry.

## Validation
- `python -m py_compile src/jarabe/journal/misc.py`