### PR TITLE
viewhelp: add loading feedback for Help and Social Help pages

### DIFF
--- a/src/jarabe/view/viewhelp.py
+++ b/src/jarabe/view/viewhelp.py
@@ -302,6 +302,12 @@ class Toolbar(Gtk.Toolbar):
         self.insert(self._forward_button, -1)
         self._forward_button.show()
 
+        self._add_separator(False)
+        self._loading_spinner = Gtk.Spinner()
+        self._loading_spinner.set_tooltip_text(_('Loading...'))
+        self._add_widget(self._loading_spinner)
+        self.set_loading(False)
+
         title = _('Help: %s') % activity_name
         self._label = Gtk.Label()
         self._label.set_markup('<b>%s</b>' % title)
@@ -343,6 +349,14 @@ class Toolbar(Gtk.Toolbar):
     def update_back_forward(self, can_go_back, can_go_forward):
         self._back_button.props.sensitive = can_go_back
         self._forward_button.props.sensitive = can_go_forward
+
+    def set_loading(self, loading):
+        if loading:
+            self._loading_spinner.show()
+            self._loading_spinner.start()
+        else:
+            self._loading_spinner.stop()
+            self._loading_spinner.hide()
 
     def __back_clicked_cb(self, button):
         self.emit('back-clicked')

--- a/src/jarabe/view/viewhelp_webkit2.py
+++ b/src/jarabe/view/viewhelp_webkit2.py
@@ -47,6 +47,7 @@ class Browser():
             'help', self.__app_scheme_cb, None)
 
         self._webview.connect('load-changed', self.__load_changed_cb)
+        self._webview.connect('load-failed', self.__load_failed_cb)
         toolbar.update_back_forward(False, False)
         toolbar.connect('back-clicked', self.__back_cb)
         toolbar.connect('forward-clicked', self.__forward_cb)
@@ -66,8 +67,17 @@ class Browser():
                        -1, Gio.content_type_guess(path, None)[0])
 
     def __load_changed_cb(self, widget, event):
+        if event == WebKit2.LoadEvent.STARTED:
+            self._toolbar.set_loading(True)
+        elif event == WebKit2.LoadEvent.FINISHED:
+            self._toolbar.set_loading(False)
+
         self._toolbar.update_back_forward(self._webview.can_go_back(),
                                           self._webview.can_go_forward())
+
+    def __load_failed_cb(self, widget, load_event, failing_uri, error):
+        self._toolbar.set_loading(False)
+        return False
 
     def __back_cb(self, widget):
         self._webview.go_back()
@@ -79,6 +89,8 @@ class Browser():
         return self._webview.get_session_state()
 
     def load_state(self, state, url):
+        self._toolbar.set_loading(True)
+
         if state is None:
             self._webview.load_uri(url)
         else:


### PR DESCRIPTION
Fixes #848

## Summary
Social Help currently gives no visual feedback while pages are loading.

This patch adds a toolbar loading spinner in the View Help window and drives it from WebKit load events.

## Changes
- add `Gtk.Spinner` to `Toolbar` in `viewhelp.py`
- add `set_loading()` API to start/stop spinner
- in `viewhelp_webkit2.py`:
  - start loading feedback on `STARTED` and before `load_state()` navigation
  - stop loading feedback on `FINISHED`
  - stop loading feedback on `load-failed`

## Result
Users get immediate feedback that Help/Social Help is loading instead of appearing unresponsive.

## Validation
- `python -m py_compile src/jarabe/view/viewhelp.py src/jarabe/view/viewhelp_webkit2.py`