### PR TITLE
Fix AttributeError: replace get_pixbuf with render_pixbuf for Rsvg 2.61+

### DIFF
--- a/src/jarabe/frame/activitiestray.py
+++ b/src/jarabe/frame/activitiestray.py
@@ -126,8 +126,8 @@ class ActivityButton(RadioToolButton):
     def __journal_drag_data_received_cb(self, widget, context, x, y, selection,
                                         targetType, time):
         data = None
-        if selection.get_pixbuf() is not None:
-            data = selection.get_pixbuf()
+        if selection.render_pixbuf() is not None:
+            data = selection.render_pixbuf()
         if len(selection.get_uris()) != 0:
             data = selection.get_uris()[0].encode()
         if selection.get_text() is not None:


### PR DESCRIPTION
Hi! I'm Saurav, a student interested in GSoC 2026.
I noticed issue #1058 where Sugar shows a black screen on systems with Rsvg 2.61+. Looking at the logs, the error was AttributeError: 'Handle' object has no attribute 'get_pixbuf' which happens because Rsvg 2.61+ removed the get_pixbuf() method.
I fixed this by replacing get_pixbuf() with render_pixbuf() in activitiestray.py as suggested by @quozl in the issue thread.
Please let me know if there's anything I need to change!