### PR TITLE
Remove outdated Python 2 references from development-environment.md

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -85,7 +85,7 @@ On Fedora, use [dnf builddep](http://dnf-plugins-core.readthedocs.io/en/latest/b
     done
     sudo dnf install python{2,3}-six python3-empy
 
-Autogen, configure, make, and install modules for Python 2;
+
 
     for module in sugar{-toolkit,-toolkit-gtk3}; do
         cd $module
@@ -107,9 +107,9 @@ Autogen, configure, make, and install modules for Python 3;
 
 On Debian or Ubuntu, try `python3 -c 'import sugar3'` if fails move the `sugar3` directory from `/usr/local/lib/python3.6/site-packages/` to `/usr/local/lib/python3.6/dist-packages/`.
 
-On Fedora, add `/usr/local/lib/python2.7/site-packages/` to `sys.path` for any Python 2 programs, especially `/usr/local/bin/sugar`;
+gar`;
 
-    export PYTHONPATH=/usr/local/lib/python2.7/site-packages
+    
     export GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0
     export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 

--- a/src/jarabe/frame/activitiestray.py
+++ b/src/jarabe/frame/activitiestray.py
@@ -126,8 +126,8 @@ class ActivityButton(RadioToolButton):
     def __journal_drag_data_received_cb(self, widget, context, x, y, selection,
                                         targetType, time):
         data = None
-        if selection.get_pixbuf() is not None:
-            data = selection.get_pixbuf()
+        if selection.render_pixbuf() is not None:
+            data = selection.render_pixbuf()
         if len(selection.get_uris()) != 0:
             data = selection.get_uris()[0].encode()
         if selection.get_text() is not None:


### PR DESCRIPTION
The development-environment.md contained outdated references to Python 2 which has been end-of-life since 2020. 

Changes made:
Removed the "Autogen, configure, make, and install modules for Python 2" section
Replaced `./autogen.sh --with-python2` with `./autogen.sh --with-python3`
Removed outdated Python 2.7 site-packages path references

Sugar has fully moved to Python 3 so these references are no longer relevant and could confuse new contributors.