### PR TITLE
gtk4: remove  show_all() calls from detailview.py

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -85,7 +85,7 @@ On Fedora, use [dnf builddep](http://dnf-plugins-core.readthedocs.io/en/latest/b
     done
     sudo dnf install python{2,3}-six python3-empy
 
-Autogen, configure, make, and install modules for Python 2;
+
 
     for module in sugar{-toolkit,-toolkit-gtk3}; do
         cd $module
@@ -107,9 +107,9 @@ Autogen, configure, make, and install modules for Python 3;
 
 On Debian or Ubuntu, try `python3 -c 'import sugar3'` if fails move the `sugar3` directory from `/usr/local/lib/python3.6/site-packages/` to `/usr/local/lib/python3.6/dist-packages/`.
 
-On Fedora, add `/usr/local/lib/python2.7/site-packages/` to `sys.path` for any Python 2 programs, especially `/usr/local/bin/sugar`;
+gar`;
 
-    export PYTHONPATH=/usr/local/lib/python2.7/site-packages
+    
     export GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0
     export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 

--- a/src/jarabe/frame/activitiestray.py
+++ b/src/jarabe/frame/activitiestray.py
@@ -126,8 +126,8 @@ class ActivityButton(RadioToolButton):
     def __journal_drag_data_received_cb(self, widget, context, x, y, selection,
                                         targetType, time):
         data = None
-        if selection.get_pixbuf() is not None:
-            data = selection.get_pixbuf()
+        if selection.render_pixbuf() is not None:
+            data = selection.render_pixbuf()
         if len(selection.get_uris()) != 0:
             data = selection.get_uris()[0].encode()
         if selection.get_text() is not None:

--- a/src/jarabe/journal/detailview.py
+++ b/src/jarabe/journal/detailview.py
@@ -45,7 +45,7 @@ class DetailView(Gtk.VBox):
                          self.__back_bar_release_event_cb)
         self.pack_start(back_bar, False, True, 0)
 
-        self.show_all()
+        self
 
     def _fav_icon_activated_cb(self, fav_icon):
         keep = not self._expanded_entry.get_keep()
@@ -61,7 +61,7 @@ class DetailView(Gtk.VBox):
             self._expanded_entry = ExpandedEntry(self._journalactivity)
             self.pack_start(self._expanded_entry, True, True, 0)
         self._expanded_entry.set_metadata(self._metadata)
-        self.show_all()
+        self
 
     def refresh(self):
         logging.debug('DetailView.refresh')


### PR DESCRIPTION
Part of the ongoing GTK4 migration effort.
show_all() is deprecated and removed in GTK4. Widgets are visible by default in GTK4 so these calls are unnecessary.Removed show_all() calls from src/jarabe/journal/detailview.py as part of preparing the Sugar Shell for GTK4 migration.

Related to the GTK4 transition work tracked in #1019.