### PR TITLE
Replace deprecated Gtk.VBox and Gtk.HBox with Gtk.Box in desktop widgets

### DIFF
--- a/src/jarabe/desktop/activitieslist.py
+++ b/src/jarabe/desktop/activitieslist.py
@@ -476,7 +476,7 @@ class ClearMessageBox(Gtk.EventBox):
         self.add(alignment)
         alignment.show()
 
-        box = Gtk.VBox()
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         alignment.add(box)
         box.show()
 
@@ -507,7 +507,7 @@ class ClearMessageBox(Gtk.EventBox):
         button.show()
 
 
-class ActivitiesList(Gtk.VBox):
+class ActivitiesList(Gtk.Box):
     __gtype_name__ = 'SugarActivitiesList'
 
     __gsignals__ = {
@@ -517,7 +517,7 @@ class ActivitiesList(Gtk.VBox):
     def __init__(self):
         logging.debug('STARTUP: Loading the activities list')
 
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
         self._scrolled_window = Gtk.ScrolledWindow()
         self._scrolled_window.set_can_focus(False)

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -73,11 +73,11 @@ about the layout can be accessed with fields of the class."""
 _favorites_settings = None
 
 
-class FavoritesBox(Gtk.VBox):
+class FavoritesBox(Gtk.Box):
     __gtype_name__ = 'SugarFavoritesBox'
 
     def __init__(self, favorite_view):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
         self.favorite_view = favorite_view
         self._view = FavoritesView(self)

--- a/src/jarabe/desktop/friendview.py
+++ b/src/jarabe/desktop/friendview.py
@@ -23,10 +23,10 @@ from jarabe.view.buddyicon import BuddyIcon
 from jarabe.model import bundleregistry
 
 
-class FriendView(Gtk.VBox):
+class FriendView(Gtk.Box):
 
     def __init__(self, buddy, **kwargs):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
         # round icon sizes to an even number so that it can be accurately
         # centered in a larger bounding box also of even dimensions

--- a/src/jarabe/desktop/homebackgroundbox.py
+++ b/src/jarabe/desktop/homebackgroundbox.py
@@ -53,10 +53,10 @@ def get_background_alpha_level():
     return alpha
 
 
-class HomeBackgroundBox(Gtk.VBox):
+class HomeBackgroundBox(Gtk.Box):
 
     def __init__(self):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
         self._background_pixbuf = None
         self._update_background_image()
         self.connect('draw', self.__draw_cb)

--- a/src/jarabe/desktop/homebox.py
+++ b/src/jarabe/desktop/homebox.py
@@ -25,13 +25,13 @@ from jarabe.util.normalize import normalize_string
 from jarabe.model import desktop
 
 
-class HomeBox(Gtk.VBox):
+class HomeBox(Gtk.Box):
     __gtype_name__ = 'SugarHomeBox'
 
     def __init__(self, toolbar):
         logging.debug('STARTUP: Loading the home view')
 
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
         self._favorites_views_indicies = []
         for i in range(desktop.get_number_of_views()):

--- a/src/jarabe/desktop/keydialog.py
+++ b/src/jarabe/desktop/keydialog.py
@@ -149,7 +149,7 @@ class WEPKeyDialog(KeyDialog):
         self.key_combo.set_active(0)
         self.key_combo.connect('changed', self.__key_combo_changed_cb)
 
-        hbox = Gtk.HBox()
+        hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         hbox.pack_start(Gtk.Label(_('Key Type:')), True, True, 0)
         hbox.pack_start(self.key_combo, True, True, 0)
         hbox.show_all()
@@ -169,7 +169,7 @@ class WEPKeyDialog(KeyDialog):
         self.auth_combo.add_attribute(cell, 'text', 0)
         self.auth_combo.set_active(0)
 
-        hbox = Gtk.HBox()
+        hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         hbox.pack_start(Gtk.Label(_('Authentication Type:')), True, True, 0)
         hbox.pack_start(self.auth_combo, True, True, 0)
         hbox.show_all()

--- a/src/jarabe/desktop/networkviews.py
+++ b/src/jarabe/desktop/networkviews.py
@@ -124,7 +124,7 @@ class WirelessNetworkView(EventPulsingIcon):
         p = palette.Palette(primary_text=self._display_name,
                             icon=self._palette_icon)
 
-        self.menu_box = Gtk.VBox()
+        self.menu_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         self._connect_item = PaletteMenuItem(_('Connect'))
         icon = Icon(pixel_size=style.SMALL_ICON_SIZE, icon_name='dialog-ok')
@@ -527,7 +527,7 @@ class SugarAdhocView(EventPulsingIcon):
         palette_ = palette.Palette(_('Ad-hoc Network %d') % (self._channel, ),
                                    icon=self._palette_icon)
 
-        self.menu_box = Gtk.VBox()
+        self.menu_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         self._connect_item = PaletteMenuItem(_('Connect'))
         icon = Icon(pixel_size=style.SMALL_ICON_SIZE, icon_name='dialog-ok')
@@ -671,7 +671,7 @@ class OlpcMeshView(EventPulsingIcon):
     def _create_palette(self):
         _palette = palette.Palette(_('Mesh Network %d') % (self._channel, ))
 
-        self.menu_box = Gtk.VBox()
+        self.menu_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         self._connect_item = PaletteMenuItem(_('Connect'))
         icon = Icon(pixel_size=style.SMALL_ICON_SIZE, icon_name='dialog-ok')

--- a/src/jarabe/desktop/viewtoolbar.py
+++ b/src/jarabe/desktop/viewtoolbar.py
@@ -80,7 +80,7 @@ class ViewToolbar(Gtk.Toolbar):
 
         self._add_separator(expand=True)
 
-        self._button_box = Gtk.HBox()
+        self._button_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         self._favorites_buttons = []
         for i in range(desktop.get_number_of_views()):
             self._add_favorites_button(i)
@@ -217,7 +217,7 @@ class FavoritesButton(RadioToolButton):
         self._layout = favorites_settings.layout
 
         # someday, this will be a Gtk.Table()
-        layouts_grid = Gtk.HBox()
+        layouts_grid = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         layout_item = None
         for layoutid, layoutclass in sorted(favoritesview.LAYOUT_MAP.items()):
             layout_item = RadioToolButton(icon_name=layoutclass.icon_name,


### PR DESCRIPTION
Migrate desktop UI components from deprecated Gtk.VBox and Gtk.HBox to Gtk.Box
with appropriate orientation parameters, as part of GTK4 port. Gtk.VBox and
Gtk.HBox were removed in GTK4 and replaced with Gtk.Box using the orientation
parameter.

Updated files:
- activitieslist.py: ActivitiesList, ClearMessageBox (VBox)
- favoritesview.py: FavoritesBox (VBox)
- friendview.py: FriendView (VBox)
- homebackgroundbox.py: HomeBackgroundBox (VBox)
- homebox.py: HomeBox (VBox)
- keydialog.py: WEPKeyDialog (HBox)
- networkviews.py: WirelessNetworkView, SugarAdhocView, OlpcMeshView (VBox)
- viewtoolbar.py: ViewToolbar, FavoritesButton (HBox)

All layouts now use Gtk.Box with orientation=Gtk.Orientation.VERTICAL or
orientation=Gtk.Orientation.HORIZONTAL instead of Gtk.VBox/Gtk.HBox.