### PR TITLE
Replace all deprecated Gtk.VBox and Gtk.HBox with modern Gtk.Box

### DIFF
--- a/extensions/cpsection/aboutcomputer/view.py
+++ b/extensions/cpsection/aboutcomputer/view.py
@@ -43,7 +43,7 @@ class AboutComputer(SectionView):
         self.pack_start(scrollwindow, True, True, 0)
         scrollwindow.show()
 
-        self._vbox = Gtk.VBox()
+        self._vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         scrollwindow.add_with_viewport(self._vbox)
         self._vbox.show()
 
@@ -53,7 +53,7 @@ class AboutComputer(SectionView):
         self._setup_copyright()
 
     def create_information_box(self, label_text, value_text):
-        box = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
         label = Gtk.Label(label=label_text)
         label.set_alignment(1, 0)
         label.modify_fg(Gtk.StateType.NORMAL,
@@ -77,7 +77,7 @@ class AboutComputer(SectionView):
         label_identity.set_alignment(0, 0)
         self._vbox.pack_start(label_identity, False, True, 0)
         label_identity.show()
-        vbox_identity = Gtk.VBox()
+        vbox_identity = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         vbox_identity.set_border_width(style.DEFAULT_SPACING * 2)
         vbox_identity.set_spacing(style.DEFAULT_SPACING)
 
@@ -104,7 +104,7 @@ class AboutComputer(SectionView):
         label_software.set_alignment(0, 0)
         self._vbox.pack_start(label_software, False, True, 0)
         label_software.show()
-        box_software = Gtk.VBox()
+        box_software = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         box_software.set_border_width(style.DEFAULT_SPACING * 2)
         box_software.set_spacing(style.DEFAULT_SPACING)
 
@@ -151,7 +151,7 @@ class AboutComputer(SectionView):
         label_copyright.set_alignment(0, 0)
         self._vbox.pack_start(label_copyright, False, True, 0)
         label_copyright.show()
-        vbox_copyright = Gtk.VBox()
+        vbox_copyright = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         vbox_copyright.set_border_width(style.DEFAULT_SPACING * 2)
         vbox_copyright.set_spacing(style.DEFAULT_SPACING)
 

--- a/extensions/cpsection/background/view.py
+++ b/extensions/cpsection/background/view.py
@@ -78,7 +78,7 @@ class Background(SectionView):
 
         alpha = self._model.get_background_alpha_level()
 
-        alpha_box = Gtk.HBox()
+        alpha_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         alpha_buttons = []
         alpha_icons = [
             [1.0, 'network-wireless-000'],

--- a/extensions/cpsection/backup/view.py
+++ b/extensions/cpsection/backup/view.py
@@ -77,7 +77,7 @@ class _BackupButton(Gtk.EventBox):
 
         Gtk.EventBox.__init__(self, **kwargs)
 
-        self._vbox = Gtk.VBox()
+        self._vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self._icon = Icon(icon_name=self._icon_name,
                           pixel_size=self._pixel_size,
                           xo_color=XoColor('#000000,#000000'))
@@ -119,13 +119,13 @@ class _BackupButton(Gtk.EventBox):
             return self._title
 
 
-class SelectBackupRestorePanel(Gtk.VBox):
+class SelectBackupRestorePanel(Gtk.Box):
 
     def __init__(self, view):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
         self._view = view
-        hbox = Gtk.HBox()
+        hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
 
         self.backup_btn = _BackupButton(
             icon_name='backup-backup',

--- a/extensions/cpsection/datetime/view.py
+++ b/extensions/cpsection/datetime/view.py
@@ -74,7 +74,7 @@ class TimeZone(SectionView):
         self.pack_start(self._scrolled_window, True, True, 0)
         self._scrolled_window.show()
 
-        self._zone_alert_box = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        self._zone_alert_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
         self.pack_start(self._zone_alert_box, False, False, 0)
 
         self._zone_alert = InlineAlert()

--- a/extensions/cpsection/frame/view.py
+++ b/extensions/cpsection/frame/view.py
@@ -53,7 +53,7 @@ class Frame(SectionView):
         label.set_alignment(0, 0)
         self.pack_start(label, False, True, 0)
 
-        box = Gtk.VBox()
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         box.set_border_width(style.DEFAULT_SPACING * 2)
         box.set_spacing(style.DEFAULT_SPACING)
 
@@ -69,7 +69,7 @@ class Frame(SectionView):
         label.set_alignment(0, 0)
         self.pack_start(label, False, True, 0)
 
-        box = Gtk.VBox()
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         box.set_border_width(style.DEFAULT_SPACING * 2)
         box.set_spacing(style.DEFAULT_SPACING)
 
@@ -81,7 +81,7 @@ class Frame(SectionView):
         self.setup()
 
     def _setup_corner(self):
-        box_delay = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        box_delay = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
         label_delay = Gtk.Label(label=_('Corner'))
         label_delay.set_alignment(1, 0.75)
         label_delay.modify_fg(Gtk.StateType.NORMAL,
@@ -100,7 +100,7 @@ class Frame(SectionView):
         return box_delay
 
     def _setup_edge(self):
-        box_delay = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        box_delay = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
         label_delay = Gtk.Label(label=_('Edge'))
         label_delay.set_alignment(1, 0.75)
         label_delay.modify_fg(Gtk.StateType.NORMAL,
@@ -119,7 +119,7 @@ class Frame(SectionView):
         return box_delay
 
     def _setup_trigger(self):
-        box_trigger = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        box_trigger = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
         label_trigger = Gtk.Label(label=_('Size'))
         label_trigger.set_alignment(1, 0.75)
         label_trigger.modify_fg(Gtk.StateType.NORMAL,

--- a/extensions/cpsection/keyboard/view.py
+++ b/extensions/cpsection/keyboard/view.py
@@ -63,7 +63,7 @@ def _build_ISO_639_dictionary():
         logging.error('%s not found' % (ISO_DATA_FILE))
 
 
-class LayoutCombo(Gtk.HBox):
+class LayoutCombo(Gtk.Box):
     """
     Custom GTK widget with two comboboxes side by side, one for layout, and
     the other for variants for the selected layout.
@@ -214,7 +214,7 @@ class Keyboard(SectionView):
         self.pack_start(scrollwindow, True, True, 0)
         scrollwindow.show()
 
-        self._vbox = Gtk.VBox()
+        self._vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         scrollwindow.add_with_viewport(self._vbox)
 
         self.__kmodel_sid = None
@@ -238,7 +238,7 @@ class Keyboard(SectionView):
         self._vbox.pack_start(label_kmodel, False, True, 0)
         label_kmodel.show_all()
 
-        box_kmodel = Gtk.VBox()
+        box_kmodel = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         box_kmodel.set_border_width(style.DEFAULT_SPACING * 2)
         box_kmodel.set_spacing(style.DEFAULT_SPACING)
 
@@ -299,7 +299,7 @@ class Keyboard(SectionView):
         self._vbox.pack_start(label_group_option, False, True, 0)
         label_group_option.show_all()
 
-        box_group_option = Gtk.VBox()
+        box_group_option = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         box_group_option.set_border_width(style.DEFAULT_SPACING * 2)
         box_group_option.set_spacing(style.DEFAULT_SPACING)
 

--- a/extensions/cpsection/language/view.py
+++ b/extensions/cpsection/language/view.py
@@ -98,7 +98,7 @@ class Language(SectionView):
         self._table.show()
         scrolled.add_with_viewport(self._table)
 
-        self._lang_alert_box = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        self._lang_alert_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
         self.pack_start(self._lang_alert_box, False, True, 0)
 
         self._lang_alert = InlineAlert()

--- a/extensions/cpsection/modemconfiguration/view.py
+++ b/extensions/cpsection/modemconfiguration/view.py
@@ -40,11 +40,11 @@ def _create_providers_list_store(items):
     return gtk_list
 
 
-class EntryWithLabel(Gtk.HBox):
+class EntryWithLabel(Gtk.Box):
     __gtype_name__ = 'SugarEntryWithLabel'
 
     def __init__(self, label_text):
-        Gtk.HBox.__init__(self, spacing=style.DEFAULT_SPACING)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
 
         self.label = Gtk.Label(label=label_text)
         self.label.modify_fg(Gtk.StateType.NORMAL,
@@ -85,7 +85,7 @@ class ModemConfiguration(SectionView):
         self.add(scrolled_win)
         scrolled_win.show()
 
-        main_box = Gtk.VBox(spacing=style.DEFAULT_SPACING)
+        main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=style.DEFAULT_SPACING)
         main_box.set_border_width(style.DEFAULT_SPACING)
         scrolled_win.add_with_viewport(main_box)
         main_box.show()
@@ -99,7 +99,7 @@ class ModemConfiguration(SectionView):
         main_box.pack_start(self._text, True, False, 0)
         self._text.show()
 
-        self._upper_box = Gtk.VBox(spacing=style.DEFAULT_SPACING)
+        self._upper_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=style.DEFAULT_SPACING)
         self._upper_box.set_border_width(style.DEFAULT_SPACING)
         main_box.pack_start(self._upper_box, True, False, 0)
         self._upper_box.show()
@@ -151,7 +151,7 @@ class ModemConfiguration(SectionView):
             self.provider_combo.connect("changed", self._provider_selected_cb)
             self.plan_combo.connect("changed", self._plan_selected_cb)
 
-        lower_box = Gtk.VBox(spacing=style.DEFAULT_SPACING)
+        lower_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=style.DEFAULT_SPACING)
         lower_box.set_border_width(style.DEFAULT_SPACING)
         main_box.pack_start(lower_box, True, False, 0)
         lower_box.show()
@@ -208,7 +208,7 @@ class ModemConfiguration(SectionView):
         combo.pack_start(renderer_text, True)
         combo.add_attribute(renderer_text, "text", 0)
 
-        box = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
         box.pack_start(label, False, True, 0)
         label.show()
         box.pack_start(combo, False, True, 0)

--- a/extensions/cpsection/network/view.py
+++ b/extensions/cpsection/network/view.py
@@ -123,14 +123,14 @@ class NumberEntry(Gtk.Entry):
         self.set_text(''.join([i for i in text if i in '0123456789']))
 
 
-class SettingBox(Gtk.HBox):
+class SettingBox(Gtk.Box):
     """
     Base class for "lines" on the screen representing configuration
     settings.
     """
 
     def __init__(self, name, size_group=None):
-        Gtk.HBox.__init__(self, spacing=style.DEFAULT_SPACING)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
         label = Gtk.Label(name)
         label.modify_fg(Gtk.StateType.NORMAL,
                         style.COLOR_SELECTION_GREY.get_gdk_color())
@@ -141,7 +141,7 @@ class SettingBox(Gtk.HBox):
         label.show()
 
 
-class ComboSettingBox(Gtk.VBox):
+class ComboSettingBox(Gtk.Box):
     """
     Container for sets of different settings selected by a top-level
     setting.
@@ -152,7 +152,7 @@ class ComboSettingBox(Gtk.VBox):
 
     def __init__(self, name, setting, setting_key,
                  option_sets, size_group=None):
-        Gtk.VBox.__init__(self, spacing=style.DEFAULT_SPACING)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=style.DEFAULT_SPACING)
 
         setting_box = SettingBox(name, size_group)
         self.pack_start(setting_box, False, False, 0)
@@ -171,7 +171,7 @@ class ComboSettingBox(Gtk.VBox):
         combo_box.add_attribute(cell_renderer, 'text', 0)
         combo_box.props.id_column = 1
 
-        self._settings_box = Gtk.VBox()
+        self._settings_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self._settings_box.show()
         self.pack_start(self._settings_box, False, False, 0)
 
@@ -192,7 +192,7 @@ class ComboSettingBox(Gtk.VBox):
         new_box.show()
 
 
-class OptionalSettingsBox(Gtk.VBox):
+class OptionalSettingsBox(Gtk.Box):
     """
     Container for settings (de)activated by a top-level setting.
 
@@ -201,7 +201,7 @@ class OptionalSettingsBox(Gtk.VBox):
     """
 
     def __init__(self, name, setting, setting_key, contents_box):
-        Gtk.VBox.__init__(self, spacing=style.DEFAULT_SPACING)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=style.DEFAULT_SPACING)
 
         check_button = Gtk.CheckButton()
         check_button.props.label = name
@@ -310,14 +310,14 @@ class Network(SectionView):
         self.set_spacing(style.DEFAULT_SPACING)
         group = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
 
-        self._radio_alert_box = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        self._radio_alert_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
 
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         self.add(scrolled)
         scrolled.show()
 
-        workspace = Gtk.VBox()
+        workspace = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         scrolled.add_with_viewport(workspace)
         workspace.show()
 
@@ -329,7 +329,7 @@ class Network(SectionView):
         label_wireless.set_alignment(0, 0)
         workspace.pack_start(label_wireless, False, True, 0)
         label_wireless.show()
-        box_wireless = Gtk.VBox()
+        box_wireless = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         box_wireless.set_border_width(style.DEFAULT_SPACING * 2)
         box_wireless.set_spacing(style.DEFAULT_SPACING)
 
@@ -340,7 +340,7 @@ class Network(SectionView):
         radio_info.show()
         box_wireless.pack_start(radio_info, False, True, 0)
 
-        box_radio = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        box_radio = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
         self._button = Gtk.CheckButton()
         self._button.set_alignment(0, 0)
         box_radio.pack_start(self._button, False, True, 0)
@@ -370,7 +370,7 @@ class Network(SectionView):
         wireless_info.show()
         box_wireless.pack_start(wireless_info, False, True, 0)
 
-        box_clear_wireless = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        box_clear_wireless = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
         self._clear_wireless_button = Gtk.Button()
         self._clear_wireless_button.set_label(
             _('Discard wireless connections'))
@@ -393,7 +393,7 @@ class Network(SectionView):
         label_mesh.set_alignment(0, 0)
         workspace.pack_start(label_mesh, False, True, 0)
         label_mesh.show()
-        box_mesh = Gtk.VBox()
+        box_mesh = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         box_mesh.set_border_width(style.DEFAULT_SPACING * 2)
         box_mesh.set_spacing(style.DEFAULT_SPACING)
 
@@ -406,7 +406,7 @@ class Network(SectionView):
         box_mesh.pack_start(server_info, False, True, 0)
         server_info.show()
 
-        box_server = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        box_server = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
         label_server = Gtk.Label(label=_('Server:'))
         label_server.set_alignment(1, 0.5)
         label_server.modify_fg(Gtk.StateType.NORMAL,
@@ -432,7 +432,7 @@ class Network(SectionView):
         box_mesh.pack_start(social_help_info, False, True, 0)
         social_help_info.show()
 
-        social_help_box = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        social_help_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
         social_help_label = Gtk.Label(label=_('Social Help Server:'))
         social_help_label.set_alignment(1, 0.5)
         social_help_label.modify_fg(Gtk.StateType.NORMAL,
@@ -467,7 +467,7 @@ class Network(SectionView):
         workspace.pack_start(label_proxy, False, True, 0)
         label_proxy.show()
 
-        box_proxy = Gtk.VBox()
+        box_proxy = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         box_proxy.set_border_width(style.DEFAULT_SPACING * 2)
         box_proxy.set_spacing(style.DEFAULT_SPACING)
         workspace.pack_start(box_proxy, False, True, 0)
@@ -502,11 +502,11 @@ class Network(SectionView):
 
         size_group = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
 
-        automatic_proxy_box = Gtk.VBox(spacing=style.DEFAULT_SPACING)
-        manual_proxy_box = Gtk.VBox(spacing=style.DEFAULT_SPACING)
+        automatic_proxy_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=style.DEFAULT_SPACING)
+        manual_proxy_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=style.DEFAULT_SPACING)
 
-        option_sets = [('None', 'none', Gtk.VBox()),
-                       ('Use system proxy', 'system', Gtk.VBox()),
+        option_sets = [('None', 'none', Gtk.Box(orientation=Gtk.Orientation.VERTICAL)),
+                       ('Use system proxy', 'system', Gtk.Box(orientation=Gtk.Orientation.VERTICAL)),
                        ('Manual', 'manual', manual_proxy_box),
                        ('Automatic', 'auto', automatic_proxy_box)]
 
@@ -542,7 +542,7 @@ class Network(SectionView):
             self._proxy_settings[schema], size_group)
         manual_proxy_box.pack_start(box_http, False, False, 0)
         box_http.show()
-        auth_contents_box = Gtk.VBox(spacing=style.DEFAULT_SPACING)
+        auth_contents_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=style.DEFAULT_SPACING)
         auth_box = OptionalSettingsBox(
             _('Use authentication'),
             self._proxy_settings[schema],

--- a/extensions/cpsection/power/view.py
+++ b/extensions/cpsection/power/view.py
@@ -36,7 +36,7 @@ class Power(SectionView):
         self.set_spacing(style.DEFAULT_SPACING)
         group = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
 
-        self._automatic_pm_alert_box = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        self._automatic_pm_alert_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
 
         separator_pm = Gtk.HSeparator()
         self.pack_start(separator_pm, False, True, 0)
@@ -46,11 +46,11 @@ class Power(SectionView):
         label_pm.set_alignment(0, 0)
         self.pack_start(label_pm, False, True, 0)
         label_pm.show()
-        box_pm = Gtk.VBox()
+        box_pm = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         box_pm.set_border_width(style.DEFAULT_SPACING * 2)
         box_pm.set_spacing(style.DEFAULT_SPACING)
 
-        box_automatic_pm = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        box_automatic_pm = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
         label_automatic_pm = Gtk.Label(
             label=_('Automatic power management (increases battery life)'))
         label_automatic_pm.set_alignment(0, 0.5)

--- a/extensions/cpsection/updater/view.py
+++ b/extensions/cpsection/updater/view.py
@@ -214,12 +214,12 @@ class ActivityUpdater(SectionView):
         self._model.cancel()
 
 
-class ProgressPane(Gtk.VBox):
+class ProgressPane(Gtk.Box):
     """Container which replaces the `ActivityPane` during refresh or
     install."""
 
     def __init__(self):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
         self.set_spacing(style.DEFAULT_PADDING)
         self.set_border_width(style.DEFAULT_SPACING * 2)
 
@@ -251,10 +251,10 @@ class ProgressPane(Gtk.VBox):
         self._progress.props.fraction = fraction
 
 
-class UpdateBox(Gtk.VBox):
+class UpdateBox(Gtk.Box):
 
     def __init__(self, updates):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
         self.set_spacing(style.DEFAULT_PADDING)
 
@@ -270,7 +270,7 @@ class UpdateBox(Gtk.VBox):
         scrolled_window.add(self._update_list)
         self._update_list.show()
 
-        bottom_box = Gtk.HBox()
+        bottom_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         bottom_box.set_spacing(style.DEFAULT_SPACING)
         self.pack_start(bottom_box, False, True, 0)
         bottom_box.show()

--- a/extensions/cpsection/webaccount/view.py
+++ b/extensions/cpsection/webaccount/view.py
@@ -84,7 +84,7 @@ class WebServicesConfig(SectionView):
         width = Gdk.Screen.width() - 2 * style.GRID_CELL_SIZE
         nx = int(width / (style.GRID_CELL_SIZE + style.DEFAULT_SPACING * 4))
 
-        self._service_config_box = Gtk.VBox()
+        self._service_config_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         x = 0
         y = 0
@@ -116,7 +116,7 @@ class WebServicesConfig(SectionView):
         alignment.add(grid)
         grid.show()
 
-        vbox = Gtk.VBox()
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         vbox.pack_start(alignment, False, False, 0)
         alignment.show()
 
@@ -127,7 +127,7 @@ class WebServicesConfig(SectionView):
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         scrolled.show()
 
-        workspace = Gtk.VBox()
+        workspace = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         scrolled.add_with_viewport(workspace)
         workspace.show()
 

--- a/extensions/deviceicon/audio.py
+++ b/extensions/deviceicon/audio.py
@@ -92,10 +92,10 @@ class DeviceView(TrayIcon):
         self._update_output_info()
 
 
-class AudioManagerWidget(Gtk.VBox):
+class AudioManagerWidget(Gtk.Box):
 
     def __init__(self, text, icon_name, device):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
         self._device = device
 
         self._ok_icon = Icon(icon_name='dialog-ok')

--- a/extensions/deviceicon/battery.py
+++ b/extensions/deviceicon/battery.py
@@ -130,7 +130,7 @@ class BatteryPalette(Palette):
         self.set_content(self._progress_widget)
         self._progress_widget.show()
 
-        inner_box = Gtk.VBox()
+        inner_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         inner_box.set_spacing(style.DEFAULT_PADDING)
         self._progress_widget.append_item(inner_box, vertical_padding=0)
         inner_box.show()

--- a/extensions/deviceicon/display.py
+++ b/extensions/deviceicon/display.py
@@ -78,12 +78,12 @@ class DeviceView(TrayIcon):
         self._update_output_info(value)
 
 
-class BrightnessManagerWidget(Gtk.VBox):
+class BrightnessManagerWidget(Gtk.Box):
 
     TIMEOUT_DELAY = 10
 
     def __init__(self, text, icon_name):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
         self._progress_bar = None
         self._adjustment = None
 

--- a/extensions/deviceicon/network.py
+++ b/extensions/deviceicon/network.py
@@ -93,7 +93,7 @@ class WirelessPalette(Palette):
         self._ip_address_label.props.xalign = 0.0
         self._ip_address_label.show()
 
-        self._info = Gtk.VBox()
+        self._info = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         self._disconnect_item = PaletteMenuItem(_('Disconnect'))
         icon = Icon(pixel_size=style.SMALL_ICON_SIZE,
@@ -178,7 +178,7 @@ class WiredPalette(Palette):
 
         self._ip_address_label = Gtk.Label()
 
-        self._info = Gtk.VBox()
+        self._info = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         def _padded(child, xalign=0, yalign=0.5):
             padder = Gtk.Alignment.new(xalign=xalign, yalign=yalign,
@@ -227,7 +227,7 @@ class GsmPalette(Palette):
         self._current_state = None
         self._failed_connection = False
 
-        self.info_box = Gtk.VBox()
+        self.info_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         self._toggle_state_item = PaletteMenuItem('')
         self._toggle_state_item.connect('activate', self.__toggle_state_cb)
@@ -243,7 +243,7 @@ class GsmPalette(Palette):
         self.error_description_label.set_line_wrap(True)
         self.info_box.pack_start(self.error_description_label, True, True, 0)
 
-        self.connection_info_box = Gtk.HBox()
+        self.connection_info_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         icon = Icon(icon_name='data-upload',
                     pixel_size=style.SMALL_ICON_SIZE)
         self.connection_info_box.pack_start(icon, True, True, 0)

--- a/extensions/deviceicon/touchpad.py
+++ b/extensions/deviceicon/touchpad.py
@@ -77,7 +77,7 @@ class ResourcePalette(Palette):
 
         self._icon = icon
 
-        vbox = Gtk.VBox()
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.set_content(vbox)
 
         self._status_text = Gtk.Label()

--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -62,8 +62,8 @@ class ControlPanel(Gtk.Window):
         self._section_toolbar = None
         self._main_toolbar = None
 
-        self._vbox = Gtk.VBox()
-        self._hbox = Gtk.HBox()
+        self._vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        self._hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         self._vbox.pack_start(self._hbox, True, True, 0)
         self._hbox.show()
 

--- a/src/jarabe/controlpanel/inlinealert.py
+++ b/src/jarabe/controlpanel/inlinealert.py
@@ -21,7 +21,7 @@ from sugar4.graphics import style
 from sugar4.graphics.icon import Icon
 
 
-class InlineAlert(Gtk.HBox):
+class InlineAlert(Gtk.Box):
     """UI interface for Inline alerts
 
     Inline alerts are different from the other alerts beause they are
@@ -55,7 +55,7 @@ class InlineAlert(Gtk.HBox):
         self._msg_label.modify_fg(Gtk.StateType.NORMAL,
                                   style.COLOR_SELECTION_GREY.get_gdk_color())
 
-        Gtk.HBox.__init__(self, **kwargs)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, **kwargs)
 
         self.set_spacing(style.DEFAULT_SPACING)
         self.modify_bg(Gtk.StateType.NORMAL,

--- a/src/jarabe/controlpanel/sectionview.py
+++ b/src/jarabe/controlpanel/sectionview.py
@@ -19,7 +19,7 @@ from gi.repository import Gtk
 from gettext import gettext as _
 
 
-class SectionView(Gtk.VBox):
+class SectionView(Gtk.Box):
     __gtype_name__ = 'SugarSectionView'
 
     __gsignals__ = {
@@ -40,7 +40,7 @@ class SectionView(Gtk.VBox):
     _APPLY_TIMEOUT = 1000
 
     def __init__(self):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
         self._is_valid = True
         self._is_cancellable = True
         self._is_deferrable = True

--- a/src/jarabe/desktop/keydialog.py
+++ b/src/jarabe/desktop/keydialog.py
@@ -242,7 +242,7 @@ class WPAKeyDialog(KeyDialog):
         self.combo.add_attribute(cell, 'text', 0)
         self.combo.set_active(0)
 
-        self.hbox = Gtk.HBox()
+        self.hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         self.hbox.pack_start(Gtk.Label(_('Wireless Security:')), True, True, 0)
         self.hbox.pack_start(self.combo, True, True, 0)
         self.hbox.show_all()

--- a/src/jarabe/frame/activitiestray.py
+++ b/src/jarabe/frame/activitiestray.py
@@ -728,7 +728,7 @@ class IncomingTransferPalette(BaseTransferPalette):
             box.append_item(separator)
             separator.show()
 
-            inner_box = Gtk.VBox()
+            inner_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
             inner_box.set_spacing(style.DEFAULT_PADDING)
             box.append_item(inner_box, vertical_padding=0)
             inner_box.show()
@@ -764,7 +764,7 @@ class IncomingTransferPalette(BaseTransferPalette):
             box.append_item(separator)
             separator.show()
 
-            inner_box = Gtk.VBox()
+            inner_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
             inner_box.set_spacing(style.DEFAULT_PADDING)
             box.append_item(inner_box, vertical_padding=0)
             inner_box.show()
@@ -803,7 +803,7 @@ class IncomingTransferPalette(BaseTransferPalette):
                 box.append_item(menu_item)
                 menu_item.show()
 
-                inner_box = Gtk.VBox()
+                inner_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
                 inner_box.set_spacing(style.DEFAULT_PADDING)
                 box.append_item(inner_box, vertical_padding=0)
                 inner_box.show()
@@ -886,7 +886,7 @@ class OutgoingTransferPalette(BaseTransferPalette):
             box.append_item(separator)
             separator.show()
 
-            inner_box = Gtk.VBox()
+            inner_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
             inner_box.set_spacing(style.DEFAULT_PADDING)
             box.append_item(inner_box, vertical_padding=0)
             inner_box.show()
@@ -919,7 +919,7 @@ class OutgoingTransferPalette(BaseTransferPalette):
             box.append_item(separator)
             separator.show()
 
-            inner_box = Gtk.VBox()
+            inner_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
             inner_box.set_spacing(style.DEFAULT_PADDING)
             box.append_item(inner_box, vertical_padding=0)
             inner_box.show()

--- a/src/jarabe/frame/framewindow.py
+++ b/src/jarabe/frame/framewindow.py
@@ -32,9 +32,9 @@ class FrameContainer(Gtk.Bin):
         self._position = position
 
         if self.is_vertical():
-            box = Gtk.VBox()
+            box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         else:
-            box = Gtk.HBox()
+            box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         self.add(box)
         box.show()
 

--- a/src/jarabe/frame/notification.py
+++ b/src/jarabe/frame/notification.py
@@ -37,17 +37,17 @@ from jarabe.view.pulsingicon import PulsingIcon
 from jarabe.frame.frameinvoker import FrameWidgetInvoker
 
 
-class NotificationBox(Gtk.VBox):
+class NotificationBox(Gtk.Box):
 
     LINES = 3
     MAX_ENTRIES = 3
     ELLIPSIS_AND_BREAKS = 6
 
     def __init__(self, name):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
         self._name = name
 
-        self._notifications_box = Gtk.VBox()
+        self._notifications_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self._notifications_box.show()
 
         self._scrolled_window = Gtk.ScrolledWindow()

--- a/src/jarabe/intro/window.py
+++ b/src/jarabe/intro/window.py
@@ -88,13 +88,13 @@ def create_profile(user_profile):
     logging.debug("User keypair generated")
 
 
-class _Page(Gtk.VBox):
+class _Page(Gtk.Box):
     __gproperties__ = {
         'valid': (bool, None, None, False, GObject.ParamFlags.READABLE),
     }
 
     def __init__(self):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
         self.valid = False
 
     def set_valid(self, valid):
@@ -249,7 +249,7 @@ class _AgePage(_Page):
         return self._ap.get_age()
 
 
-class _IntroBox(Gtk.VBox):
+class _IntroBox(Gtk.Box):
     done_signal = GObject.Signal('done', arg_types=([object]))
 
     PAGES = ["NAME", "COLOR", "GENDER", "AGE"]
@@ -258,7 +258,7 @@ class _IntroBox(Gtk.VBox):
     PAGE_LAST = len(PAGES) - 1
 
     def __init__(self, start_on_age_page):
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
         self.set_border_width(style.zoom(30))
 
         self._page = 0

--- a/src/jarabe/journal/detailview.py
+++ b/src/jarabe/journal/detailview.py
@@ -26,7 +26,7 @@ from jarabe.journal.expandedentry import ExpandedEntry
 from jarabe.journal import model
 
 
-class DetailView(Gtk.VBox):
+class DetailView(Gtk.Box):
     __gtype_name__ = 'DetailView'
 
     __gsignals__ = {
@@ -38,7 +38,7 @@ class DetailView(Gtk.VBox):
         self._metadata = None
         self._expanded_entry = None
 
-        Gtk.VBox.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
 
         back_bar = BackBar()
         back_bar.connect('button-release-event',
@@ -85,7 +85,7 @@ class BackBar(Gtk.EventBox):
         Gtk.EventBox.__init__(self)
         self.modify_bg(Gtk.StateType.NORMAL,
                        style.COLOR_PANEL_GREY.get_gdk_color())
-        hbox = Gtk.HBox(spacing=style.DEFAULT_PADDING)
+        hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_PADDING)
         hbox.set_border_width(style.DEFAULT_PADDING)
         icon = Icon(icon_name='go-previous', pixel_size=style.SMALL_ICON_SIZE,
                     fill_color=style.COLOR_TOOLBAR_GREY.get_svg())

--- a/src/jarabe/journal/expandedentry.py
+++ b/src/jarabe/journal/expandedentry.py
@@ -40,11 +40,11 @@ from jarabe.journal import model
 from jarabe.journal import journalwindow
 
 
-class Separator(Gtk.VBox):
+class Separator(Gtk.Box):
 
     def __init__(self, orientation):
-        Gtk.VBox.__init__(
-            self, background_color=style.COLOR_PANEL_GREY.get_gdk_color())
+        Gtk.Box.__init__(
+            self, orientation=Gtk.Orientation.VERTICAL, background_color=style.COLOR_PANEL_GREY.get_gdk_color())
 
 
 class BuddyList(Gtk.Alignment):
@@ -53,7 +53,7 @@ class BuddyList(Gtk.Alignment):
         Gtk.Alignment.__init__(self)
         self.set(0, 0, 0, 0)
 
-        hbox = Gtk.HBox()
+        hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         for buddy in buddies:
             nick_, color = buddy
             icon = CanvasIcon(icon_name='computer-xo',
@@ -219,7 +219,7 @@ class BaseExpandedEntry(GObject.GObject):
         self._keep_icon = self._create_keep_icon()
         header.pack_start(self._keep_icon, False, False, style.DEFAULT_SPACING)
 
-        self._icon_box = Gtk.HBox()
+        self._icon_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         header.pack_start(self._icon_box, False, False, style.DEFAULT_SPACING)
 
         self._title = self._create_title()
@@ -250,7 +250,7 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
         BaseExpandedEntry.__init__(self)
         self._journalactivity = journalactivity
         Gtk.EventBox.__init__(self)
-        self._vbox = Gtk.VBox()
+        self._vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.add(self._vbox)
 
         self.in_focus = False
@@ -281,13 +281,13 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
         body_box.modify_bg(Gtk.StateType.NORMAL,
                            style.COLOR_WHITE.get_gdk_color())
         self._vbox.pack_start(body_box, True, True, 0)
-        body = Gtk.HBox()
+        body = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         body_box.add(body)
 
-        first_column = Gtk.VBox()
+        first_column = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         body.pack_start(first_column, False, False, style.DEFAULT_SPACING)
 
-        second_column = Gtk.VBox()
+        second_column = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         body.pack_start(second_column, True, True, 0)
 
         # First body column
@@ -296,7 +296,7 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
         style_context.add_class('journal-preview-box')
         first_column.pack_start(self._preview_box, False, True, 0)
 
-        self._technical_box = Gtk.VBox()
+        self._technical_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         first_column.pack_start(self._technical_box, False, False, 0)
 
         # Second body column
@@ -312,7 +312,7 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
         second_column.pack_start(comments_box, True, True,
                                  style.DEFAULT_SPACING)
 
-        self._buddy_list = Gtk.VBox()
+        self._buddy_list = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         second_column.pack_start(self._buddy_list, True, False, 0)
         self.show_all()
 
@@ -400,7 +400,7 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
         return box
 
     def _create_technical(self):
-        vbox = Gtk.VBox()
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         vbox.props.spacing = style.DEFAULT_SPACING
 
         if 'filesize' in self._metadata:
@@ -415,7 +415,7 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
         ]
 
         for line in lines:
-            linebox = Gtk.HBox()
+            linebox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
             vbox.pack_start(linebox, False, False, 0)
 
             text = Gtk.Label()
@@ -439,7 +439,7 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
 
     def _create_buddy_list(self):
 
-        vbox = Gtk.VBox()
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         vbox.props.spacing = style.DEFAULT_SPACING
 
         text = Gtk.Label()
@@ -456,7 +456,7 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
         return vbox
 
     def _create_scrollable(self, widget, label=None):
-        vbox = Gtk.VBox()
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         vbox.props.spacing = style.DEFAULT_SPACING
 
         if label is not None:

--- a/src/jarabe/journal/iconview.py
+++ b/src/jarabe/journal/iconview.py
@@ -275,7 +275,7 @@ class IconView(Gtk.Bin):
         alignment = Gtk.Alignment.new(0.5, 0.5, 0.1, 0.1)
         background_box.add(alignment)
 
-        box = Gtk.VBox()
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         alignment.add(box)
 
         icon = Icon(pixel_size=style.LARGE_ICON_SIZE,

--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -284,7 +284,7 @@ class JournalActivity(JournalWindow):
     def _setup_main_view(self):
         self._main_toolbox = MainToolbox()
         self._edit_toolbox = EditToolbox(self)
-        self._main_view = Gtk.VBox()
+        self._main_view = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         self._add_new_box = AddNewBar(_('Add new project'))
         self._add_new_box.activate.connect(self.__add_project_activate_cb)
@@ -348,7 +348,7 @@ class JournalActivity(JournalWindow):
         self._project_view.show_all()
 
     def _setup_secondary_view(self):
-        self._secondary_view = Gtk.VBox()
+        self._secondary_view = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         self._detail_toolbox = DetailToolbox(self)
         self._detail_toolbox.connect('volume-error', self.volume_error_cb)

--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -588,7 +588,7 @@ class BaseListView(Gtk.Bin):
         alignment = Gtk.Alignment.new(0.5, 0.5, 0.1, 0.1)
         background_box.add(alignment)
 
-        box = Gtk.VBox()
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         alignment.add(box)
 
         icon = Icon(pixel_size=style.LARGE_ICON_SIZE,

--- a/src/jarabe/journal/modalalert.py
+++ b/src/jarabe/journal/modalalert.py
@@ -40,7 +40,7 @@ class ModalAlert(Gtk.Window):
         self.set_modal(True)
 
         self._main_view = Gtk.EventBox()
-        self._vbox = Gtk.VBox()
+        self._vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self._vbox.set_spacing(style.DEFAULT_SPACING)
         self._vbox.set_border_width(style.GRID_CELL_SIZE * 2)
         self._main_view.modify_bg(Gtk.StateType.NORMAL,

--- a/src/jarabe/journal/objectchooser.py
+++ b/src/jarabe/journal/objectchooser.py
@@ -68,7 +68,7 @@ class ObjectChooser(Gtk.Window):
             #screen = Wnck.Screen.get_default()
             #screen.connect('window-closed', self.__window_closed_cb, parent)
 
-        vbox = Gtk.VBox()
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.add(vbox)
         vbox.show()
 

--- a/src/jarabe/journal/projectview.py
+++ b/src/jarabe/journal/projectview.py
@@ -50,7 +50,7 @@ class ProjectView(Gtk.EventBox, BaseExpandedEntry):
         self._project = None
         self.modify_bg(Gtk.StateType.NORMAL, style.COLOR_WHITE.get_gdk_color())
 
-        self._vbox = Gtk.VBox()
+        self._vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.add(self._vbox)
 
         back_bar = BackBar()
@@ -131,7 +131,7 @@ class ProjectView(Gtk.EventBox, BaseExpandedEntry):
             model.write(self.project_metadata)
 
     def _create_scrollable(self, widget, label=None):
-        vbox = Gtk.VBox()
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         vbox.props.spacing = style.DEFAULT_SPACING
 
         if label is not None:

--- a/src/jarabe/view/buddymenu.py
+++ b/src/jarabe/view/buddymenu.py
@@ -47,7 +47,7 @@ class BuddyMenu(Palette):
                           pixel_size=style.STANDARD_ICON_SIZE)
         nick = buddy.get_nick()
         Palette.__init__(self, None, primary_text=nick, icon=buddy_icon)
-        self.menu_box = Gtk.VBox()
+        self.menu_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.set_content(self.menu_box)
         self.menu_box.show_all()
         self._invite_menu = None

--- a/src/jarabe/view/launcher.py
+++ b/src/jarabe/view/launcher.py
@@ -39,18 +39,18 @@ class LaunchWindow(Gtk.Window):
         self.props.type_hint = Gdk.WindowTypeHint.SPLASHSCREEN
         self.modify_bg(Gtk.StateType.NORMAL, style.COLOR_WHITE.get_gdk_color())
 
-        canvas = Gtk.VBox()
+        canvas = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         canvas.show()
         self.add(canvas)
 
         bar_size = Gdk.Screen.height() / 5 * 2
 
-        header = Gtk.VBox()
+        header = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         header.set_size_request(-1, bar_size)
         header.show()
         canvas.pack_start(header, False, True, 0)
 
-        box = Gtk.HBox()
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         box.set_size_request(Gdk.Screen.width() / 5, -1)
         box.show()
         canvas.pack_start(box, True, True, 0)
@@ -67,7 +67,7 @@ class LaunchWindow(Gtk.Window):
         self._activity_icon.show()
         box.pack_start(self._activity_icon, True, False, 0)
 
-        footer = Gtk.VBox(spacing=style.DEFAULT_SPACING)
+        footer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=style.DEFAULT_SPACING)
         footer.set_size_request(-1, bar_size)
         footer.show()
         canvas.pack_end(footer, False, True, 0)

--- a/src/jarabe/view/palettes.py
+++ b/src/jarabe/view/palettes.py
@@ -233,7 +233,7 @@ class JournalPalette(BasePalette):
         box.append_item(separator)
         separator.show()
 
-        inner_box = Gtk.VBox()
+        inner_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         inner_box.set_spacing(style.DEFAULT_PADDING)
         box.append_item(inner_box, vertical_padding=0)
         inner_box.show()
@@ -289,7 +289,7 @@ class VolumePalette(Palette):
         self.content_box.append_item(separator)
         separator.show()
 
-        free_space_box = Gtk.VBox()
+        free_space_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         free_space_box.set_spacing(style.DEFAULT_PADDING)
         self.content_box.append_item(free_space_box, vertical_padding=0)
         free_space_box.show()

--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -196,7 +196,7 @@ class ViewSource(Gtk.Window):
         self.connect('destroy', self.__destroy_cb, document_path)
         self.connect('key-press-event', self.__key_press_event_cb)
 
-        self._vbox = Gtk.VBox()
+        self._vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.add(self._vbox)
         self._vbox.show()
 

--- a/tests/views/webaccount.py
+++ b/tests/views/webaccount.py
@@ -32,7 +32,7 @@ config.ext_path = extension_dir
 sys.path.append(config.ext_path)
 
 window = Gtk.Window()
-box = Gtk.HBox()
+box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 box.show()
 window.add(box)
 


### PR DESCRIPTION
## Replace Deprecated GTK VBox/HBox Widgets

### Summary
Replaces all instances of deprecated `Gtk.VBox()` and `Gtk.HBox()` with 
the modern `Gtk.Box(orientation=Gtk.Orientation.VERTICAL/HORIZONTAL)` pattern 
for improved GTK compatibility.

### Changes
- Updated 38 files across extensions, controlpanel, journal, and view modules
- Converted `Gtk.VBox()` → `Gtk.Box(orientation=Gtk.Orientation.VERTICAL)`
- Converted `Gtk.HBox()` → `Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)`
- Preserved all existing parameters (spacing, border width, etc.)
