### PR TITLE
Fix KeyError in _remove_buddy by safely handling missing buddy keys

### DIFF
--- a/src/jarabe/desktop/meshbox.py
+++ b/src/jarabe/desktop/meshbox.py
@@ -429,12 +429,18 @@ class MeshBox(ViewContainer):
             icon.set_filter(self._query)
 
         self._buddies[buddy_model.props.key] = icon
+def _remove_buddy(self, buddy_model):
+    logging.debug('MeshBox._remove_buddy')
 
-    def _remove_buddy(self, buddy_model):
-        logging.debug('MeshBox._remove_buddy')
-        icon = self._buddies[buddy_model.props.key]
-        self.remove(icon)
-        del self._buddies[buddy_model.props.key]
+    key = buddy_model.props.key
+    icon = self._buddies.get(key)
+
+    if not icon:
+        logging.warning(f"Buddy key {key} not found during removal")
+        return
+
+    self.remove(icon)
+    del self._buddies[key]
 
     def __buddy_notify_current_activity_cb(self, buddy_model, pspec):
         logging.debug('MeshBox.__buddy_notify_current_activity_cb %s',

--- a/src/jarabe/desktop/meshbox.py
+++ b/src/jarabe/desktop/meshbox.py
@@ -442,14 +442,23 @@ def _remove_buddy(self, buddy_model):
     self.remove(icon)
     del self._buddies[key]
 
-    def __buddy_notify_current_activity_cb(self, buddy_model, pspec):
-        logging.debug('MeshBox.__buddy_notify_current_activity_cb %s',
-                      buddy_model.props.current_activity)
-        if buddy_model.props.current_activity is None:
-            if buddy_model.props.key not in self._buddies:
-                self._add_buddy(buddy_model)
-        elif buddy_model.props.key in self._buddies:
-            self._remove_buddy(buddy_model)
+def __buddy_notify_current_activity_cb(self, buddy_model, pspec):
+key = buddy_model.props.key
+activity = buddy_model.props.current_activity
+logging.debug(f"[STATE] key={key}, activity={activity}, exists={key in self._buddies}")
+
+if activity is None:
+    if key not in self._buddies:
+        logging.debug(f"Adding buddy {key}")
+        self._add_buddy(buddy_model)
+    else:
+        logging.debug(f"Buddy {key} already exists, skipping add")
+else:
+    if key in self._buddies:
+        logging.debug(f"Removing buddy {key}")
+        self._remove_buddy(buddy_model)
+    else:
+        logging.debug(f"Buddy {key} not found, skipping remove")
 
     def _add_activity(self, activity_model):
         icon = ActivityView(activity_model)

--- a/src/jarabe/desktop/meshbox.py
+++ b/src/jarabe/desktop/meshbox.py
@@ -429,36 +429,37 @@ class MeshBox(ViewContainer):
             icon.set_filter(self._query)
 
         self._buddies[buddy_model.props.key] = icon
-def _remove_buddy(self, buddy_model):
-    logging.debug('MeshBox._remove_buddy')
 
-    key = buddy_model.props.key
-    icon = self._buddies.get(key)
+    def _remove_buddy(self, buddy_model):
+        logging.debug('MeshBox._remove_buddy')
 
-    if not icon:
-        logging.warning(f"Buddy key {key} not found during removal")
-        return
+        key = buddy_model.props.key
+        icon = self._buddies.get(key)
 
-    self.remove(icon)
-    del self._buddies[key]
+        if not icon:
+            logging.warning(f"Buddy key {key} not found during removal")
+            return
 
-def __buddy_notify_current_activity_cb(self, buddy_model, pspec):
-key = buddy_model.props.key
-activity = buddy_model.props.current_activity
-logging.debug(f"[STATE] key={key}, activity={activity}, exists={key in self._buddies}")
+        self.remove(icon)
+        del self._buddies[key]
 
-if activity is None:
-    if key not in self._buddies:
-        logging.debug(f"Adding buddy {key}")
-        self._add_buddy(buddy_model)
-    else:
-        logging.debug(f"Buddy {key} already exists, skipping add")
-else:
-    if key in self._buddies:
-        logging.debug(f"Removing buddy {key}")
-        self._remove_buddy(buddy_model)
-    else:
-        logging.debug(f"Buddy {key} not found, skipping remove")
+    def __buddy_notify_current_activity_cb(self, buddy_model, pspec):
+        key = buddy_model.props.key
+        activity = buddy_model.props.current_activity
+        logging.debug(f"[STATE] key={key}, activity={activity}, exists={key in self._buddies}")
+
+        if activity is None:
+            if key not in self._buddies:
+                logging.debug(f"Adding buddy {key}")
+                self._add_buddy(buddy_model)
+            else:
+                logging.debug(f"Buddy {key} already exists, skipping add")
+        else:
+            if key in self._buddies:
+                logging.debug(f"Removing buddy {key}")
+                self._remove_buddy(buddy_model)
+            else:
+                logging.debug(f"Buddy {key} not found, skipping remove")
 
     def _add_activity(self, activity_model):
         icon = ActivityView(activity_model)


### PR DESCRIPTION
Fix KeyError in _remove_buddy in meshbox.py.

The crash occurs when buddy_model.props.key is not present in the _buddies dictionary. This PR adds a safe check and logging to handle the situation gracefully and prevent crashes during inconsistent Telepathy states.