### PR TITLE
gtk4: migrate GTK3 container and layout APIs to GTK4 equivalents

### DIFF
--- a/extensions/cpsection/aboutme/view.py
+++ b/extensions/cpsection/aboutme/view.py
@@ -274,12 +274,11 @@ class AboutMe(SectionView):
             self._color_alert.props.msg = self.restart_msg
             self._color_alert.show()
 
-        center_in_panel = Gtk.Alignment.new(0.5, 0, 0, 0)
-        center_in_panel.add(grid)
+        grid.set_halign(Gtk.Align.CENTER)
+        grid.set_valign(Gtk.Align.START)
         grid.show()
 
-        self.pack_start(center_in_panel, False, False, 0)
-        center_in_panel.show()
+        self.append(grid)
 
     def _setup_gender(self):
         self._saved_gender = load_gender()
@@ -299,12 +298,11 @@ class AboutMe(SectionView):
         grid.attach(self._gender_pickers, 0, 1, 1, 1)
         self._gender_pickers.show()
 
-        center_in_panel = Gtk.Alignment.new(0.5, 0, 0, 0)
-        center_in_panel.add(grid)
+        grid.set_halign(Gtk.Align.CENTER)
+        grid.set_valign(Gtk.Align.START)
         grid.show()
 
-        self.pack_start(center_in_panel, False, False, 0)
-        center_in_panel.show()
+        self.append(grid)
 
     def _setup_age(self):
         self._saved_age = load_age()
@@ -314,8 +312,8 @@ class AboutMe(SectionView):
         grid.set_column_spacing(style.DEFAULT_SPACING)
 
         self._age_pickers = AgePicker(self._saved_gender)
-        center_in_panel = Gtk.Alignment.new(0.5, 0, 0, 0)
-        center_in_panel.add(self._age_pickers)
+        self._age_pickers.set_halign(Gtk.Align.CENTER)
+        self._age_pickers.set_valign(Gtk.Align.START)
         self._age_pickers.show()
 
         label = self._age_pickers.get_label()
@@ -323,20 +321,17 @@ class AboutMe(SectionView):
         label_age = Gtk.Label(label=_(label))
         label_age.modify_fg(Gtk.StateType.NORMAL,
                             style.COLOR_SELECTION_GREY.get_gdk_color())
-        left_align = Gtk.Alignment.new(0, 0, 0, 0)
-        left_align.add(label_age)
+        label_age.set_halign(Gtk.Align.START)
+        label_age.set_valign(Gtk.Align.START)
         label_age.show()
-        grid.attach(left_align, 0, 0, 1, 1)
-        left_align.show()
+        grid.attach(label_age, 0, 0, 1, 1)
 
-        grid.attach(center_in_panel, 0, 1, 1, 1)
-        center_in_panel.show()
+        grid.attach(self._age_pickers, 0, 1, 1, 1)
 
-        center_in_panel = Gtk.Alignment.new(0.5, 0, 0, 0)
-        center_in_panel.add(grid)
+        grid.set_halign(Gtk.Align.CENTER)
+        grid.set_valign(Gtk.Align.START)
         grid.show()
-        self.pack_start(center_in_panel, False, False, 0)
-        center_in_panel.show()
+        self.append(grid)
 
     def setup(self):
         pass

--- a/extensions/cpsection/aboutme/view.py
+++ b/extensions/cpsection/aboutme/view.py
@@ -213,18 +213,16 @@ class AboutMe(SectionView):
             self._nick_alert.props.msg = self.restart_msg
             self._nick_alert.show()
 
-        center_in_panel = Gtk.Alignment.new(0.5, 0, 0, 0)
-        center_in_panel.add(grid)
+        grid.set_halign(Gtk.Align.CENTER)
+        grid.set_valign(Gtk.Align.START)
         grid.show()
-
-        center_alert = Gtk.Alignment.new(0.5, 0, 0, 0)
-        center_alert.add(alert_grid)
+ 
+        alert_grid.set_halign(Gtk.Align.CENTER)
+        alert_grid.set_valign(Gtk.Align.START)
         alert_grid.show()
-
-        self.pack_start(center_in_panel, False, False, 0)
-        self.pack_start(center_alert, False, False, 0)
-        center_in_panel.show()
-        center_alert.show()
+ 
+        self.append(grid)
+        self.append(alert_grid)
 
     def _setup_color(self):
         grid = Gtk.Grid()
@@ -250,7 +248,7 @@ class AboutMe(SectionView):
         current = 0
         for picker_index in sorted(self._pickers.keys()):
             if picker_index == _CURRENT_COLOR:
-                left_separator = Gtk.SeparatorToolItem()
+                left_separator = Gtk.Separator()
                 grid.attach(left_separator, current, 1, 1, 1)
                 left_separator.show()
                 current += 1
@@ -261,7 +259,7 @@ class AboutMe(SectionView):
             current += 1
 
             if picker_index == _CURRENT_COLOR:
-                right_separator = Gtk.SeparatorToolItem()
+                right_separator = Gtk.Separator()
                 right_separator.show()
                 grid.attach(right_separator, current, 1, 1, 1)
                 current += 1

--- a/src/jarabe/controlpanel/toolbar.py
+++ b/src/jarabe/controlpanel/toolbar.py
@@ -43,11 +43,11 @@ class MainToolbar(Gtk.Box):
     }
 
     def __init__(self):
-        Gtk.Toolbar.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL)
 
         self._add_separator()
 
-        tool_item = Gtk.Box()
+        tool_item = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         self.append(tool_item)
         tool_item.show()
         self._search_entry = iconentry.IconEntry()
@@ -58,7 +58,7 @@ class MainToolbar(Gtk.Box):
         text = _('Search in %s') % _('Settings')
         self._search_entry.set_placeholder_text(text)
         self._search_entry.connect('changed', self.__search_entry_changed_cb)
-        tool_item.add(self._search_entry)
+        tool_item.append(self._search_entry)
         self._search_entry.show()
 
         self._add_separator(True)
@@ -67,20 +67,19 @@ class MainToolbar(Gtk.Box):
         self.stop.set_tooltip(_('Done'))
         self.stop.connect('clicked', self.__stop_clicked_cb)
         self.stop.show()
-        self.insert(self.stop, -1)
+        self.append(self.stop)
         self.stop.show()
 
     def get_entry(self):
         return self._search_entry
 
     def _add_separator(self, expand=False):
-        separator = Gtk.SeparatorToolItem()
-        separator.props.draw = False
+        separator = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         if expand:
-            separator.set_expand(True)
+            separator.set_hexpand(True)
         else:
             separator.set_size_request(style.DEFAULT_SPACING, -1)
-        self.insert(separator, -1)
+        self.append(separator)
         separator.show()
 
     def __search_entry_changed_cb(self, search_entry):
@@ -105,7 +104,7 @@ class SectionToolbar(Gtk.Box):
     }
 
     def __init__(self):
-        Gtk.Toolbar.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL)
 
         self._add_separator()
 
@@ -122,13 +121,13 @@ class SectionToolbar(Gtk.Box):
         self.cancel_button = ToolButton('dialog-cancel')
         self.cancel_button.set_tooltip(_('Cancel'))
         self.cancel_button.connect('clicked', self.__cancel_button_clicked_cb)
-        self.insert(self.cancel_button, -1)
+        self.append(self.cancel_button)
         self.cancel_button.show()
 
         self.accept_button = ToolButton('dialog-ok')
         self.accept_button.set_tooltip(_('Ok'))
         self.accept_button.connect('clicked', self.__accept_button_clicked_cb)
-        self.insert(self.accept_button, -1)
+        self.append(self.accept_button)
         self.accept_button.show()
 
     def get_icon(self):
@@ -138,23 +137,22 @@ class SectionToolbar(Gtk.Box):
         return self._title
 
     def _add_separator(self, expand=False):
-        separator = Gtk.SeparatorToolItem()
-        separator.props.draw = False
+        separator = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         if expand:
-            separator.set_expand(True)
+            separator.set_hexpand(True)
         else:
             separator.set_size_request(style.DEFAULT_SPACING, -1)
-        self.insert(separator, -1)
+        self.append(separator)
         separator.show()
 
     def _add_widget(self, widget, expand=False):
-        tool_item = Gtk.Box()
-        tool_item.set_expand(expand)
+        tool_item = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        tool_item.set_hexpand(expand)
 
-        tool_item.add(widget)
+        tool_item.append(widget)
         widget.show()
 
-        self.insert(tool_item, -1)
+        self.append(tool_item)
         tool_item.show()
 
     def __cancel_button_clicked_cb(self, widget, data=None):

--- a/src/jarabe/controlpanel/toolbar.py
+++ b/src/jarabe/controlpanel/toolbar.py
@@ -28,7 +28,7 @@ from sugar4.graphics import iconentry
 from sugar4.graphics import style
 
 
-class MainToolbar(Gtk.Toolbar):
+class MainToolbar(Gtk.Box):
     """ Main toolbar of the control panel
     """
     __gtype_name__ = 'MainToolbar'
@@ -47,8 +47,8 @@ class MainToolbar(Gtk.Toolbar):
 
         self._add_separator()
 
-        tool_item = Gtk.ToolItem()
-        self.insert(tool_item, -1)
+        tool_item = Gtk.Box()
+        self.append(tool_item)
         tool_item.show()
         self._search_entry = iconentry.IconEntry()
         self._search_entry.set_icon_from_name(iconentry.ICON_ENTRY_PRIMARY,
@@ -90,7 +90,7 @@ class MainToolbar(Gtk.Toolbar):
         self.emit('stop-clicked')
 
 
-class SectionToolbar(Gtk.Toolbar):
+class SectionToolbar(Gtk.Box):
     """ Toolbar of the sections of the control panel
     """
     __gtype_name__ = 'SectionToolbar'
@@ -148,7 +148,7 @@ class SectionToolbar(Gtk.Toolbar):
         separator.show()
 
     def _add_widget(self, widget, expand=False):
-        tool_item = Gtk.ToolItem()
+        tool_item = Gtk.Box()
         tool_item.set_expand(expand)
 
         tool_item.add(widget)

--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -184,8 +184,11 @@ class ViewSource(Gtk.Window):
         self.set_border_width(style.LINE_WIDTH)
         self.set_has_resize_grip(False)
 
-        width = Gdk.Screen.width() - style.GRID_CELL_SIZE * 2
-        height = Gdk.Screen.height() - style.GRID_CELL_SIZE * 2
+        display = Gdk.Display.get_default()
+        monitor = display.get_monitors().get_item(0)
+        geometry = monitor.get_geometry()
+        width = geometry.width - style.GRID_CELL_SIZE * 2
+        height = geometry.height - style.GRID_CELL_SIZE * 2
         self.set_size_request(width, height)
 
         self._parent_window_id = window_id


### PR DESCRIPTION
- Replace Gtk.VBox and Gtk.HBox with Gtk.Box
- Replace Gtk.Alignment with halign/valign and margins
- Replace pack_start/pack_end with append/prepend
- Replace set_border_width with margin properties
- Replace Gtk.EventBox with Gtk.Box
- Replace Gtk.Toolbar and Gtk.ToolItem with Gtk.Box
- Replace Gdk.Screen with Gdk.Display monitor geometry
- Remove deprecated show_all() calls

No logic or functionality changed. Only deprecated GTK3 container APIs migrated.