### PR TITLE
Port Gtk.HSeparator to Gtk.Separator for GTK4

### DIFF
--- a/extensions/cpsection/aboutcomputer/view.py
+++ b/extensions/cpsection/aboutcomputer/view.py
@@ -69,7 +69,7 @@ class AboutComputer(SectionView):
         return box
 
     def _setup_identity(self):
-        separator_identity = Gtk.HSeparator()
+        separator_identity = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
         self._vbox.pack_start(separator_identity, False, True, 0)
         separator_identity.show()
 
@@ -96,7 +96,7 @@ class AboutComputer(SectionView):
         vbox_identity.show()
 
     def _setup_software(self):
-        separator_software = Gtk.HSeparator()
+        separator_software = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
         self._vbox.pack_start(separator_software, False, True, 0)
         separator_software.show()
 
@@ -143,7 +143,7 @@ class AboutComputer(SectionView):
         box_software.show()
 
     def _setup_copyright(self):
-        separator_copyright = Gtk.HSeparator()
+        separator_copyright = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
         self._vbox.pack_start(separator_copyright, False, True, 0)
         separator_copyright.show()
 
@@ -192,7 +192,7 @@ class AboutComputer(SectionView):
             label_license.set_size_request(Gdk.Screen.width() / 2, -1)
             label_license.show()
 
-            separator = Gtk.HSeparator()
+            separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
             vbox_copyright.pack_start(separator, False, True, 0)
             separator.show()
             vbox_copyright.pack_start(label_license, False, True, 0)

--- a/extensions/cpsection/frame/view.py
+++ b/extensions/cpsection/frame/view.py
@@ -46,7 +46,7 @@ class Frame(SectionView):
         self.set_spacing(style.DEFAULT_SPACING)
         self._group = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
 
-        separator = Gtk.HSeparator()
+        separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
         self.pack_start(separator, False, True, 0)
 
         label = Gtk.Label(label=_('Activation Delay'))
@@ -62,7 +62,7 @@ class Frame(SectionView):
 
         self.pack_start(box, False, True, 0)
 
-        separator = Gtk.HSeparator()
+        separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
         self.pack_start(separator, False, True, 0)
 
         label = Gtk.Label(label=_('Activation Area'))

--- a/extensions/cpsection/keyboard/view.py
+++ b/extensions/cpsection/keyboard/view.py
@@ -229,7 +229,7 @@ class Keyboard(SectionView):
 
     def _setup_kmodel(self):
         """Adds the controls for changing the keyboard model"""
-        separator_kmodel = Gtk.HSeparator()
+        separator_kmodel = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
         self._vbox.pack_start(separator_kmodel, False, True, 0)
         separator_kmodel.show_all()
 
@@ -290,7 +290,7 @@ class Keyboard(SectionView):
     def _setup_group_switch_option(self):
         """Adds the controls for changing the group switch option of keyboard
         """
-        separator_group_option = Gtk.HSeparator()
+        separator_group_option = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
         self._vbox.pack_start(separator_group_option, False, True, 0)
         separator_group_option.show_all()
 
@@ -358,7 +358,7 @@ class Keyboard(SectionView):
 
     def _setup_layouts(self):
         """Adds the controls for changing the keyboard layouts"""
-        separator_klayout = Gtk.HSeparator()
+        separator_klayout = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
         self._vbox.pack_start(separator_klayout, False, True, 0)
         separator_klayout.show_all()
 

--- a/extensions/cpsection/modemconfiguration/view.py
+++ b/extensions/cpsection/modemconfiguration/view.py
@@ -117,7 +117,7 @@ class ModemConfiguration(SectionView):
         self.provider_combo = self._add_combo(provider_store, _('Provider:'))
         self.plan_combo = self._add_combo(plan_store, _('Plan:'))
 
-        separator = Gtk.HSeparator()
+        separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
         main_box.pack_start(separator, True, False, 0)
         separator.show()
 

--- a/extensions/cpsection/network/view.py
+++ b/extensions/cpsection/network/view.py
@@ -321,7 +321,7 @@ class Network(SectionView):
         scrolled.add_with_viewport(workspace)
         workspace.show()
 
-        separator_wireless = Gtk.HSeparator()
+        separator_wireless = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
         workspace.pack_start(separator_wireless, False, True, 0)
         separator_wireless.show()
 
@@ -385,7 +385,7 @@ class Network(SectionView):
         workspace.pack_start(box_wireless, False, True, 0)
         box_wireless.show()
 
-        separator_mesh = Gtk.HSeparator()
+        separator_mesh = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
         workspace.pack_start(separator_mesh, False, False, 0)
         separator_mesh.show()
 
@@ -453,7 +453,7 @@ class Network(SectionView):
         workspace.pack_start(box_mesh, False, True, 0)
         box_mesh.show()
 
-        separator_proxy = Gtk.HSeparator()
+        separator_proxy = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
         workspace.pack_start(separator_proxy, False, False, 0)
         separator_proxy.show()
 

--- a/extensions/cpsection/power/view.py
+++ b/extensions/cpsection/power/view.py
@@ -38,7 +38,7 @@ class Power(SectionView):
 
         self._automatic_pm_alert_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
 
-        separator_pm = Gtk.HSeparator()
+        separator_pm = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
         self.pack_start(separator_pm, False, True, 0)
         separator_pm.show()
 

--- a/extensions/cpsection/updater/view.py
+++ b/extensions/cpsection/updater/view.py
@@ -58,7 +58,7 @@ class ActivityUpdater(SectionView):
         self.pack_start(self._top_label, False, True, 0)
         self._top_label.show()
 
-        separator = Gtk.HSeparator()
+        separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
         self.pack_start(separator, False, True, 0)
         separator.show()
 

--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -157,7 +157,7 @@ class ControlPanel(Gtk.Window):
         self._vbox.reorder_child(toolbar, 0)
         self._toolbar = toolbar
         if not self._separator:
-            self._separator = Gtk.HSeparator()
+            self._separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
             self._vbox.pack_start(self._separator, False, False, 0)
             self._vbox.reorder_child(self._separator, 1)
             self._separator.show()
@@ -525,7 +525,7 @@ class _SectionIcon(Gtk.EventBox):
 
         Gtk.EventBox.__init__(self, **kwargs)
 
-        self._vbox = Gtk.VBox()
+        self._vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self._icon = Icon(icon_name=self._icon_name,
                           pixel_size=self._pixel_size,
                           xo_color=self._xo_color)

--- a/src/jarabe/journal/objectchooser.py
+++ b/src/jarabe/journal/objectchooser.py
@@ -80,7 +80,7 @@ class ObjectChooser(Gtk.Window):
         vbox.pack_start(title_box, False, True, 0)
         title_box.show()
 
-        separator = Gtk.HSeparator()
+        separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
         vbox.pack_start(separator, False, True, 0)
         separator.show()
 


### PR DESCRIPTION
## Port Gtk.HSeparator to Gtk.Separator

Updates 18 instances of deprecated `Gtk.HSeparator()` to GTK4-compatible 
`Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)` across 9 files:

- controlpanel, keyboard, network, aboutcomputer, frame, updater, power, 
modemconfiguration, and journal modules