### PR TITLE
Enhancement: Add type hints to journal model datastore functions

### DIFF
--- a/src/jarabe/journal/model.py
+++ b/src/jarabe/journal/model.py
@@ -715,7 +715,7 @@ def copy(metadata, mount_point, ready_callback=None):
           ready_callback=ready_callback)
 
 
-def write(metadata, file_path='', update_mtime=True, transfer_ownership=True,
+def write(metadata:dict, file_path: str='', update_mtime: bool=True, transfer_ownership: bool=True,
           ready_callback=None):
     """Creates or updates an entry for that id
     """


### PR DESCRIPTION
Fixes #1095

Adds PEP 484 type hints to the core write function in src/jarabe/journal/model.py. This explicitly defines the metadata parameter as a dict (along with boolean/string flags), laying the groundwork for strict type safety and data validation required for upcoming backend API middleware integrations.