### PR TITLE
Replace Gtk.Box and Gtk.EventBox direct __init__() calls with super()

### DIFF
--- a/extensions/cpsection/backup/view.py
+++ b/extensions/cpsection/backup/view.py
@@ -75,7 +75,7 @@ class _BackupButton(Gtk.EventBox):
         self._xo_color = None
         self._title = 'No Title'
 
-        Gtk.EventBox.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         self._vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self._icon = Icon(icon_name=self._icon_name,
@@ -122,7 +122,7 @@ class _BackupButton(Gtk.EventBox):
 class SelectBackupRestorePanel(Gtk.Box):
 
     def __init__(self, view):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
 
         self._view = view
         hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)

--- a/extensions/cpsection/modemconfiguration/view.py
+++ b/extensions/cpsection/modemconfiguration/view.py
@@ -44,7 +44,7 @@ class EntryWithLabel(Gtk.Box):
     __gtype_name__ = 'SugarEntryWithLabel'
 
     def __init__(self, label_text):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
+        super().__init__(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
 
         self.label = Gtk.Label(label=label_text)
         self.label.modify_fg(Gtk.StateType.NORMAL,

--- a/extensions/cpsection/network/view.py
+++ b/extensions/cpsection/network/view.py
@@ -130,7 +130,7 @@ class SettingBox(Gtk.Box):
     """
 
     def __init__(self, name, size_group=None):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
+        super().__init__(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_SPACING)
         label = Gtk.Label(name)
         label.modify_fg(Gtk.StateType.NORMAL,
                         style.COLOR_SELECTION_GREY.get_gdk_color())
@@ -152,7 +152,7 @@ class ComboSettingBox(Gtk.Box):
 
     def __init__(self, name, setting, setting_key,
                  option_sets, size_group=None):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=style.DEFAULT_SPACING)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=style.DEFAULT_SPACING)
 
         setting_box = SettingBox(name, size_group)
         self.pack_start(setting_box, False, False, 0)
@@ -201,7 +201,7 @@ class OptionalSettingsBox(Gtk.Box):
     """
 
     def __init__(self, name, setting, setting_key, contents_box):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=style.DEFAULT_SPACING)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=style.DEFAULT_SPACING)
 
         check_button = Gtk.CheckButton()
         check_button.props.label = name

--- a/extensions/cpsection/updater/view.py
+++ b/extensions/cpsection/updater/view.py
@@ -219,7 +219,7 @@ class ProgressPane(Gtk.Box):
     install."""
 
     def __init__(self):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self.set_spacing(style.DEFAULT_PADDING)
         self.set_border_width(style.DEFAULT_SPACING * 2)
 
@@ -254,7 +254,7 @@ class ProgressPane(Gtk.Box):
 class UpdateBox(Gtk.Box):
 
     def __init__(self, updates):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
 
         self.set_spacing(style.DEFAULT_PADDING)
 

--- a/extensions/deviceicon/audio.py
+++ b/extensions/deviceicon/audio.py
@@ -95,7 +95,7 @@ class DeviceView(TrayIcon):
 class AudioManagerWidget(Gtk.Box):
 
     def __init__(self, text, icon_name, device):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self._device = device
 
         self._ok_icon = Icon(icon_name='dialog-ok')

--- a/extensions/deviceicon/display.py
+++ b/extensions/deviceicon/display.py
@@ -83,7 +83,7 @@ class BrightnessManagerWidget(Gtk.Box):
     TIMEOUT_DELAY = 10
 
     def __init__(self, text, icon_name):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self._progress_bar = None
         self._adjustment = None
 

--- a/src/jarabe/controlpanel/gui.py
+++ b/src/jarabe/controlpanel/gui.py
@@ -523,7 +523,7 @@ class _SectionIcon(Gtk.EventBox):
         self._xo_color = None
         self._title = 'No Title'
 
-        Gtk.EventBox.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         self._vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self._icon = Icon(icon_name=self._icon_name,

--- a/src/jarabe/controlpanel/inlinealert.py
+++ b/src/jarabe/controlpanel/inlinealert.py
@@ -55,7 +55,7 @@ class InlineAlert(Gtk.Box):
         self._msg_label.modify_fg(Gtk.StateType.NORMAL,
                                   style.COLOR_SELECTION_GREY.get_gdk_color())
 
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, **kwargs)
+        super().__init__(orientation=Gtk.Orientation.HORIZONTAL, **kwargs)
 
         self.set_spacing(style.DEFAULT_SPACING)
         self.modify_bg(Gtk.StateType.NORMAL,

--- a/src/jarabe/controlpanel/sectionview.py
+++ b/src/jarabe/controlpanel/sectionview.py
@@ -40,7 +40,7 @@ class SectionView(Gtk.Box):
     _APPLY_TIMEOUT = 1000
 
     def __init__(self):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self._is_valid = True
         self._is_cancellable = True
         self._is_deferrable = True

--- a/src/jarabe/desktop/activitieslist.py
+++ b/src/jarabe/desktop/activitieslist.py
@@ -467,7 +467,7 @@ class CellRendererActivityIcon(CellRendererIcon):
 class ClearMessageBox(Gtk.EventBox):
 
     def __init__(self, message, button_callback):
-        Gtk.EventBox.__init__(self)
+        super().__init__()
 
         self.modify_bg(Gtk.StateType.NORMAL,
                        style.COLOR_WHITE.get_gdk_color())
@@ -517,7 +517,7 @@ class ActivitiesList(Gtk.Box):
     def __init__(self):
         logging.debug('STARTUP: Loading the activities list')
 
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
 
         self._scrolled_window = Gtk.ScrolledWindow()
         self._scrolled_window.set_can_focus(False)

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -77,7 +77,7 @@ class FavoritesBox(Gtk.Box):
     __gtype_name__ = 'SugarFavoritesBox'
 
     def __init__(self, favorite_view):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
 
         self.favorite_view = favorite_view
         self._view = FavoritesView(self)

--- a/src/jarabe/desktop/friendview.py
+++ b/src/jarabe/desktop/friendview.py
@@ -26,7 +26,7 @@ from jarabe.model import bundleregistry
 class FriendView(Gtk.Box):
 
     def __init__(self, buddy, **kwargs):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
 
         # round icon sizes to an even number so that it can be accurately
         # centered in a larger bounding box also of even dimensions

--- a/src/jarabe/desktop/homebackgroundbox.py
+++ b/src/jarabe/desktop/homebackgroundbox.py
@@ -56,7 +56,7 @@ def get_background_alpha_level():
 class HomeBackgroundBox(Gtk.Box):
 
     def __init__(self):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self._background_pixbuf = None
         self._update_background_image()
         self.connect('draw', self.__draw_cb)

--- a/src/jarabe/desktop/homebox.py
+++ b/src/jarabe/desktop/homebox.py
@@ -31,7 +31,7 @@ class HomeBox(Gtk.Box):
     def __init__(self, toolbar):
         logging.debug('STARTUP: Loading the home view')
 
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
 
         self._favorites_views_indicies = []
         for i in range(desktop.get_number_of_views()):

--- a/src/jarabe/frame/notification.py
+++ b/src/jarabe/frame/notification.py
@@ -44,7 +44,7 @@ class NotificationBox(Gtk.Box):
     ELLIPSIS_AND_BREAKS = 6
 
     def __init__(self, name):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self._name = name
 
         self._notifications_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
@@ -252,7 +252,7 @@ class NotificationIcon(Gtk.EventBox):
         self._icon = NotificationPulsingIcon()
         self._icon.props.pixel_size = style.STANDARD_ICON_SIZE
 
-        Gtk.EventBox.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.props.visible_window = False
 
         self._icon.props.pulse_color = \

--- a/src/jarabe/intro/colorpicker.py
+++ b/src/jarabe/intro/colorpicker.py
@@ -24,7 +24,7 @@ from sugar4.graphics.xocolor import XoColor
 class ColorPicker(Gtk.EventBox):
 
     def __init__(self):
-        Gtk.EventBox.__init__(self)
+        super().__init__()
         self._xo_color = None
 
         self._xo = Icon(pixel_size=style.XLARGE_ICON_SIZE,

--- a/src/jarabe/intro/window.py
+++ b/src/jarabe/intro/window.py
@@ -94,7 +94,7 @@ class _Page(Gtk.Box):
     }
 
     def __init__(self):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self.valid = False
 
     def set_valid(self, valid):
@@ -258,7 +258,7 @@ class _IntroBox(Gtk.Box):
     PAGE_LAST = len(PAGES) - 1
 
     def __init__(self, start_on_age_page):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self.set_border_width(style.zoom(30))
 
         self._page = 0

--- a/src/jarabe/journal/detailview.py
+++ b/src/jarabe/journal/detailview.py
@@ -38,7 +38,7 @@ class DetailView(Gtk.Box):
         self._metadata = None
         self._expanded_entry = None
 
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
 
         back_bar = BackBar()
         back_bar.connect('button-release-event',
@@ -82,7 +82,7 @@ class DetailView(Gtk.Box):
 class BackBar(Gtk.EventBox):
 
     def __init__(self):
-        Gtk.EventBox.__init__(self)
+        super().__init__()
         self.modify_bg(Gtk.StateType.NORMAL,
                        style.COLOR_PANEL_GREY.get_gdk_color())
         hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=style.DEFAULT_PADDING)

--- a/src/jarabe/journal/expandedentry.py
+++ b/src/jarabe/journal/expandedentry.py
@@ -43,8 +43,8 @@ from jarabe.journal import journalwindow
 class Separator(Gtk.Box):
 
     def __init__(self, orientation):
-        Gtk.Box.__init__(
-            self, orientation=Gtk.Orientation.VERTICAL, background_color=style.COLOR_PANEL_GREY.get_gdk_color())
+        super().__init__(
+            orientation=Gtk.Orientation.VERTICAL, background_color=style.COLOR_PANEL_GREY.get_gdk_color())
 
 
 class BuddyList(Gtk.Alignment):
@@ -249,7 +249,7 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
     def __init__(self, journalactivity):
         BaseExpandedEntry.__init__(self)
         self._journalactivity = journalactivity
-        Gtk.EventBox.__init__(self)
+        super().__init__()
         self._vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.add(self._vbox)
 

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -885,7 +885,7 @@ class BatchCopyButton(ToolButton):
 class MultiSelectEntriesInfoWidget(Gtk.Box):
 
     def __init__(self):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
 
         self._selected_entries = 0
         self._total = 0
@@ -918,7 +918,7 @@ class FilterToolItem(Gtk.Box):
 
     def __init__(self, default_icon, default_label, palette_content=None):
         self._palette_invoker = ToolInvoker()
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self._label = default_label
 
         self.set_size_request(style.GRID_CELL_SIZE, -1)
@@ -1090,7 +1090,7 @@ class AddNewBar(Gtk.Box):
     activate = GObject.Signal('activate', arg_types=[str])
 
     def __init__(self, placeholder=None):
-        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL)
+        super().__init__(orientation=Gtk.Orientation.HORIZONTAL)
 
         self._button = EventIcon(icon_name='list-add')
         self._button.connect('button-release-event',

--- a/src/jarabe/journal/projectview.py
+++ b/src/jarabe/journal/projectview.py
@@ -42,7 +42,7 @@ class ProjectView(Gtk.EventBox, BaseExpandedEntry):
     }
 
     def __init__(self, **kwargs):
-        Gtk.EventBox.__init__(self)
+        super().__init__(**kwargs)
         BaseExpandedEntry.__init__(self)
         self.project_metadata = None
         self._service = None

--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -824,4 +824,4 @@ class ImageBox(Gtk.EventBox):
     __gtype_name__ = 'SugarViewSourceImageBox'
 
     def __init__(self):
-        Gtk.EventBox.__init__(self)
+        super().__init__()


### PR DESCRIPTION
## Replace Gtk.Box/EventBox __init__() calls with super()

Replace direct parent class `__init__()` calls with `super().__init__()` 
for Gtk.Box and Gtk.EventBox . Pure code style refactor.

**Example:**
```python
# Before
Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
Gtk.EventBox.__init__(self)

# After
super().__init__(orientation=Gtk.Orientation.VERTICAL)
super().__init__()