### PR TITLE
fix(journal): replace bare except with OSError in delete logic

### DIFF
--- a/src/jarabe/journal/model.py
+++ b/src/jarabe/journal/model.py
@@ -691,7 +691,7 @@ def delete(object_id):
                                   'for file=%s', old_file, filename)
         try:
             os.rmdir(metadata_path)
-        except:
+        except OSError:
             # if can't remove is because there are other metadata
             pass
         deleted.send(None, object_id=object_id)


### PR DESCRIPTION
### PR Category
- [x] Bug fix
- [ ] Feature
- [ ] Performance
- [ ] Tests
- [ ] Documentation

### Summary
Replaces a bare `except:` block in `model.py` with a scoped `except OSError:`.

### Why
Bare `except:` clauses catch all exceptions, including system-level interrupts. Since `os.rmdir()` raises `OSError` for expected filesystem cases (e.g., directory not empty), this can be scoped more safely.

### What changed
- Updated exception handling in `delete()` to catch `OSError` instead of all exceptions

### Notes
- No change in intended behavior
- Improves error handling clarity

Fixes #1097 