### PR TITLE
docs(journal): add docstrings to bundle evaluation helpers in misc.py

### DIFF
--- a/src/jarabe/journal/misc.py
+++ b/src/jarabe/journal/misc.py
@@ -332,19 +332,23 @@ def _downgrade_alert_response_cb(alert, response_id, metadata):
 
 
 def is_activity_bundle(metadata):
+    """Return True if metadata represents an activity bundle."""
     mime_type = metadata.get('mime_type', '')
     return mime_type == ActivityBundle.MIME_TYPE
 
 
 def is_content_bundle(metadata):
+    """Return True if metadata represents a content bundle."""
     return metadata.get('mime_type', '') == ContentBundle.MIME_TYPE
 
 
 def is_journal_bundle(metadata):
+    """Return True if metadata represents a journal entry bundle."""
     return metadata.get('mime_type', '') == JournalEntryBundle.MIME_TYPE
 
 
 def is_bundle(metadata):
+    """Return True if metadata represents any supported bundle type."""
     return is_activity_bundle(metadata) or is_content_bundle(metadata) or \
         is_journal_bundle(metadata)
 


### PR DESCRIPTION
### Summary
Adds missing docstrings to the bundle evaluation helper functions in `misc.py`.

### Why
Functions like `is_activity_bundle`, `is_content_bundle`, `is_journal_bundle`, and `is_bundle` are frequently used throughout the Journal logic to identify bundle types, but they lacked docstrings. Adding them improves readability for developers navigating the metadata handling logic.

### What changed
- Added descriptive, one-line docstrings to 4 bundle helper functions.

### Impact
- Zero logic changes.
- Improves codebase documentation and maintainability.