### PR TITLE
Harden proxy ping to avoid shell injection

### DIFF
--- a/extensions/cpsection/network/view.py
+++ b/extensions/cpsection/network/view.py
@@ -639,7 +639,7 @@ class Network(SectionView):
                 if (schema != 'org.sugarlabs.system.proxy'):
                     hostname = Gio.Settings.get_string(
                         self._proxy_settings[schema], 'host')
-                    if hostname:
+                    if hostname: 
                         non_blank_host_name_counter += 1
                         try:
                             response = subprocess.run(

--- a/extensions/cpsection/network/view.py
+++ b/extensions/cpsection/network/view.py
@@ -642,14 +642,13 @@ class Network(SectionView):
                     if hostname: 
                         non_blank_host_name_counter += 1
                         try:
-                            response = subprocess.run(
+                            subprocess.run(
                                 ['ping', '-c', '1', '-W', '1', '--', hostname],
                                 stdout=subprocess.DEVNULL,
-                                stderr=subprocess.DEVNULL
-                            ).returncode
+                                stderr=subprocess.DEVNULL,
+                                check=True
+                            )
                         except (OSError, subprocess.SubprocessError):
-                            response = 1
-                        if (response):
                             self._proxy_inline_alerts[schema].show()
                             response_to_return = False
         if non_blank_host_name_counter == 0:

--- a/extensions/cpsection/network/view.py
+++ b/extensions/cpsection/network/view.py
@@ -648,7 +648,7 @@ class Network(SectionView):
                                 stderr=subprocess.DEVNULL
                             ).returncode
                         except (OSError, subprocess.SubprocessError):
-                            response=1
+                            response = 1
                         if (response):
                             self._proxy_inline_alerts[schema].show()
                             response_to_return = False

--- a/extensions/cpsection/network/view.py
+++ b/extensions/cpsection/network/view.py
@@ -30,6 +30,7 @@ from jarabe.controlpanel.sectionview import SectionView
 from jarabe.controlpanel.inlinealert import InlineAlert
 
 import os
+import subprocess
 
 CLASS = 'Network'
 ICON = 'module-network'
@@ -638,9 +639,16 @@ class Network(SectionView):
                 if (schema != 'org.sugarlabs.system.proxy'):
                     hostname = Gio.Settings.get_string(
                         self._proxy_settings[schema], 'host')
-                    if hostname != '':
+                    if hostname:
                         non_blank_host_name_counter += 1
-                        response = os.system("ping -c 1 -W 1 " + hostname)
+                        try:
+                            response = subprocess.run(
+                                ['ping', '-c', '1', '-W', '1', '--', hostname],
+                                stdout=subprocess.DEVNULL,
+                                stderr=subprocess.DEVNULL
+                            ).returncode
+                        except (OSError, subprocess.SubprocessError):
+                            response=1
                         if (response):
                             self._proxy_inline_alerts[schema].show()
                             response_to_return = False


### PR DESCRIPTION
The proxy configuration flow concatenates user-provided hostnames directly into an os.system call. This creates a local shell injection vector. 

This replaces os.system with subprocess.run and an argument list to bypass the shell entirely, eliminating the injection risk. It also adds '--' before the hostname argument to prevent flag injection in case a malformed hostname starts with a hyphen.

Manual Test Plan:
Verified locally by entering '127.0.0.1; touch ~/ping_test' in the proxy settings. On the old code, the file is created. With this patch, the ping safely fails to resolve the malformed host, bypassing the shell, and no file is created.

Took inspiration from:- https://github.com/sugarlabs/sugar-ai/pull/136