### PR TITLE
fix ten journal defects in the list, chooser and detail view

### DIFF
--- a/src/jarabe/journal/expandedentry.py
+++ b/src/jarabe/journal/expandedentry.py
@@ -438,9 +438,16 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
         return _('No date')
 
     def _create_buddy_list(self):
-
+        # No orphan heading: the label appears only when somebody
+        # actually worked on this together with the child.
         vbox = Gtk.VBox()
         vbox.props.spacing = style.DEFAULT_SPACING
+
+        buddies = []
+        if self._metadata.get('buddies'):
+            buddies = list(json.loads(self._metadata['buddies']).values())
+        if not buddies:
+            return vbox
 
         text = Gtk.Label()
         text.set_markup('<span foreground="%s">%s</span>' % (
@@ -449,10 +456,7 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
         halign.add(text)
         vbox.pack_start(halign, False, False, 0)
 
-        if self._metadata.get('buddies'):
-            buddies = list(json.loads(self._metadata['buddies']).values())
-            vbox.pack_start(BuddyList(buddies), False, False, 0)
-            return vbox
+        vbox.pack_start(BuddyList(buddies), False, False, 0)
         return vbox
 
     def _create_scrollable(self, widget, label=None):

--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -51,7 +51,6 @@ from jarabe.journal import model
 from jarabe.journal.journalwindow import JournalWindow
 from jarabe.journal.bundlelauncher import launch_bundle, get_bundle
 from jarabe.journal import journalwindow
-from jarabe.journal.listmodel import ListModel
 
 from jarabe.model import session, shell
 

--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -409,6 +409,12 @@ class JournalActivity(JournalWindow):
                 self._main_toolbox.search_entry.grab_focus()
 
         elif self._active_view == JournalViews.DETAIL:
+            # Arrow keys and Return are writing when a text field has
+            # the keyboard; they only steer the Journal when none does.
+            focus = self.get_focus()
+            if isinstance(focus, (Gtk.Entry, Gtk.TextView)):
+                return False
+
             if keyname == 'Left':
                 path, col = self._list_view.tree_view.get_cursor()
                 self._list_view.tree_view.grab_focus()

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -997,7 +997,7 @@ class FilterToolItem(Gtk.ToolButton):
             # draw a black background, has been done by the engine before
             cr.set_source_rgb(0, 0, 0)
             cr.rectangle(0, 0, allocation.width, allocation.height)
-            cr.paint()
+            cr.fill()
 
         Gtk.ToolButton.do_draw(self, cr)
 

--- a/src/jarabe/journal/listmodel.py
+++ b/src/jarabe/journal/listmodel.py
@@ -163,18 +163,17 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
         metadata = self._result_set.read()
         metadata.update(self._updated_entries.get(metadata['uid'], {}))
 
-        self._last_requested_index = index
-        self._cached_row = []
-        self._cached_row.append(metadata['uid'])
-        self._cached_row.append(metadata.get('keep', '0') == '1')
-        self._cached_row.append(misc.get_icon_name(metadata))
+        row = []
+        row.append(metadata['uid'])
+        row.append(metadata.get('keep', '0') == '1')
+        row.append(misc.get_icon_name(metadata))
 
         if misc.is_activity_bundle(metadata):
             xo_color = XoColor('%s,%s' % (style.COLOR_BUTTON_GREY.get_svg(),
                                           style.COLOR_TRANSPARENT.get_svg()))
         else:
             xo_color = misc.get_icon_color(metadata)
-        self._cached_row.append(xo_color)
+        row.append(xo_color)
 
         title_value = metadata.get('title', _('Untitled'))
         if not isinstance(title_value, str):
@@ -184,7 +183,7 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
                             metadata['uid'], title_value)
             title_value = _('Untitled')
         title = GObject.markup_escape_text(title_value)
-        self._cached_row.append('<b>%s</b>' % (title, ))
+        row.append('<b>%s</b>' % (title, ))
 
         try:
             timestamp = float(metadata.get('timestamp', 0))
@@ -192,27 +191,27 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
             timestamp_content = _('Unknown')
         else:
             timestamp_content = util.timestamp_to_elapsed_string(timestamp)
-        self._cached_row.append(timestamp_content)
+        row.append(timestamp_content)
 
         try:
             creation_time = float(metadata.get('creation_time'))
         except (TypeError, ValueError):
-            self._cached_row.append(_('Unknown'))
+            row.append(_('Unknown'))
         else:
-            self._cached_row.append(
+            row.append(
                 util.timestamp_to_elapsed_string(float(creation_time)))
 
         try:
             size = int(metadata.get('filesize'))
         except (TypeError, ValueError):
             size = None
-        self._cached_row.append(util.format_size(size))
+        row.append(util.format_size(size))
 
         try:
             progress = int(float(metadata.get('progress', 100)))
         except (TypeError, ValueError):
             progress = 100
-        self._cached_row.append(progress)
+        row.append(progress)
 
         buddies = []
         if metadata.get('buddies'):
@@ -235,11 +234,13 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
                     logging.warning('Malformed buddies for %r: %s',
                                     metadata['uid'], exception)
                 else:
-                    self._cached_row.append([nick, XoColor(color)])
+                    row.append([nick, XoColor(color)])
                     continue
 
-            self._cached_row.append(None)
+            row.append(None)
 
+        self._cached_row = row
+        self._last_requested_index = index
         return self._cached_row[column]
 
     def do_iter_nth_child(self, parent_iter, n):

--- a/src/jarabe/journal/listmodel.py
+++ b/src/jarabe/journal/listmodel.py
@@ -139,6 +139,9 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
         if column == ListModel.COLUMN_TITLE:
             metadata['title'] = value
         self._updated_entries[metadata['uid']] = metadata
+        # The edit must survive a re-read of this same row: the row
+        # cache was primed by the read that preceded this write.
+        self._last_requested_index = None
         if self._updated_callback is not None:
             model.updated.disconnect(self._updated_callback)
         model.write(metadata, update_mtime=False,

--- a/src/jarabe/journal/listmodel.py
+++ b/src/jarabe/journal/listmodel.py
@@ -54,7 +54,6 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
     COLUMN_BUDDY_1 = 9
     COLUMN_BUDDY_2 = 10
     COLUMN_BUDDY_3 = 11
-    COLUMN_SELECT = 12
 
     _COLUMN_TYPES = {
         COLUMN_UID: str,
@@ -69,7 +68,6 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
         COLUMN_BUDDY_1: object,
         COLUMN_BUDDY_3: object,
         COLUMN_BUDDY_2: object,
-        COLUMN_SELECT: bool,
     }
 
     _PAGE_SIZE = 10

--- a/src/jarabe/journal/listmodel.py
+++ b/src/jarabe/journal/listmodel.py
@@ -176,8 +176,14 @@ class ListModel(GObject.GObject, Gtk.TreeModel, Gtk.TreeDragSource):
             xo_color = misc.get_icon_color(metadata)
         self._cached_row.append(xo_color)
 
-        title = GObject.markup_escape_text(metadata.get('title',
-                                                        _('Untitled')))
+        title_value = metadata.get('title', _('Untitled'))
+        if not isinstance(title_value, str):
+            # GObject.markup_escape_text raises TypeError on
+            # anything that isn't a string.
+            logging.warning('Content of title for %r is not a string: %r',
+                            metadata['uid'], title_value)
+            title_value = _('Untitled')
+        title = GObject.markup_escape_text(title_value)
         self._cached_row.append('<b>%s</b>' % (title, ))
 
         try:

--- a/src/jarabe/journal/listview.py
+++ b/src/jarabe/journal/listview.py
@@ -773,7 +773,7 @@ class ListView(BaseListView):
                 if self.cell_title.props.editable:
                     self.emit('title-edit-started')
 
-                column = self.tree_view.get_column(3)
+                column = self._title_column
                 tree_view.set_cursor_on_cell(path, column, self.cell_title,
                                          start_editing=True)
 

--- a/src/jarabe/journal/objectchooser.py
+++ b/src/jarabe/journal/objectchooser.py
@@ -150,7 +150,7 @@ class ObjectChooser(Gtk.Window):
 
     def __visibility_notify_event_cb(self, window, event):
         logging.debug('visibility_notify_event_cb %r', self)
-        visible = event.get_state() == Gdk.VisibilityState.FULLY_OBSCURED
+        visible = event.get_state() != Gdk.VisibilityState.FULLY_OBSCURED
         if not self._show_preview:
             self._list_view.set_is_visible(visible)
         else:


### PR DESCRIPTION
While working on a larger Journal series, there were small unrelated bugs, so here they are as their own PR first. 
One fix for a commit:

- object chooser wasn't updating its list while it was open.
- The filter toolbar's background was drawn over the whole surface instead of just its own box.
- Entries made alone still showed a "Participants" heading, with nobody under it.
- The list model still carried a column for selection that nothing uses anymore.
- If an entry's title wasn't text, its row crashed instead of drawing.
- The Journal could keep showing an outdated row: a half-made one after an error, or the old title after a rename (2 commits).
- One file imported ListModel twice.
- While typing in an entry's detail view, pressing Enter or the Left arrow threw you out of the text field instead of typing in it.
- The list view found its title column by counting positions instead of using the reference it already has, which breaks the moment a column is added.

This is the base of a stacked series but merges fine on its own. 

Two notes: 
1. make test is already red on master before this PR, and the journal test suite arrives in the next PR, not here. 
2. Tested by running the shell on a VM.