### PR TITLE
add the offline reflection engine and the privacy strip rule

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -75,6 +75,7 @@ src/jarabe/journal/model.py
 src/jarabe/journal/modalalert.py
 src/jarabe/journal/objectchooser.py
 src/jarabe/journal/palettes.py
+src/jarabe/journal/reflection.py
 src/jarabe/journal/volumestoolbar.py
 src/jarabe/journal/iconmodel.py
 src/jarabe/journal/iconview.py

--- a/src/jarabe/journal/Makefile.am
+++ b/src/jarabe/journal/Makefile.am
@@ -22,4 +22,5 @@ sugar_PYTHON =				\
 	projectview.py			\
 	timeline.py			\
 	palettes.py			\
+	reflection.py			\
 	volumestoolbar.py

--- a/src/jarabe/journal/model.py
+++ b/src/jarabe/journal/model.py
@@ -36,6 +36,8 @@ from sugar3 import dispatch
 from sugar3 import mime
 from sugar3 import util
 
+from jarabe.journal import reflection
+
 
 DS_DBUS_SERVICE = 'org.laptop.sugar.DataStore'
 DS_DBUS_INTERFACE = 'org.laptop.sugar.DataStore'
@@ -775,6 +777,17 @@ def _rename_entry_on_external_device(file_path, destination_path,
                                   'for file=%s', ofile, old_fname)
 
 
+def _rewrites_entry_in_place(metadata):
+    """True when the write lands back on the very file the entry
+    already is, on its own volume. That is the only case where the
+    sidecar may keep the child's talk with Jo; everything else is a
+    copy going somewhere new.
+    """
+    return ('uid' in metadata and os.path.exists(metadata['uid']) and
+            metadata['uid'].startswith(
+                metadata['mountpoint'].rstrip('/') + '/'))
+
+
 def _write_entry_on_external_device(metadata, file_path, ready_callback=None):
     """Create and update an entry copied from the
     DS to an external storage device.
@@ -841,6 +854,11 @@ def _write_entry_on_external_device(metadata, file_path, ready_callback=None):
     metadata_copy.pop('mountpoint', None)
     metadata_copy.pop('uid', None)
     metadata_copy.pop('filesize', None)
+    # A copy leaving the Journal, or moving between volumes, never
+    # carries the child's talk with Jo; only a rewrite of an entry on
+    # its own volume keeps what its sidecar already holds.
+    if not _rewrites_entry_in_place(metadata):
+        reflection.strip_private(metadata_copy)
 
     metadata_dir_path = os.path.join(metadata['mountpoint'],
                                      JOURNAL_METADATA_DIR)

--- a/src/jarabe/journal/reflection.py
+++ b/src/jarabe/journal/reflection.py
@@ -1,0 +1,812 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import logging
+import os
+import random
+import re
+import time
+import unicodedata
+import uuid
+from gettext import gettext as _
+
+
+SCHEMA_VERSION = 1
+
+# Hard budget for the serialized metadata['reflections'] string. Any
+# property over ~500 KB makes carquinyol's metadatareader.c raise
+# ValueError and the whole entry becomes unreadable; 64 KB is margin.
+MAX_REFLECTIONS_BYTES = 64 * 1024
+
+ROLE_JO = 'jo'
+ROLE_CHILD = 'child'
+
+# The metadata keys holding the child's private talk: the serialized
+# conversation, the numbered moment snaps (momentcard builds its key
+# from this prefix), and next_steps, written only by the server
+# layer's capture. Never copied where others browse.
+SNAP_KEY_PREFIX = 'moment-snap-'
+_PRIVATE_KEYS = ('reflections', 'next_steps')
+
+
+def strip_private(metadata):
+    for key in _PRIVATE_KEYS:
+        metadata.pop(key, None)
+    for key in [k for k in metadata if k.startswith(SNAP_KEY_PREFIX)]:
+        del metadata[key]
+
+
+def empty_conversation():
+    return {'version': SCHEMA_VERSION, 'sessions': []}
+
+
+def loads(raw):
+    """Parse metadata['reflections']. Never raises; unknown keys survive."""
+    if not raw:
+        return empty_conversation()
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return empty_conversation()
+    if not isinstance(data, dict):
+        return empty_conversation()
+    sessions = data.get('sessions', [])
+    if not isinstance(sessions, list):
+        return empty_conversation()
+    data['sessions'] = [s for s in sessions if isinstance(s, dict)]
+    moments = data.get('moments', [])
+    if not isinstance(moments, list):
+        moments = []
+    data['moments'] = [m for m in moments if isinstance(m, dict)]
+    seq = data.get('moment_seq', 0)
+    if not isinstance(seq, int) or isinstance(seq, bool) or seq < 0:
+        data['moment_seq'] = max(
+            [m.get('snap_seq', -1) for m in data['moments']
+             if isinstance(m.get('snap_seq'), int)] + [-1]) + 1
+    data.setdefault('version', SCHEMA_VERSION)
+    return data
+
+
+def dumps(data):
+    """Serialize, evicting whole sessions oldest-first to fit
+    MAX_REFLECTIONS_BYTES. Never the last one; never mutates input.
+    """
+    body = dict(data)
+    sessions = list(body.get('sessions', []))
+    body['sessions'] = sessions
+    text = json.dumps(body)
+    while len(text.encode('utf-8')) > MAX_REFLECTIONS_BYTES and \
+            len(sessions) > 1:
+        sessions.pop(0)
+        body['sessions'] = sessions
+        text = json.dumps(body)
+    return text
+
+
+def new_session(framework):
+    return {'ts': int(time.time()), 'framework': framework, 'turns': []}
+
+
+def new_session_id():
+    """An id for a session that may need re-merging later. The
+    datastore prunes any key an update omits, so an activity's stale
+    close-time save drops the shell's session; the id puts it back.
+    """
+    return uuid.uuid4().hex
+
+
+def find_session(data, sid):
+    if not sid:
+        return None
+    for session in data.get('sessions', []):
+        if session.get('sid') == sid:
+            return session
+    return None
+
+
+def merge_session(data, session):
+    sid = session.get('sid')
+    body = dict(data)
+    sessions = [s for s in body.get('sessions', [])
+                if sid is None or s.get('sid') != sid]
+    sessions.append(session)
+    body['sessions'] = sessions
+    return body
+
+
+def merge_sessions_for_write(fresh_raw, sessions):
+    """The store's current state with our sessions merged in. update()
+    prunes any key the writer omits, so never write from a stale copy.
+    Matched by sid then ts; whichever copy holds more turns wins.
+    """
+    data = loads(fresh_raw)
+    for session in sessions:
+        sid = session.get('sid')
+        held = find_session(data, sid)
+        if held is None:
+            for candidate in data.get('sessions', []):
+                if 'sid' not in candidate and 'sid' not in session and \
+                        candidate.get('ts') == session.get('ts'):
+                    held = candidate
+                    break
+        if held is not None:
+            if len(held.get('turns', ())) > len(session.get('turns', ())):
+                continue
+            if held is not find_session(data, sid):
+                body = dict(data)
+                body['sessions'] = [s for s in body.get('sessions', [])
+                                    if s is not held]
+                data = body
+        data = merge_session(data, session)
+    data['sessions'] = sorted(data.get('sessions', []),
+                              key=lambda s: s.get('ts', 0))
+    return data
+
+
+def has_kept_line(description, text):
+    return text in (description or '').split('\n')
+
+
+def kept_lines(raw, description, limit=2):
+    """The kept child lines still in the description, newest first."""
+    if not raw or not description:
+        return []
+    data = loads(raw)
+    lines = []
+    for session in reversed(data.get('sessions', [])):
+        for turn in reversed(session.get('turns', [])):
+            if turn.get('role') != ROLE_CHILD:
+                continue
+            text = turn.get('text', '')
+            if text and text not in lines and \
+                    has_kept_line(description, text):
+                lines.append(text)
+                if len(lines) >= limit:
+                    return lines
+    return lines
+
+
+def add_turn(session, role, text, peer=False, q=None, local=False):
+    """Append a turn to a session and return it. peer marks a Jo turn
+    voicing another child's comment, and rides the stored turn so
+    later sessions still read it as a people question. q is the
+    scripted question's stable id, stamped from the text or passed in
+    when a composed line stands in for a script slot. local marks a Jo
+    turn whose text must never reach the wire, and latches the child's
+    answer off the wire with it.
+    """
+    if role not in (ROLE_JO, ROLE_CHILD):
+        raise ValueError('Unknown role: %r' % (role,))
+    turn = {'role': role, 'text': text}
+    if peer:
+        turn['peer'] = True
+    if role == ROLE_JO:
+        if q is None:
+            q = _QUESTION_ID.get(text)
+        if q is not None:
+            turn['q'] = q
+        if local:
+            turn['local'] = True
+    session.setdefault('turns', []).append(turn)
+    return session
+
+
+def _asks_about_people(text):
+    return text in (TOGETHER_OPENER, NEARBY_NUDGE, NEARBY_MIDFLOW,
+                    NEARBY_FOLLOWUP)
+
+
+def _people_turn(turn):
+    if turn.get('peer'):
+        return True
+    qid = turn.get('q')
+    if isinstance(qid, str):
+        return qid in _PEOPLE_IDS
+    return _asks_about_people(turn.get('text', ''))
+
+
+# Memory is the server's alone. When the AI asked something
+# forward-looking and the child answered, that answer rides the next
+# request as previous_next_steps for the server to weave in - Jo
+# herself never quotes it. Floor questions carry a 'q' stamp, so an
+# offline talk can never produce one; the marker sniff below only
+# ever reads the server's own question text.
+_FORWARD_RE = re.compile(
+    r'\b(next|would|will|if you|try|wish|want)\b')
+
+
+def _asked_about_people(turns, index):
+    """Whether the Jo question the index-th turn answers - walking
+    back over the child's consecutive lines - was about people.
+    """
+    j = index - 1
+    while j >= 0 and turns[j].get('role') != ROLE_JO:
+        j -= 1
+    return j >= 0 and _people_turn(turns[j])
+
+
+def extract_next_steps(session):
+    """The child's answer to a server-asked forward question, or ''.
+    """
+    turns = session.get('turns', [])
+    for i in range(len(turns) - 1, -1, -1):
+        turn = turns[i]
+        if turn.get('role') != ROLE_CHILD:
+            continue
+        if _asked_about_people(turns, i):
+            # An answer about who was there tends to carry a peer's
+            # name; it must never persist or ride a request.
+            continue
+        if i > 0 and turns[i - 1].get('role') == ROLE_JO:
+            prev = turns[i - 1]
+            if prev.get('q') is not None or prev.get('peer'):
+                continue
+            if _FORWARD_RE.search(prev.get('text', '').lower()):
+                # Clipped at the write so a paste cannot grow the
+                # metadata property without bound.
+                return clip_line(turn.get('text', ''), 120)
+    return ''
+
+
+def resolve_next_steps(session, previous):
+    """What metadata['next_steps'] should hold after this session.
+
+    A fresh answer replaces the note. A server session that renewed
+    nothing retires it - carrying it further would be nagging. An
+    offline session leaves it alone: the floor never saw it.
+    """
+    fresh = extract_next_steps(session)
+    if fresh:
+        return fresh
+    for turn in session.get('turns', []):
+        if turn.get('role') == ROLE_JO and turn.get('q') is None and \
+                not turn.get('peer'):
+            return ''
+    return previous or ''
+
+
+def get_next_steps(metadata):
+    return metadata.get('next_steps', '') or ''
+
+
+def keep_in_description(description, text):
+    """Append a starred answer to the description, verbatim."""
+    if not description:
+        return text
+    return description.rstrip('\n') + '\n' + text
+
+
+def unkeep_from_description(description, text):
+    lines = description.split('\n')
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i] == text:
+            del lines[i]
+            return '\n'.join(lines)
+    return description
+
+
+# Activities grouped into the five categories the offline floor asks
+# from. The server keeps its own copy, held in step by hand; if the
+# two drift, an unknown bundle just falls to creative on both sides.
+CATEGORY_BUNDLES = {
+    'creative': [
+        'org.laptop.TurtleArtActivity',
+        'org.laptop.Oficina',
+        'org.laptop.AbiWordActivity',
+        'org.laptop.Record',
+        'org.sugarlabs.MusicBlocksActivity',
+    ],
+    'programming': [
+        'org.laptop.PippyActivity',
+        'org.laptop.Pippy',
+        'org.laptop.Calculate',
+        'org.laptop.Terminal',
+        'org.laptop.Physics',
+        'org.laptop.Measure',
+    ],
+    'exploration': [
+        'org.laptop.WebActivity',
+        'org.laptop.Log',
+        'org.laptop.ImageViewerActivity',
+    ],
+    'game': [
+        'org.laptop.Memorize',
+        'org.sugarlabs.Maze',
+        'org.sugarlabs.Clock',
+        'org.sugarlabs.Abacus',
+    ],
+    'communication': [
+        'org.laptop.Chat',
+        'org.laptop.Speak',
+    ],
+}
+
+DEFAULT_CATEGORY = 'creative'
+
+BUNDLE_CATEGORY = {}
+for _category, _bundles in CATEGORY_BUNDLES.items():
+    for _bundle_id in _bundles:
+        BUNDLE_CATEGORY[_bundle_id] = _category
+
+
+def get_category(activity_id):
+    return BUNDLE_CATEGORY.get(activity_id, DEFAULT_CATEGORY)
+
+
+# Static banks for when Jo cannot see the work. Two questions is the
+# whole visit - past the pair, a floor turn is one Jo cannot react to.
+FLOOR_BANK = {
+    'creative': [
+        _("I can't see your work right now, but I'd love to hear "
+          "about it. What did you make?"),
+        _("If you could add one more thing to it, what would it be?"),
+    ],
+    'programming': [
+        _("I can't see your project right now, but tell me about it. "
+          "What were you trying to make it do?"),
+        _("If you kept going, what would you make it do next?"),
+    ],
+    'exploration': [
+        _("I can't see what you found right now, but tell me about "
+          "it. What did you discover?"),
+        _("Where would you look next?"),
+    ],
+    'game': [
+        _("I can't see how your game went right now, but tell me "
+          "about it. What happened when you played?"),
+        _("What will you try differently next time?"),
+    ],
+    'communication': [
+        _("I can't see your conversation right now, but tell me "
+          "about it. Who did you talk to?"),
+        _("What would you ask them next time?"),
+    ],
+}
+
+DEFAULT_FLOOR_BANK = [
+    _("I can't see your work right now, but tell me about it. What "
+      "did you just do?"),
+    _("What would you do differently next time?"),
+]
+
+# Openers for work on screen, keyed by the one each stands in for.
+# Jo still never claims to see it; these only drop the disclaimer.
+VISIBLE_WORK_OPENERS = {
+    FLOOR_BANK['creative'][0]:
+        _("I'd love to hear about what you made. What is it?"),
+    FLOOR_BANK['programming'][0]:
+        _("Tell me about your project. What were you trying to make "
+          "it do?"),
+    FLOOR_BANK['exploration'][0]:
+        _("Tell me about what you found. What did you discover?"),
+    FLOOR_BANK['game'][0]:
+        _("How did your game go? What happened when you played?"),
+    FLOOR_BANK['communication'][0]:
+        _("Tell me about your conversation. Who did you talk to?"),
+    DEFAULT_FLOOR_BANK[0]:
+        _("Tell me about what you just did. What was it?"),
+}
+
+# Never composed from the description, which is prose the child owns.
+# TRANS: %(title)s is the child's own title or caption, quoted as is.
+TITLED_OPENER = _('You called this “%(title)s”. '
+                  'What do you like most about it?')
+
+# Asked once beside work with a recorded shared session. That record
+# is wrong both ways, so the question stays open and names no one.
+TOGETHER_OPENER = _("What did you work out together on this one, "
+                    "or was it all you?")
+
+# When the bank runs dry, point the child at a nearby person, once
+# per artifact, carrying a question to ask - never a line to repeat.
+NEARBY_NUDGE = _("I'm out of questions about this one. What does "
+                 "someone near you notice when you show it to them?")
+NEARBY_FOLLOWUP = _("If you talked this one over with someone, "
+                    "what did you two figure out?")
+
+# The room can also come up mid-talk. Either form spends the one
+# nearby slot; both numbers below are guesses until children set them.
+# TRANS: the same question as the nudge above without its preamble -
+# please keep the two parallel.
+NEARBY_MIDFLOW = _("What does someone near you notice when you show "
+                   "it to them?")
+NEARBY_MIDFLOW_CHANCE = 0.25
+NEARBY_MIDFLOW_WARMUP = 1
+
+# A peer's question from the stock comments box, voiced as a Jo turn,
+# once each. Comments arrive from other people, so only one shaped
+# like an honest question gets a voice, and it and its answers stay
+# off the wire: another child's words and name.
+# TRANS: %(who)s is the commenter's name, %(question)s their words.
+PEER_QUESTION_OPENER = _('%(who)s saw this and asks: “%(question)s”')
+# TRANS: the same line for a comment that carries no name.
+PEER_QUESTION_ANON = _('Someone saw this and asks: “%(question)s”')
+
+# A name longer than any real name is not a name; the line it would
+# build could evict the child's whole saved talk.
+PEER_NAME_LIMIT = 40
+
+_ALL_FLOOR_QUESTIONS = set(DEFAULT_FLOOR_BANK)
+for _questions in FLOOR_BANK.values():
+    _ALL_FLOOR_QUESTIONS.update(_questions)
+_ALL_FLOOR_QUESTIONS.update(VISIBLE_WORK_OPENERS.values())
+_ALL_FLOOR_QUESTIONS.add(TOGETHER_OPENER)
+_ALL_FLOOR_QUESTIONS.add(NEARBY_NUDGE)
+_ALL_FLOOR_QUESTIONS.add(NEARBY_MIDFLOW)
+_ALL_FLOOR_QUESTIONS.add(NEARBY_FOLLOWUP)
+
+# Every scripted question carries a stable id, stamped on the Jo turn
+# as 'q', so used-tracking survives a locale switch. An opener and
+# its beside-the-work variant share one id: one slot, either voice.
+_QUESTION_ID = {}
+_ID_QUESTION = {}
+
+
+def _register_question(qid, text):
+    _QUESTION_ID[text] = qid
+    _ID_QUESTION.setdefault(qid, text)
+
+
+for _cat, _questions in FLOOR_BANK.items():
+    for _i, _question in enumerate(_questions):
+        _register_question('floor:%s:%d' % (_cat, _i), _question)
+for _i, _question in enumerate(DEFAULT_FLOOR_BANK):
+    _register_question('floor:default:%d' % _i, _question)
+for _plain, _beside in VISIBLE_WORK_OPENERS.items():
+    _register_question(_QUESTION_ID[_plain], _beside)
+_register_question('together', TOGETHER_OPENER)
+_register_question('nearby:nudge', NEARBY_NUDGE)
+_register_question('nearby:midflow', NEARBY_MIDFLOW)
+_register_question('nearby:followup', NEARBY_FOLLOWUP)
+
+_PEOPLE_IDS = {'together', 'nearby:nudge', 'nearby:midflow',
+               'nearby:followup'}
+
+
+def floor_bank(activity_id):
+    category = BUNDLE_CATEGORY.get(activity_id)
+    if category is None:
+        return DEFAULT_FLOOR_BANK
+    return FLOOR_BANK[category]
+
+
+def floor_question(activity_id, used=(), artifact_visible=False):
+    for question in floor_bank(activity_id):
+        variant = VISIBLE_WORK_OPENERS.get(question)
+        if question in used or (variant is not None and variant in used):
+            continue
+        if artifact_visible and variant is not None:
+            return variant
+        return question
+    return None
+
+
+def opener_slot_id(activity_id):
+    return _QUESTION_ID[floor_bank(activity_id)[0]]
+
+
+def quoted_child_text(text, limit):
+    """Drop format characters and wrap in first-strong isolates, so a
+    stray RLO or a Latin title in an RTL UI cannot reorder Jo's words.
+    """
+    text = ''.join(ch for ch in text if unicodedata.category(ch)
+                   not in ('Cc', 'Cf', 'Zl', 'Zp'))
+    return '\u2068%s\u2069' % clip_line(text, limit)
+
+
+def titled_opener(label):
+    """Speak with q=opener_slot_id(...) so it spends the opener slot."""
+    return TITLED_OPENER % {'title': quoted_child_text(label, 60)}
+
+
+def has_buddies(metadata):
+    raw = metadata.get('buddies', '')
+    if not raw:
+        return False
+    try:
+        buddies = json.loads(raw)
+    except (TypeError, ValueError):
+        return False
+    return isinstance(buddies, dict) and bool(buddies)
+
+
+def together_question(metadata, used=()):
+    if TOGETHER_OPENER in used or not has_buddies(metadata):
+        return None
+    return TOGETHER_OPENER
+
+
+def nearby_nudge(used=()):
+    if NEARBY_NUDGE in used or NEARBY_MIDFLOW in used:
+        return None
+    return NEARBY_NUDGE
+
+
+def nearby_midflow(used=(), turns=(), roll=1.0):
+    """The same move mid-talk. It spends the one nearby slot."""
+    if NEARBY_NUDGE in used or NEARBY_MIDFLOW in used:
+        return None
+    replies = _child_replies(turns)
+    if len(replies) < NEARBY_MIDFLOW_WARMUP:
+        return None
+    if roll >= NEARBY_MIDFLOW_CHANCE:
+        return None
+    return NEARBY_MIDFLOW
+
+
+def nearby_followup(used=(), data=None, now=None):
+    """The what-came-of-it opener, once and only after time away."""
+    if NEARBY_FOLLOWUP in used:
+        return None
+    if NEARBY_NUDGE not in used and NEARBY_MIDFLOW not in used:
+        return None
+    if data is not None and not feed_forward_due(data, now):
+        return None
+    return NEARBY_FOLLOWUP
+
+
+def parse_comments(raw):
+    if not raw:
+        return []
+    try:
+        comments = json.loads(raw)
+    except (TypeError, ValueError):
+        return []
+    if not isinstance(comments, list):
+        return []
+    return [c for c in comments if isinstance(c, dict)]
+
+
+def _plain_text(text):
+    return all(unicodedata.category(ch) not in ('Cc', 'Cf', 'Zl', 'Zp')
+               for ch in text)
+
+
+def compose_peer_question(comment):
+    message = comment.get('message')
+    if not isinstance(message, str):
+        return None
+    message = message.strip()
+    if not turn_acceptable(message) or not _plain_text(message):
+        return None
+    who = comment.get('from')
+    who = who.strip() if isinstance(who, str) else ''
+    if len(who) > PEER_NAME_LIMIT or not _plain_text(who):
+        who = ''
+    if who:
+        return PEER_QUESTION_OPENER % {'who': who, 'question': message}
+    return PEER_QUESTION_ANON % {'question': message}
+
+
+def peer_question(comments_raw, spoken=()):
+    for comment in parse_comments(comments_raw):
+        text = compose_peer_question(comment)
+        if text is not None and text not in spoken:
+            return text
+    return None
+
+
+def jo_texts(conversation, turns=()):
+    """Every line Jo has said here. Peer questions are composed, not
+    from a bank, so voiced-once needs the whole record.
+    """
+    texts = set()
+    sessions = conversation.get('sessions', []) if conversation else []
+    for session in sessions:
+        for turn in session.get('turns', []):
+            if turn.get('role') == ROLE_JO:
+                texts.add(turn.get('text', ''))
+    for turn in turns:
+        if turn.get('role') == ROLE_JO:
+            texts.add(turn.get('text', ''))
+    return texts
+
+
+def used_floor_questions(conversation, turns=()):
+    used = set()
+    sessions = conversation.get('sessions', []) if conversation else []
+    for session in sessions:
+        for turn in session.get('turns', []):
+            _collect_used(turn, used)
+    for turn in turns:
+        _collect_used(turn, used)
+    return used
+
+
+def _collect_used(turn, used):
+    """Mark a Jo turn's question used: by stable id first, which
+    survives a locale switch, then by text as a defense for a
+    record whose stamp went missing.
+    """
+    if turn.get('role') != ROLE_JO:
+        return
+    qid = turn.get('q')
+    if isinstance(qid, str) and qid in _ID_QUESTION:
+        used.add(_ID_QUESTION[qid])
+    elif turn.get('text') in _ALL_FLOOR_QUESTIONS:
+        used.add(turn['text'])
+
+
+# Jo introduces itself once, on whichever surface the child meets
+# first. That fact lives here, not in any entry's metadata.
+STATE_PATH = os.path.expanduser('~/.sugar/default/reflection-state.json')
+
+INTRO_LINE = _("I'm Jo. I like hearing about things people make. "
+               "Can I ask you about this one?")
+_register_question('intro', INTRO_LINE)
+
+
+def _read_state(path=STATE_PATH):
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def state_flag(key, path=STATE_PATH):
+    return bool(_read_state(path).get(key))
+
+
+def mark_state(key, path=STATE_PATH):
+    """Record a once-ever moment. Best-effort; it may repeat."""
+    data = _read_state(path)
+    data[key] = True
+    try:
+        with open(path, 'w') as f:
+            json.dump(data, f)
+    except OSError:
+        logging.exception('Error writing reflection state %r', path)
+
+
+STATUS_OK = 'ok'
+
+
+def _result(object_id, generation, status, turn=None,
+            should_continue=True):
+    return {'object_id': object_id, 'generation': generation,
+            'status': status, 'turn': turn,
+            'should_continue': should_continue}
+
+
+# The nearby follow-up is only honest after real time away - no
+# talk in the room can have happened a minute after Jo pointed at it.
+FEED_FORWARD_GAP = 45 * 60
+
+
+def latest_session_ts(data):
+    ts = 0
+    for session in data.get('sessions', []):
+        try:
+            ts = max(ts, int(session.get('ts', 0)))
+        except (TypeError, ValueError):
+            continue
+    return ts
+
+
+def feed_forward_due(data, now=None):
+    if now is None:
+        now = time.time()
+    return (now - latest_session_ts(data)) > FEED_FORWARD_GAP
+
+
+def count_turns(data):
+    """Turns held by a parsed conversation, before any eviction."""
+    return sum(len(s.get('turns', ())) for s in data.get('sessions', []))
+
+
+def total_turns(raw):
+    """How many turns a record holds. The write guard's yardstick: a
+    talk only grows, so a shrinking count means a stale copy.
+    """
+    data = loads(raw)
+    return sum(len(s.get('turns', []))
+               for s in data.get('sessions', []))
+
+
+def clip_line(text, limit):
+    text = ' '.join(text.split())
+    if len(text) <= limit:
+        return text
+    trimmed = text[:limit]
+    if ' ' in trimmed:
+        trimmed = trimmed.rsplit(' ', 1)[0]
+    return trimmed + '…'
+
+
+def hanging_question(data):
+    sessions = data.get('sessions', [])
+    if not sessions:
+        return None
+    turns = sessions[-1].get('turns', [])
+    if not turns:
+        return None
+    last = turns[-1]
+    if last.get('role') != ROLE_JO:
+        return None
+    text = (last.get('text') or '').strip()
+    # A voiced peer question ends on its closing quote.
+    if not text.rstrip('”').endswith(_QUESTION_ENDS):
+        return None
+    return text
+
+
+def _child_replies(turns):
+    return [turn.get('text', '') for turn in turns
+            if turn.get('role') == ROLE_CHILD]
+
+
+# Question terminators beyond ASCII: Arabic, fullwidth CJK, and the
+# unambiguous Greek U+037E, Armenian and Ethiopic marks. The ASCII
+# semicolon Greek actually types stays out - accepting it would read
+# every clause break as a question.
+_QUESTION_ENDS = ('?', '？', '؟', '\u037e', '\u055e', '\u1367')
+_SENTENCE_MARKS = '.!?。！？؟\u0964\u06d4\u0589\u1362'
+
+
+def turn_acceptable(text):
+    """Whether a server turn is shaped like Jo: short, one question."""
+    text = text.strip()
+    if not text or len(text) > 140 or '\n' in text:
+        return False
+    if not text.endswith(_QUESTION_ENDS):
+        return False
+    if ':' in text or ' - ' in text or '•' in text:
+        return False
+    return sum(text.count(mark) for mark in _SENTENCE_MARKS) <= 2
+
+
+def _floor_result(object_id, generation, activity_id, conversation, turns,
+                  artifact_visible=False, opener=None):
+    used = used_floor_questions(conversation, turns)
+    # Mid-talk the "I can't see" preamble reads absurd, so a fallback
+    # landing after the child has spoken takes the beside-work voice.
+    in_talk = bool(_child_replies(turns))
+    question = floor_question(activity_id, used, artifact_visible or in_talk)
+    if question is not None and opener is not None and \
+            not in_talk and \
+            _QUESTION_ID.get(question) == opener.get('q'):
+        # When the floor would open, the child's own words lead.
+        turn = {'role': ROLE_JO, 'text': opener['text'],
+                'q': opener['q']}
+        if opener.get('local'):
+            turn['local'] = True
+        return _result(object_id, generation, STATUS_OK, turn=turn)
+    if question is not None:
+        midflow = nearby_midflow(used, turns, random.random())
+        if midflow is not None:
+            question = midflow
+    if question is None:
+        return _result(object_id, generation, STATUS_OK)
+    return _result(object_id, generation, STATUS_OK,
+                   turn={'role': ROLE_JO, 'text': question})
+
+
+def request_turn(object_id, generation, activity_id, title, description,
+                 turns, next_steps=None, conversation=None,
+                 artifact_visible=False, opener=None):
+    """Compose Jo's next turn from the floor bank.
+
+    The result carries (object_id, generation), so a caller with
+    several requests in flight can place a late reply. A dry bank
+    comes back as STATUS_OK with turn None: Jo has nothing new to
+    open with and stays silent. title, description and next_steps
+    are unused here; the server layer consumes them.
+    """
+    return _floor_result(object_id, generation, activity_id,
+                         conversation, turns, artifact_visible,
+                         opener=opener)

--- a/tests/journal/test_model_privacy.py
+++ b/tests/journal/test_model_privacy.py
@@ -1,0 +1,107 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import tempfile
+import unittest
+
+# gi is an apt-installed system package, not something `uvx pytest`'s
+# own managed interpreter has -- skip rather than error when it isn't
+# importable. Gtk/Gdk must be pinned to 3.0 before jarabe.journal.model
+# pulls them in bare.
+try:
+    import gi
+    gi.require_version('Gtk', '3.0')
+    gi.require_version('Gdk', '3.0')
+except (ImportError, ValueError):
+    raise unittest.SkipTest('gi is not available')
+
+# jarabe isn't on sys.path outside a built/installed tree.
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
+
+from jarabe.journal import model  # noqa: E402
+
+
+class TestRewritesEntryInPlace(unittest.TestCase):
+    """The one gate that decides whether a child's talk with Jo rides
+    along with an entry. False here means strip; anything that is not
+    provably the entry rewriting itself on its own volume must strip.
+    """
+
+    def setUp(self):
+        self.volume = tempfile.mkdtemp()
+        self.addCleanup(_rmtree, self.volume)
+        self.entry = os.path.join(self.volume, 'drawing.png')
+        open(self.entry, 'w').close()
+
+    def test_rewrite_on_its_own_volume_keeps_the_talk(self):
+        self.assertTrue(model._rewrites_entry_in_place(
+            {'uid': self.entry, 'mountpoint': self.volume}))
+
+    def test_trailing_slash_on_the_mountpoint_still_matches(self):
+        self.assertTrue(model._rewrites_entry_in_place(
+            {'uid': self.entry, 'mountpoint': self.volume + '/'}))
+
+    def test_copy_out_of_the_datastore_strips(self):
+        # A datastore entry has no file path of its own to rewrite.
+        self.assertFalse(model._rewrites_entry_in_place(
+            {'mountpoint': self.volume}))
+
+    def test_a_datastore_object_id_is_not_a_path(self):
+        self.assertFalse(model._rewrites_entry_in_place(
+            {'uid': '6f1a2b3c-4d5e-6f70-8192-a3b4c5d6e7f8',
+             'mountpoint': self.volume}))
+
+    def test_copy_between_volumes_strips(self):
+        other = tempfile.mkdtemp()
+        self.addCleanup(_rmtree, other)
+        self.assertFalse(model._rewrites_entry_in_place(
+            {'uid': self.entry, 'mountpoint': other}))
+
+    def test_a_sibling_volume_sharing_a_name_prefix_strips(self):
+        # /media/stick must not look like a rewrite of /media/stick2.
+        sibling = self.volume + '2'
+        os.makedirs(sibling)
+        self.addCleanup(_rmtree, sibling)
+        stray = os.path.join(sibling, 'drawing.png')
+        open(stray, 'w').close()
+        self.assertFalse(model._rewrites_entry_in_place(
+            {'uid': stray, 'mountpoint': self.volume}))
+
+    def test_a_path_that_no_longer_exists_strips(self):
+        os.unlink(self.entry)
+        self.assertFalse(model._rewrites_entry_in_place(
+            {'uid': self.entry, 'mountpoint': self.volume}))
+
+    def test_a_missing_uid_never_reaches_the_mountpoint(self):
+        # Short-circuit order matters: callers reach this gate having
+        # already indexed 'mountpoint', but 'uid' may legitimately be
+        # absent, and testing it first is what keeps that safe.
+        self.assertFalse(model._rewrites_entry_in_place({}))
+
+
+def _rmtree(path):
+    for root, dirs, files in os.walk(path, topdown=False):
+        for name in files:
+            os.unlink(os.path.join(root, name))
+        for name in dirs:
+            os.rmdir(os.path.join(root, name))
+    os.rmdir(path)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/journal/test_reflection.py
+++ b/tests/journal/test_reflection.py
@@ -1,0 +1,925 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import contextlib
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+# jarabe/__init__.py and jarabe/journal/__init__.py are both gi-free, but
+# jarabe isn't on sys.path outside a built/installed tree.
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
+
+from jarabe.journal import reflection  # noqa: E402
+
+
+class TestConversationModel(unittest.TestCase):
+
+    # --- Conversation model: serialize/deserialize ---
+
+    def test_loads_empty_returns_fresh_structure(self):
+        self.assertEqual(reflection.loads(''), reflection.empty_conversation())
+        self.assertEqual(
+            reflection.loads(None), reflection.empty_conversation())
+
+    def test_loads_malformed_json_starts_fresh(self):
+        self.assertEqual(
+            reflection.loads('{not json'), reflection.empty_conversation())
+
+    def test_loads_non_dict_json_starts_fresh(self):
+        self.assertEqual(
+            reflection.loads('[1, 2, 3]'), reflection.empty_conversation())
+        self.assertEqual(
+            reflection.loads('"hello"'), reflection.empty_conversation())
+
+    def test_loads_sessions_wrong_type_starts_fresh(self):
+        raw = json.dumps({'version': 1, 'sessions': 'nope'})
+        self.assertEqual(
+            reflection.loads(raw), reflection.empty_conversation())
+
+    def test_loads_missing_sessions_key_defaults_to_empty_list(self):
+        raw = json.dumps({'version': 1, 'note': 'kept'})
+        data = reflection.loads(raw)
+        self.assertEqual(data['sessions'], [])
+        self.assertEqual(data['note'], 'kept')
+
+    def test_round_trip_preserves_unknown_top_level_keys(self):
+        data = reflection.empty_conversation()
+        data['future_field'] = 'kept-around'
+        session = reflection.new_session('creative_spiral')
+        reflection.add_turn(session, reflection.ROLE_JO, 'What did you make?')
+        data['sessions'].append(session)
+
+        reloaded = reflection.loads(reflection.dumps(data))
+        self.assertEqual(reloaded['future_field'], 'kept-around')
+        self.assertEqual(
+            reloaded['sessions'][0]['turns'][0]['text'], 'What did you make?')
+
+    def test_round_trip_preserves_unknown_session_and_turn_keys(self):
+        session = reflection.new_session('creative_spiral')
+        session['mood'] = 'excited'
+        reflection.add_turn(session, reflection.ROLE_CHILD, 'A rocket')
+        session['turns'][0]['lang'] = 'en'
+
+        data = reflection.empty_conversation()
+        data['sessions'].append(session)
+
+        reloaded = reflection.loads(reflection.dumps(data))
+        reloaded_session = reloaded['sessions'][0]
+        self.assertEqual(reloaded_session['mood'], 'excited')
+        self.assertEqual(reloaded_session['turns'][0]['lang'], 'en')
+
+    def test_add_turn_rejects_unknown_role(self):
+        session = reflection.new_session('creative_spiral')
+        with self.assertRaises(ValueError):
+            reflection.add_turn(session, 'teacher', 'hi')
+
+    # --- Conversation model: session re-merge after a stale-save wipe ---
+
+    def test_new_session_ids_are_unique(self):
+        self.assertNotEqual(
+            reflection.new_session_id(), reflection.new_session_id())
+
+    def test_find_session_by_sid(self):
+        session = reflection.new_session('creative')
+        session['sid'] = 'abc'
+        data = reflection.empty_conversation()
+        data['sessions'].append(session)
+        self.assertIs(reflection.find_session(data, 'abc'), session)
+        self.assertIsNone(reflection.find_session(data, 'missing'))
+        self.assertIsNone(reflection.find_session(data, None))
+        self.assertIsNone(reflection.find_session(data, ''))
+
+    def test_find_session_ignores_sessions_without_sid(self):
+        data = reflection.empty_conversation()
+        data['sessions'].append(reflection.new_session('creative'))
+        self.assertIsNone(reflection.find_session(data, 'abc'))
+
+    def test_merge_session_appends_unknown_session(self):
+        data = reflection.empty_conversation()
+        data['sessions'].append(reflection.new_session('creative'))
+        session = reflection.new_session('creative')
+        session['sid'] = 'abc'
+
+        merged = reflection.merge_session(data, session)
+        self.assertEqual(len(merged['sessions']), 2)
+        self.assertIs(merged['sessions'][-1], session)
+        # the original structure is untouched
+        self.assertEqual(len(data['sessions']), 1)
+
+    def test_merge_session_replaces_stale_copy_with_same_sid(self):
+        stale = reflection.new_session('creative')
+        stale['sid'] = 'abc'
+        reflection.add_turn(stale, reflection.ROLE_JO, 'Opener?')
+
+        data = reflection.empty_conversation()
+        data['sessions'].append(stale)
+
+        fresh = dict(stale)
+        fresh['turns'] = list(stale['turns'])
+        reflection.add_turn(fresh, reflection.ROLE_CHILD, 'An answer')
+
+        merged = reflection.merge_session(data, fresh)
+        self.assertEqual(len(merged['sessions']), 1)
+        self.assertIs(merged['sessions'][0], fresh)
+        self.assertEqual(len(merged['sessions'][0]['turns']), 2)
+
+    def test_merge_session_without_sid_appends(self):
+        data = reflection.empty_conversation()
+        data['sessions'].append(reflection.new_session('creative'))
+        merged = reflection.merge_session(data, reflection.new_session('game'))
+        self.assertEqual(len(merged['sessions']), 2)
+
+    def test_has_kept_line_matches_whole_lines_only(self):
+        description = 'first line\nThe tricky part\nlast'
+        self.assertTrue(
+            reflection.has_kept_line(description, 'The tricky part'))
+        self.assertFalse(reflection.has_kept_line(description, 'tricky'))
+        self.assertFalse(reflection.has_kept_line('', 'The tricky part'))
+        self.assertFalse(reflection.has_kept_line(None, 'The tricky part'))
+
+    # --- Conversation model: size budget and eviction ---
+
+    def test_dumps_stays_under_budget_and_evicts_oldest_first(self):
+        data = reflection.empty_conversation()
+        for i in range(40):
+            session = reflection.new_session('creative_spiral')
+            reflection.add_turn(session, reflection.ROLE_JO,
+                                'marker SESSION-%d ' % i + ('x' * 3000))
+            data['sessions'].append(session)
+
+        raw_size = len(json.dumps(data).encode('utf-8'))
+        self.assertGreater(raw_size, reflection.MAX_REFLECTIONS_BYTES)
+
+        text = reflection.dumps(data)
+        encoded = text.encode('utf-8')
+        self.assertLessEqual(len(encoded), reflection.MAX_REFLECTIONS_BYTES)
+
+        self.assertIn('SESSION-39', text)
+        self.assertNotIn('SESSION-0', text)
+
+        reloaded = reflection.loads(text)
+        self.assertTrue(
+            reloaded['sessions'][-1]['turns'][0]['text'].startswith(
+                'marker SESSION-39'))
+
+    def test_dumps_never_evicts_the_last_remaining_session(self):
+        data = reflection.empty_conversation()
+        session = reflection.new_session('creative_spiral')
+        reflection.add_turn(session, reflection.ROLE_JO, 'x' * 200000)
+        data['sessions'].append(session)
+
+        text = reflection.dumps(data)
+        reloaded = reflection.loads(text)
+        self.assertEqual(len(reloaded['sessions']), 1)
+
+    def test_dumps_does_not_mutate_input(self):
+        data = reflection.empty_conversation()
+        for i in range(40):
+            session = reflection.new_session('creative_spiral')
+            reflection.add_turn(session, reflection.ROLE_JO, 'x' * 3000)
+            data['sessions'].append(session)
+
+        before = len(data['sessions'])
+        reflection.dumps(data)
+        self.assertEqual(len(data['sessions']), before)
+
+
+class TestFloorBank(unittest.TestCase):
+
+    # --- Offline floor bank ---
+
+    def test_floor_bank_covers_every_category_with_unique_questions(self):
+        for category in reflection.CATEGORY_BUNDLES:
+            bank = reflection.FLOOR_BANK[category]
+            self.assertGreaterEqual(len(bank), 2)
+            self.assertEqual(len(set(bank)), len(bank))
+        self.assertGreaterEqual(len(reflection.DEFAULT_FLOOR_BANK), 2)
+
+    def test_floor_question_first_ask_returns_bank_head(self):
+        for category, bundles in reflection.CATEGORY_BUNDLES.items():
+            question = reflection.floor_question(bundles[0])
+            self.assertEqual(question, reflection.FLOOR_BANK[category][0])
+
+    def test_floor_question_unknown_bundle_uses_default_bank(self):
+        question = reflection.floor_question('org.example.NeverHeardOfIt')
+        self.assertEqual(question, reflection.DEFAULT_FLOOR_BANK[0])
+
+    def test_floor_question_skips_used_questions(self):
+        bank = reflection.FLOOR_BANK['creative']
+        question = reflection.floor_question(
+            'org.laptop.TurtleArtActivity', used={bank[0]})
+        self.assertEqual(question, bank[1])
+
+    def test_floor_question_dry_bank_returns_none(self):
+        bank = reflection.FLOOR_BANK['programming']
+        question = reflection.floor_question(
+            'org.laptop.PippyActivity', used=set(bank))
+        self.assertIsNone(question)
+
+    def test_used_floor_questions_collects_jo_floor_turns_across_sessions(
+            self):
+        bank = reflection.FLOOR_BANK['creative']
+        data = reflection.empty_conversation()
+
+        first = reflection.new_session('creative_spiral')
+        reflection.add_turn(first, reflection.ROLE_JO, bank[0])
+        reflection.add_turn(first, reflection.ROLE_CHILD, 'a rocket')
+        data['sessions'].append(first)
+
+        second = reflection.new_session('creative_spiral')
+        reflection.add_turn(second, reflection.ROLE_JO,
+                            'What color is the rocket?')
+        data['sessions'].append(second)
+
+        used = reflection.used_floor_questions(data)
+        self.assertIn(bank[0], used)
+        self.assertNotIn('a rocket', used)
+        self.assertNotIn('What color is the rocket?', used)
+
+    def test_used_floor_questions_includes_current_turns(self):
+        bank = reflection.FLOOR_BANK['creative']
+        turns = [{'role': reflection.ROLE_JO, 'text': bank[1]}]
+        used = reflection.used_floor_questions(None, turns)
+        self.assertEqual(used, {bank[1]})
+
+    def test_get_category_defaults_unknown_bundle_to_creative(self):
+        self.assertEqual(
+            reflection.get_category('org.example.NeverHeardOfIt'), 'creative')
+
+    def test_floor_question_beside_visible_work_swaps_opener_only(self):
+        bank = reflection.FLOOR_BANK['creative']
+        variant = reflection.VISIBLE_WORK_OPENERS[bank[0]]
+        self.assertEqual(reflection.floor_question(
+            'org.laptop.TurtleArtActivity', artifact_visible=True), variant)
+        self.assertEqual(reflection.floor_question(
+            'org.laptop.TurtleArtActivity', used={variant},
+            artifact_visible=True), bank[1])
+
+    def test_floor_question_either_opener_form_spends_the_opener(self):
+        bank = reflection.FLOOR_BANK['creative']
+        variant = reflection.VISIBLE_WORK_OPENERS[bank[0]]
+        self.assertEqual(reflection.floor_question(
+            'org.laptop.TurtleArtActivity', used={bank[0]},
+            artifact_visible=True), bank[1])
+        self.assertEqual(reflection.floor_question(
+            'org.laptop.TurtleArtActivity', used={variant}), bank[1])
+
+    def test_used_floor_questions_counts_opener_variants(self):
+        bank = reflection.FLOOR_BANK['creative']
+        variant = reflection.VISIBLE_WORK_OPENERS[bank[0]]
+        turns = [{'role': reflection.ROLE_JO, 'text': variant}]
+        self.assertIn(variant, reflection.used_floor_questions(None, turns))
+
+    def test_state_flags_round_trip(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        tmp_path = pathlib.Path(tmp_dir.name)
+        path = str(tmp_path / 'reflection-state.json')
+        self.assertFalse(reflection.state_flag('intro', path=path))
+        reflection.mark_state('intro', path=path)
+        self.assertTrue(reflection.state_flag('intro', path=path))
+        self.assertFalse(reflection.state_flag('keep_hint', path=path))
+
+    def test_state_flag_tolerates_garbage_file(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        tmp_path = pathlib.Path(tmp_dir.name)
+        path = str(tmp_path / 'reflection-state.json')
+        with open(path, 'w') as f:
+            f.write('not json')
+        self.assertFalse(reflection.state_flag('intro', path=path))
+        reflection.mark_state('intro', path=path)
+        self.assertTrue(reflection.state_flag('intro', path=path))
+
+
+class TestKeepDescription(unittest.TestCase):
+
+    # --- keep-this: description append/remove ---
+
+    def test_keep_in_description_starts_empty_description(self):
+        self.assertEqual(
+            reflection.keep_in_description('', 'The dragon wing.'),
+            'The dragon wing.')
+
+    def test_keep_in_description_appends_on_new_line(self):
+        result = reflection.keep_in_description('My painting.',
+                                                'The dragon wing.')
+        self.assertEqual(result, 'My painting.\nThe dragon wing.')
+
+    def test_unkeep_restores_previous_description(self):
+        kept = reflection.keep_in_description('My painting.',
+                                              'The dragon wing.')
+        self.assertEqual(reflection.unkeep_from_description(
+            kept, 'The dragon wing.'), 'My painting.')
+
+    def test_unkeep_round_trip_from_empty(self):
+        kept = reflection.keep_in_description('', 'The dragon wing.')
+        self.assertEqual(reflection.unkeep_from_description(
+            kept, 'The dragon wing.'), '')
+
+    def test_unkeep_leaves_description_alone_when_line_was_edited(self):
+        edited = 'My painting.\nThe dragon wing, done three times.'
+        self.assertEqual(reflection.unkeep_from_description(
+            edited, 'The dragon wing.'), edited)
+
+    def test_unkeep_removes_only_the_last_matching_line(self):
+        description = 'it flies\nmore words\nit flies'
+        self.assertEqual(
+            reflection.unkeep_from_description(description, 'it flies'),
+            'it flies\nmore words')
+
+
+class TestHttpClient(unittest.TestCase):
+
+    # --- HTTP client: _post_json ---
+
+    # --- request_turn: end-to-end client behavior + identity contract ---
+
+    # --- Identity contract ---
+
+    # --- turn_acceptable: the shape contract on Jo's own voice ---
+
+    def test_turn_acceptable_plain_question(self):
+        self.assertTrue(reflection.turn_acceptable('What part took longest?'))
+
+    def test_turn_acceptable_warm_lead_in_passes(self):
+        self.assertTrue(reflection.turn_acceptable(
+            'That sounds tricky. What did you try next?'))
+
+    def test_turn_acceptable_rejects_statement(self):
+        self.assertFalse(
+            reflection.turn_acceptable('Great job on your project.'))
+
+    def test_turn_acceptable_rejects_list_shapes(self):
+        self.assertFalse(reflection.turn_acceptable(
+            'Here are some ideas: try one, then another?'))
+        self.assertFalse(
+            reflection.turn_acceptable('First - do this, then that?'))
+        self.assertFalse(
+            reflection.turn_acceptable('One thing.\nAnother thing?'))
+
+    def test_turn_acceptable_rejects_lecture_length(self):
+        self.assertFalse(reflection.turn_acceptable(
+            'The key to getting the most out of a reflection conversation '
+            'is to think deeply about the process you followed and what '
+            'you might change next time, right?'))
+
+    def test_turn_acceptable_rejects_question_pile(self):
+        self.assertFalse(reflection.turn_acceptable(
+            'What is it? How did you make it? What comes next?'))
+
+def _held_data(last_role, text='make the middle rounder', ts=1000):
+    return {'sessions': [{'ts': ts, 'turns': [
+        {'role': 'jo', 'text': 'What next?'},
+        {'role': last_role, 'text': text},
+    ]}]}
+
+
+def _turns(*texts):
+    turns = []
+    for text in texts:
+        turns.append({'role': 'jo', 'text': 'q?'})
+        turns.append({'role': 'child', 'text': text})
+    return turns
+
+
+class TestEngagementSignals(unittest.TestCase):
+
+    # --- feed_forward_due: 'last time' needs real time away ---
+
+    def test_feed_forward_due_empty_history(self):
+        self.assertTrue(
+            reflection.feed_forward_due({'sessions': []}, now=1000000))
+
+    def test_feed_forward_due_blocks_fresh_session(self):
+        data = {'sessions': [{'ts': 1000, 'turns': []}]}
+        self.assertFalse(reflection.feed_forward_due(data, now=1000 + 60))
+        self.assertTrue(reflection.feed_forward_due(
+            data, now=1000 + reflection.FEED_FORWARD_GAP + 1))
+
+    def test_latest_session_ts_ignores_garbage(self):
+        data = {'sessions': [{'ts': 'soon'}, {'ts': 500}, {}]}
+        self.assertEqual(reflection.latest_session_ts(data), 500)
+
+    # --- held reply: a bookmark, never a stuck message ---
+
+    def test_clip_line_trims_at_word_boundary(self):
+        text = 'the dragon lived under my bed and it only ate socks at night'
+        clipped = reflection.clip_line(text, 30)
+        self.assertTrue(clipped.endswith('…'))
+        self.assertFalse(clipped[:-1].endswith(' '))
+        self.assertLessEqual(len(clipped), 31)
+
+
+# Any request_turn test that walks a warm child through the floor
+# path must pin reflection.random - the midflow rolls on every warm
+# floor turn.
+WARM_TURNS = [
+    {'role': 'jo', 'text': 'What was tricky about this one?'},
+    {'role': 'child', 'text': 'the tower kept falling over'},
+    {'role': 'jo', 'text': 'How did you sort that out?'},
+    {'role': 'child', 'text': 'I made the base a lot wider'},
+]
+
+
+class TestQuestionBanks(unittest.TestCase):
+
+    # --- kept lines and the once-per-artifact question banks ---
+
+    def test_kept_lines_newest_first_with_limit(self):
+        description = 'first kept\nsecond kept'
+        raw = json.dumps({'sessions': [
+            {'turns': [{'role': 'child', 'text': 'first kept'}]},
+            {'turns': [{'role': 'child', 'text': 'second kept'},
+                       {'role': 'child', 'text': 'never kept'}]},
+        ]})
+        self.assertEqual(reflection.kept_lines(raw, description), [
+            'second kept', 'first kept'])
+        self.assertEqual(reflection.kept_lines(raw, description, limit=1), [
+            'second kept'])
+
+    def test_total_turns_counts_across_sessions(self):
+        raw = json.dumps({'sessions': [
+            {'turns': [{'role': 'jo', 'text': 'a?'}]},
+            {'turns': [{'role': 'child', 'text': 'b'},
+                       {'role': 'jo', 'text': 'c?'}]},
+        ]})
+        self.assertEqual(reflection.total_turns(raw), 3)
+        self.assertEqual(reflection.total_turns(''), 0)
+        self.assertEqual(reflection.total_turns('garbage'), 0)
+
+    def test_has_buddies_requires_a_real_roster(self):
+        self.assertFalse(reflection.has_buddies({}))
+        self.assertFalse(reflection.has_buddies({'buddies': ''}))
+        self.assertFalse(reflection.has_buddies({'buddies': '{}'}))
+        self.assertFalse(reflection.has_buddies({'buddies': 'garbage'}))
+        self.assertFalse(reflection.has_buddies({'buddies': '["nick"]'}))
+        roster = json.dumps({'abc123': ['Maya', '#FF0000,#00FF00']})
+        self.assertTrue(reflection.has_buddies({'buddies': roster}))
+
+    def test_together_question_spends_once(self):
+        roster = json.dumps({'abc123': ['Maya', '#FF0000,#00FF00']})
+        metadata = {'buddies': roster}
+        first = reflection.together_question(metadata)
+        self.assertEqual(first, reflection.TOGETHER_OPENER)
+        self.assertIsNone(reflection.together_question(metadata, used={first}))
+        self.assertIsNone(reflection.together_question({}))
+
+    def test_together_opener_counts_as_used_floor_question(self):
+        conversation = {'sessions': [{'turns': [
+            {'role': 'jo', 'text': reflection.TOGETHER_OPENER}]}]}
+        used = reflection.used_floor_questions(conversation)
+        self.assertIn(reflection.TOGETHER_OPENER, used)
+
+    def test_nearby_nudge_spends_once(self):
+        first = reflection.nearby_nudge()
+        self.assertEqual(first, reflection.NEARBY_NUDGE)
+        self.assertIsNone(reflection.nearby_nudge(used={first}))
+
+    def test_nearby_followup_waits_for_the_nudge(self):
+        self.assertIsNone(reflection.nearby_followup())
+        self.assertEqual(reflection.nearby_followup(
+            used={reflection.NEARBY_NUDGE}), reflection.NEARBY_FOLLOWUP)
+        self.assertIsNone(reflection.nearby_followup(
+            used={reflection.NEARBY_NUDGE,
+                  reflection.NEARBY_FOLLOWUP}))
+
+    def test_nearby_questions_count_as_used_floor_questions(self):
+        conversation = {'sessions': [{'turns': [
+            {'role': 'jo', 'text': reflection.NEARBY_NUDGE},
+            {'role': 'jo', 'text': reflection.NEARBY_MIDFLOW},
+            {'role': 'jo', 'text': reflection.NEARBY_FOLLOWUP}]}]}
+        used = reflection.used_floor_questions(conversation)
+        self.assertIn(reflection.NEARBY_NUDGE, used)
+        self.assertIn(reflection.NEARBY_MIDFLOW, used)
+        self.assertIn(reflection.NEARBY_FOLLOWUP, used)
+
+    def test_nearby_questions_read_like_jo(self):
+        self.assertTrue(reflection.turn_acceptable(reflection.NEARBY_NUDGE))
+        self.assertTrue(reflection.turn_acceptable(reflection.NEARBY_MIDFLOW))
+        self.assertTrue(reflection.turn_acceptable(reflection.NEARBY_FOLLOWUP))
+
+    def test_midflow_lands_only_on_a_warm_lucky_turn(self):
+        self.assertEqual(reflection.nearby_midflow(
+            turns=WARM_TURNS, roll=0.0), reflection.NEARBY_MIDFLOW)
+        self.assertIsNone(
+            reflection.nearby_midflow(turns=WARM_TURNS, roll=0.9))
+        self.assertIsNone(reflection.nearby_midflow(turns=(), roll=0.0))
+
+    def test_midflow_roll_boundary_is_exclusive(self):
+        # roll >= NEARBY_MIDFLOW_CHANCE misses; the code's ">=" excludes
+        # the chance value itself, not just values above it.
+        self.assertIsNone(reflection.nearby_midflow(
+            turns=WARM_TURNS,
+            roll=reflection.NEARBY_MIDFLOW_CHANCE))
+        self.assertEqual(
+            reflection.nearby_midflow(
+                turns=WARM_TURNS,
+                roll=reflection.NEARBY_MIDFLOW_CHANCE - 1e-9),
+            reflection.NEARBY_MIDFLOW)
+
+    def test_any_child_reply_warms_the_midflow(self):
+        turns = [
+            {'role': 'jo', 'text': 'What was tricky about this one?'},
+            {'role': 'child', 'text': 'ok'},
+        ]
+        self.assertEqual(reflection.nearby_midflow(
+            turns=turns, roll=0.0), reflection.NEARBY_MIDFLOW)
+
+    def test_midflow_shares_the_one_nearby_slot(self):
+        self.assertIsNone(reflection.nearby_midflow(
+            used={reflection.NEARBY_NUDGE}, turns=WARM_TURNS, roll=0.0))
+        self.assertIsNone(reflection.nearby_midflow(
+            used={reflection.NEARBY_MIDFLOW}, turns=WARM_TURNS,
+            roll=0.0))
+        self.assertIsNone(reflection.nearby_nudge(
+            used={reflection.NEARBY_MIDFLOW}))
+        self.assertEqual(reflection.nearby_followup(
+            used={reflection.NEARBY_MIDFLOW}), reflection.NEARBY_FOLLOWUP)
+
+    def test_followup_waits_for_real_time_away(self):
+        used = {reflection.NEARBY_MIDFLOW}
+        fresh = {'sessions': [{'ts': 10000, 'turns': []}]}
+        self.assertIsNone(reflection.nearby_followup(used, fresh, now=10060))
+        self.assertEqual(
+            reflection.nearby_followup(
+                used, fresh,
+                now=10000 + reflection.FEED_FORWARD_GAP + 1),
+            reflection.NEARBY_FOLLOWUP)
+
+    def test_strip_private_drops_talk_and_snaps_only(self):
+        metadata = {'reflections': '{"sessions": []}', 'next_steps': 'x',
+                    'moment-snap-0': 'AAAA', 'moment-snap-12': 'BBBB',
+                    'title': 'Spiral', 'description': 'kept line',
+                    'comments': '[]', 'buddies': '{}'}
+        reflection.strip_private(metadata)
+        self.assertEqual(
+            metadata,
+            {'title': 'Spiral', 'description': 'kept line',
+             'comments': '[]', 'buddies': '{}'})
+
+
+def _comment(who, message):
+    return {'from': who, 'message': message,
+            'icon': 'computer-xo', 'icon-color': '#FF2B34,#005FE4'}
+
+
+class TestPeerQuestions(unittest.TestCase):
+
+    # --- peer questions: the comments box reaches the talk ---
+
+    def test_peer_question_voices_a_question_shaped_comment(self):
+        raw = json.dumps(
+            [_comment('Ana', 'How did you make the roof stay up?')])
+        text = reflection.peer_question(raw)
+        self.assertEqual(text, reflection.PEER_QUESTION_OPENER % {
+            'who': 'Ana', 'question': 'How did you make the roof stay up?'})
+
+    def test_peer_question_skips_judgements_for_the_next_question(self):
+        raw = json.dumps([_comment('Ana', 'this is bad'),
+                          _comment('Ben', 'What does the red button do?')])
+        text = reflection.peer_question(raw)
+        self.assertIn('What does the red button do?', text)
+        self.assertNotIn('bad', text)
+
+    def test_peer_question_is_voiced_once(self):
+        raw = json.dumps([_comment('Ana', 'What is it made of?')])
+        first = reflection.peer_question(raw)
+        self.assertIsNotNone(first)
+        self.assertIsNone(reflection.peer_question(raw, spoken={first}))
+
+    def test_peer_question_moves_to_the_next_unvoiced_comment(self):
+        raw = json.dumps([_comment('Ana', 'What is it made of?'),
+                          _comment('Ben', 'Why is it green?')])
+        first = reflection.peer_question(raw)
+        second = reflection.peer_question(raw, spoken={first})
+        self.assertIn('Why is it green?', second)
+
+    def test_peer_question_anonymous_without_from(self):
+        raw = json.dumps([{'message': 'Why is it green?'}])
+        text = reflection.peer_question(raw)
+        self.assertEqual(text, reflection.PEER_QUESTION_ANON % {
+            'question': 'Why is it green?'})
+
+    def test_peer_question_tolerates_garbage(self):
+        self.assertIsNone(reflection.peer_question(''))
+        self.assertIsNone(reflection.peer_question('not json'))
+        self.assertIsNone(reflection.peer_question('{"a": 1}'))
+        self.assertIsNone(reflection.peer_question(json.dumps(['x', 3])))
+        self.assertIsNone(reflection.peer_question(
+            json.dumps([{'from': 'Ana'}])))
+
+    def test_add_turn_keeps_ordinary_turns_flag_free(self):
+        session = reflection.new_session('creative')
+        reflection.add_turn(session, reflection.ROLE_JO, 'q')
+        reflection.add_turn(session, reflection.ROLE_JO, 'p', peer=True)
+        self.assertNotIn('peer', session['turns'][0])
+        self.assertIs(session['turns'][1]['peer'], True)
+
+    def test_jo_texts_collects_saved_and_current_turns(self):
+        data = reflection.empty_conversation()
+        session = reflection.new_session('creative')
+        reflection.add_turn(session, reflection.ROLE_JO, 'old line')
+        reflection.add_turn(session, reflection.ROLE_CHILD, 'kid line')
+        data['sessions'].append(session)
+        texts = reflection.jo_texts(
+            data, [{'role': 'jo', 'text': 'new line'},
+                   {'role': 'child', 'text': 'another kid line'}])
+        self.assertEqual(texts, {'old line', 'new line'})
+
+    def test_peer_question_tolerates_wrong_typed_values(self):
+        self.assertIsNone(reflection.peer_question(
+            json.dumps([{'from': 'Ana', 'message': 5}])))
+        self.assertIsNone(reflection.peer_question(
+            json.dumps([{'from': 'Ana', 'message': {'x': 1}}])))
+        text = reflection.peer_question(
+            json.dumps([{'from': 7, 'message': 'What is it?'}]))
+        self.assertEqual(text, reflection.PEER_QUESTION_ANON % {
+            'question': 'What is it?'})
+
+    def test_peer_question_drops_an_unwearable_name(self):
+        long_name = 'A' * 200
+        text = reflection.peer_question(
+            json.dumps([{'from': long_name, 'message': 'What is it?'}]))
+        self.assertEqual(text, reflection.PEER_QUESTION_ANON % {
+            'question': 'What is it?'})
+        self.assertNotIn(long_name, text)
+        sneaky = reflection.peer_question(
+            json.dumps([{'from': 'Ana\nBen', 'message': 'What is it?'}]))
+        self.assertEqual(sneaky, reflection.PEER_QUESTION_ANON % {
+            'question': 'What is it?'})
+
+    def test_peer_question_rejects_control_and_format_characters(self):
+        self.assertIsNone(reflection.peer_question(
+            json.dumps([{'from': 'Ana',
+                         'message': 'line one\rline two?'}])))
+        self.assertIsNone(reflection.peer_question(
+            json.dumps([{'from': 'Ana',
+                         'message': '‮evil?'}])))
+        self.assertIsNone(reflection.peer_question(
+            json.dumps([{'from': 'Ana',
+                         'message': 'one two?'}])))
+
+
+class TestConversationSync(unittest.TestCase):
+
+    # --- one question at a time / note quotes intentions only ---
+
+    def test_hanging_question_returns_the_unanswered_closer(self):
+        data = reflection.empty_conversation()
+        session = reflection.new_session('creative')
+        reflection.add_turn(session, reflection.ROLE_JO, 'What next?')
+        data['sessions'].append(session)
+        self.assertEqual(reflection.hanging_question(data), 'What next?')
+
+    def test_hanging_question_none_after_an_answer(self):
+        data = reflection.empty_conversation()
+        session = reflection.new_session('creative')
+        reflection.add_turn(session, reflection.ROLE_JO, 'What next?')
+        reflection.add_turn(session, reflection.ROLE_CHILD, 'more fire')
+        data['sessions'].append(session)
+        self.assertIsNone(reflection.hanging_question(data))
+
+    def test_hanging_question_ignores_non_questions(self):
+        data = reflection.empty_conversation()
+        session = reflection.new_session('creative')
+        reflection.add_turn(session, reflection.ROLE_JO,
+                            'Thanks for telling me about this.')
+        data['sessions'].append(session)
+        self.assertIsNone(reflection.hanging_question(data))
+
+    def test_hanging_question_catches_a_voiced_peer_question(self):
+        voiced = reflection.PEER_QUESTION_OPENER % {
+            'who': 'Ana', 'question': 'How did you make the rockit fly?'}
+        data = reflection.empty_conversation()
+        session = reflection.new_session('creative')
+        reflection.add_turn(session, reflection.ROLE_JO, voiced, peer=True)
+        data['sessions'].append(session)
+        self.assertEqual(reflection.hanging_question(data), voiced)
+
+    def test_hanging_question_none_on_empty_record(self):
+        self.assertIsNone(reflection.hanging_question(
+            reflection.empty_conversation()))
+        data = reflection.empty_conversation()
+        data['sessions'].append(reflection.new_session('creative'))
+        self.assertIsNone(reflection.hanging_question(data))
+
+    def test_merge_for_write_starts_from_the_store_state(self):
+        ours = {'ts': 5, 'sid': 'abc', 'turns': [
+            {'role': 'jo', 'text': 'q?'}, {'role': 'child', 'text': 'a'}]}
+        fresh = json.dumps({'sessions': [
+            {'ts': 3, 'sid': 'zzz', 'turns': [{'role': 'jo', 'text': 'x?'}]}]})
+        merged = reflection.merge_sessions_for_write(fresh, [ours])
+        self.assertEqual(
+            [s.get('sid') for s in merged['sessions']], ['zzz', 'abc'])
+
+    def test_merge_for_write_restores_into_a_clobbered_store(self):
+        ours = {'ts': 5, 'sid': 'abc', 'turns': [
+            {'role': 'jo', 'text': 'q?'}, {'role': 'child', 'text': 'a'}]}
+        merged = reflection.merge_sessions_for_write('', [ours])
+        self.assertEqual(merged['sessions'], [ours])
+
+    def test_merge_for_write_bigger_copy_of_a_session_wins(self):
+        small = {
+            'ts': 5, 'sid': 'abc', 'turns': [{'role': 'jo', 'text': 'q?'}]}
+        big = {'ts': 5, 'sid': 'abc', 'turns': [
+            {'role': 'jo', 'text': 'q?'}, {'role': 'child', 'text': 'a'},
+            {'role': 'jo', 'text': 'and?'}]}
+        fresh = json.dumps({'sessions': [big]})
+        merged = reflection.merge_sessions_for_write(fresh, [small])
+        self.assertEqual(merged['sessions'], [big])
+        fresh = json.dumps({'sessions': [small]})
+        merged = reflection.merge_sessions_for_write(fresh, [big])
+        self.assertEqual(merged['sessions'], [big])
+
+    def test_merge_for_write_matches_legacy_sessions_by_ts(self):
+        theirs = {'ts': 7, 'turns': [{'role': 'jo', 'text': 'q?'}]}
+        ours = {'ts': 7, 'turns': [
+            {'role': 'jo', 'text': 'q?'}, {'role': 'child', 'text': 'a'}]}
+        fresh = json.dumps({'sessions': [theirs]})
+        merged = reflection.merge_sessions_for_write(fresh, [ours])
+        self.assertEqual(merged['sessions'], [ours])
+
+    def test_merge_for_write_orders_sessions_by_ts(self):
+        late = {'ts': 9, 'sid': 'b', 'turns': [{'role': 'child', 'text': 'y'}]}
+        early = {
+            'ts': 2, 'sid': 'a', 'turns': [{'role': 'child', 'text': 'x'}]}
+        merged = reflection.merge_sessions_for_write(
+            json.dumps({'sessions': [late]}), [early])
+        self.assertEqual([s['sid'] for s in merged['sessions']], ['a', 'b'])
+
+
+class TestQuestionIds(unittest.TestCase):
+
+    # --- stable ids: bookkeeping that survives a locale switch ---
+
+    def test_add_turn_stamps_known_questions(self):
+        session = reflection.new_session('creative_spiral')
+        reflection.add_turn(session, reflection.ROLE_JO,
+                            reflection.FLOOR_BANK['creative'][0])
+        self.assertEqual(session['turns'][0]['q'], 'floor:creative:0')
+
+    def test_add_turn_leaves_free_text_unstamped(self):
+        session = reflection.new_session('creative_spiral')
+        reflection.add_turn(session, reflection.ROLE_JO, 'A server line?')
+        reflection.add_turn(session, reflection.ROLE_CHILD,
+                            reflection.FLOOR_BANK['creative'][0])
+        self.assertNotIn('q', session['turns'][0])
+        self.assertNotIn('q', session['turns'][1])
+
+    def test_opener_and_variant_share_one_slot(self):
+        plain = reflection.FLOOR_BANK['creative'][0]
+        beside = reflection.VISIBLE_WORK_OPENERS[plain]
+        session = reflection.new_session('creative_spiral')
+        reflection.add_turn(session, reflection.ROLE_JO, beside)
+        used = reflection.used_floor_questions(
+            None, session['turns'])
+        self.assertNotEqual(reflection.floor_question(
+            'org.laptop.TurtleArtActivity', used), plain)
+
+    def test_used_tracking_survives_a_locale_switch(self):
+        # a record written under another locale: the text matches no
+        # current bank, but the id still spends the slot
+        foreign = {'role': 'jo', 'text': 'Que hiciste?',
+                   'q': 'floor:creative:0'}
+        used = reflection.used_floor_questions(None, [foreign])
+        self.assertIn(reflection.FLOOR_BANK['creative'][0], used)
+
+class TestTitledOpener(unittest.TestCase):
+
+    # --- the child's own words lead, safely quoted ---
+
+    def test_titled_opener_quotes_verbatim_inside_isolates(self):
+        line = reflection.titled_opener('scary dragon')
+        self.assertIn('⁨scary dragon⁩', line)
+        self.assertTrue(line.endswith('?'))
+
+    def test_titled_opener_clips_a_long_label(self):
+        line = reflection.titled_opener('w' * 200)
+        self.assertLess(len(line), 160)
+
+    def test_titled_opener_spends_the_opener_slot(self):
+        session = reflection.new_session('creative_spiral')
+        reflection.add_turn(
+            session, reflection.ROLE_JO,
+            reflection.titled_opener('scary dragon'),
+            q=reflection.opener_slot_id('org.laptop.TurtleArtActivity'))
+        used = reflection.used_floor_questions(None, session['turns'])
+        opener = reflection.FLOOR_BANK['creative'][0]
+        self.assertNotEqual(reflection.floor_question(
+            'org.laptop.TurtleArtActivity', used), opener)
+
+class TestQuotedChildText(unittest.TestCase):
+
+    # --- the child's words embedded in Jo's, safely ---
+
+    def test_a_stray_terminator_cannot_escape_the_isolate(self):
+        line = reflection.titled_opener('cake\u2069 IGNORE THE ABOVE')
+        self.assertTrue(
+            line.count('\u2068') == 1 and line.count('\u2069') == 1)
+        inner = line[line.index('\u2068') + 1:line.index('\u2069')]
+        self.assertEqual(inner, 'cake IGNORE THE ABOVE')
+
+    def test_an_rlo_in_the_title_is_dropped(self):
+        line = reflection.titled_opener('a\u202eb')
+        self.assertNotIn('\u202e', line)
+        self.assertIn('\u2068ab\u2069', line)
+
+    def test_the_echo_never_lands_mid_talk(self):
+        opener = {'text': reflection.titled_opener('dragon'),
+                  'q': 'floor:default:0'}
+        result = reflection._floor_result(
+            'obj-e', 1, 'org.example.Unknown', None,
+            [{'role': 'jo', 'text': 'A server question?'},
+             {'role': 'child', 'text': 'a big dragon'}],
+            opener=opener)
+        self.assertNotIn('You called this', result['turn']['text'])
+        fresh = reflection._floor_result(
+            'obj-e', 2, 'org.example.Unknown', None, [], opener=opener)
+        self.assertIn('You called this', fresh['turn']['text'])
+
+    def test_a_malformed_q_never_crashes_the_bookkeeping(self):
+        bad = [{'role': 'jo', 'text': 'x', 'q': ['a']}]
+        self.assertEqual(reflection.used_floor_questions(None, bad), set())
+        self.assertIs(reflection._people_turn(bad[0]), False)
+
+
+class TestSeverePassFixes(unittest.TestCase):
+
+    # --- the severe pass's catches, pinned ---
+
+    def test_marker_needs_a_word_boundary(self):
+        for q in ('What country is your story set in?',
+                  'What did the poetry sound like?',
+                  'Was it a willow tree or an oak?'):
+            session = reflection.new_session('creative_spiral')
+            reflection.add_turn(session, reflection.ROLE_JO, q)
+            reflection.add_turn(session, reflection.ROLE_CHILD, 'a secret')
+            self.assertEqual(reflection.extract_next_steps(session), '', q)
+
+    def test_a_server_session_retires_an_unrenewed_note(self):
+        session = reflection.new_session('creative_spiral')
+        reflection.add_turn(session, reflection.ROLE_JO,
+                            'What was the best part?')
+        reflection.add_turn(session, reflection.ROLE_CHILD, 'the sky')
+        self.assertEqual(
+            reflection.resolve_next_steps(session, 'old note'), '')
+
+    def test_an_offline_session_leaves_the_note_alone(self):
+        session = reflection.new_session('creative_spiral')
+        reflection.add_turn(session, reflection.ROLE_JO,
+                            reflection.FLOOR_BANK['creative'][0])
+        reflection.add_turn(session, reflection.ROLE_CHILD, 'the sky')
+        self.assertEqual(reflection.resolve_next_steps(
+            session, 'old note'), 'old note')
+
+    def test_the_intro_is_never_a_server_question(self):
+        session = reflection.new_session('creative_spiral')
+        reflection.add_turn(session, reflection.ROLE_JO,
+                            reflection.INTRO_LINE)
+        reflection.add_turn(session, reflection.ROLE_CHILD,
+                            'I will try a dragon')
+        self.assertEqual(reflection.extract_next_steps(session), '')
+        self.assertEqual(
+            reflection.resolve_next_steps(session, 'kept'), 'kept')
+
+    def test_a_corrupt_session_element_is_dropped(self):
+        raw = json.dumps({'version': 1, 'sessions': ['corrupt', {
+            'ts': 5, 'turns': [{'role': 'jo', 'text': 'q?'}]}]})
+        data = reflection.loads(raw)
+        self.assertEqual(len(data['sessions']), 1)
+        self.assertEqual(reflection.total_turns(raw), 1)
+        self.assertEqual(reflection.hanging_question(data), 'q?')
+
+    def test_count_turns_sees_past_eviction(self):
+        data = {'sessions': [
+            {'ts': 1, 'turns': [{'role': 'child', 'text': 'x' * 40000}]},
+            {'ts': 2, 'turns': [{'role': 'child', 'text': 'y' * 40000}]},
+        ]}
+        self.assertEqual(reflection.count_turns(data), 2)
+        survived = reflection.loads(reflection.dumps(data))
+        self.assertEqual(reflection.count_turns(survived), 1)
+
+    def test_greek_armenian_ethiopic_questions_pass(self):
+        self.assertTrue(reflection.turn_acceptable('Τι έφτιαξες;'))
+        self.assertTrue(reflection.turn_acceptable('Ինչ սարքեցիր՞'))
+        self.assertTrue(reflection.turn_acceptable('ምን ሠራህ፧'))
+        self.assertFalse(reflection.turn_acceptable('a statement;'))


### PR DESCRIPTION
Two commits:
1. reflection.py: the offline reflection engine: Jo's question banks, session storage, and the acceptance bar for turns.
2. model.strip_private: reflections, next_steps and moment snaps are cleared on writes to external volumes. In-place rewrites on the entry's own volume keep them (_rewrites_entry_in_place, eight tests); backups keep everything.

Independent of the view PRs; stacked on #1111 for ordering only.

- Jo's only memory: the opener may echo the entry title (child-typed) or the newest caption. Once, never mid-conversation.
- sugar-datastore PR (https://github.com/sugarlabs/sugar-datastore/pull/30) should land first, or reflection words
  become searchable in the Journal.
- request_turn's title/description/next_steps are unread offline: the seam for a later server layer.
- The category table and turn_acceptable overlap sugar-ai deliberately: zero third-party deps offline, and gettext strings reach translators.

221 journal tests (101 engine, 8 privacy); discovery needs the stack's tests/journal/__init__.py. 
New files in Makefile.am and POTFILES.in.
Series notes in #1111.