### PR TITLE
add the moment card and jo's place in the frame

### DIFF
--- a/data/icons/Makefile.am
+++ b/data/icons/Makefile.am
@@ -11,6 +11,7 @@ sugar_DATA =                        \
 	module-network.svg              \
 	module-power.svg                \
 	module-updater.svg		\
-	module-webaccount.svg
+	module-webaccount.svg           \
+	reflectjo.svg
 
 EXTRA_DIST = $(sugar_DATA)

--- a/data/icons/reflectjo.svg
+++ b/data/icons/reflectjo.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="75px" height="75px"
+    viewBox="0 0 75 75">
+  <!-- Jo the robot, frame chrome: white line-art like every
+       neighbouring glyph - the ember visor is the one light. -->
+  <circle cx="37.5" cy="9.2" r="4.2" fill="#FFFFFF"/>
+  <line x1="37.5" y1="13.4" x2="37.5" y2="18"
+      stroke="#FFFFFF" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M17.5,38 a20,20 0 0 1 40,0 v22
+           a4.8,4.8 0 0 1 -4.8,4.8 h-30.4
+           a4.8,4.8 0 0 1 -4.8,-4.8 z"
+      fill="#FFFFFF" stroke="#FFFFFF" stroke-width="3"/>
+  <rect x="23" y="33.5" width="29" height="13" rx="6.5"
+      fill="#E8A33D"/>
+  <circle cx="31" cy="40" r="3.2" fill="#FFFFFF"/>
+  <circle cx="44" cy="40" r="3.2" fill="#FFFFFF"/>
+  <path d="M29.5,55 C34.8,58.3 40.2,58.3 45.5,55" fill="none"
+      stroke="#E8A33D" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/extensions/deviceicon/Makefile.am
+++ b/extensions/deviceicon/Makefile.am
@@ -7,6 +7,7 @@ sugar_PYTHON = 		\
 	display.py	\
 	frame.py	\
 	network.py	\
+	reflectjo.py	\
 	speech.py	\
 	touchpad.py	\
 	volume.py

--- a/extensions/deviceicon/reflectjo.py
+++ b/extensions/deviceicon/reflectjo.py
@@ -1,0 +1,115 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Jo in the Frame: the trigger for in-activity reflection.
+
+A device icon that opens the moment card over the running activity.
+The card itself lives in jarabe.journal.momentcard and is imported
+lazily on tap, never at setup() time - devicestray swallows setup()
+exceptions, so a heavy import here could silently drop the whole icon.
+"""
+
+import logging
+from gettext import gettext as _
+
+from sugar3.graphics.palette import Palette
+from sugar3.graphics.palettemenu import PaletteMenuBox
+from sugar3.graphics.palettemenu import PaletteMenuItem
+from sugar3.graphics.tray import TrayIcon
+
+from jarabe.frame.frameinvoker import FrameWidgetInvoker
+from jarabe.model import shell
+import jarabe.frame
+
+
+class DeviceView(TrayIcon):
+
+    FRAME_POSITION_RELATIVE = 600
+
+    def __init__(self):
+        TrayIcon.__init__(self, icon_name='reflectjo')
+        self.set_palette_invoker(FrameWidgetInvoker(self))
+        self.connect('button-release-event', self.__button_release_event_cb)
+        self._panel = None
+        self._pending = False
+
+    def create_palette(self):
+        palette = Palette(_('Reflect with Jo'))
+        palette.props.secondary_text = _('Talk about your work')
+        box = PaletteMenuBox()
+        item = PaletteMenuItem(_('Open my Journal'), 'activity-journal')
+        item.connect('activate', self.__open_journal_cb)
+        box.append_item(item)
+        box.show_all()
+        palette.set_content(box)
+        palette.set_group_id('frame')
+        return palette
+
+    def __open_journal_cb(self, item):
+        jarabe.frame.get_view().hide()
+        self.__reveal_journal()
+
+    def __button_release_event_cb(self, widget, event):
+        if self._pending:
+            # A tap is already in flight; a fast second tap must not
+            # queue a second present.
+            return True
+        active = self.__active_activity()
+        if active is None or active.is_journal():
+            jarabe.frame.get_view().hide()
+            self.__reveal_journal()
+            return True
+        try:
+            from jarabe.journal.momentcard import MomentCard
+        except Exception:
+            logging.exception('reflectjo: could not open the moment card')
+            return True
+        if self._panel is None:
+            self._panel = MomentCard()
+        self._pending = True
+        event_time = event.time
+        # The card appears once the Frame has finished retracting, or
+        # the Frame would be frozen into the dimmed backdrop.
+        jarabe.frame.get_view().hide(
+            lambda: self.__present_cb(event_time))
+        return True
+
+    def __reveal_journal(self):
+        try:
+            from jarabe.journal import journalactivity
+            journal = journalactivity.get_journal()
+        except Exception:
+            logging.exception('reflectjo: could not open the Journal')
+            return
+        if journal is not None:
+            journal.reveal()
+
+    def __present_cb(self, event_time):
+        self._pending = False
+        active = self.__active_activity()
+        activity_id = active.get_activity_id() if active is not None \
+            else None
+        self._panel.present_over_activity(event_time, activity_id)
+
+    def __active_activity(self):
+        try:
+            return shell.get_model().get_active_activity()
+        except Exception:
+            logging.exception('reflectjo: could not read active activity')
+        return None
+
+
+def setup(tray):
+    tray.add_device(DeviceView())

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -73,6 +73,7 @@ src/jarabe/journal/listview.py
 src/jarabe/journal/misc.py
 src/jarabe/journal/model.py
 src/jarabe/journal/modalalert.py
+src/jarabe/journal/momentcard.py
 src/jarabe/journal/objectchooser.py
 src/jarabe/journal/palettes.py
 src/jarabe/journal/reflection.py

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -36,6 +36,7 @@ extensions/deviceicon/battery.py
 extensions/deviceicon/display.py
 extensions/deviceicon/frame.py
 extensions/deviceicon/network.py
+extensions/deviceicon/reflectjo.py
 extensions/deviceicon/speech.py
 extensions/deviceicon/touchpad.py
 extensions/deviceicon/volume.py

--- a/src/jarabe/frame/frame.py
+++ b/src/jarabe/frame/frame.py
@@ -103,8 +103,16 @@ class Frame(object):
         else:
             self.hide()
 
-    def hide(self):
+    def hide(self, hidden_cb=None):
+        """Retract the frame. If hidden_cb is given it is called once
+        the frame is actually gone (or immediately when it is already
+        hidden or already retracting), so callers can sequence on that
+        instead of guessing a delay. A show() partway through the
+        retract cancels the call rather than firing it early.
+        """
         if not self._wanted:
+            if hidden_cb is not None:
+                hidden_cb()
             return
 
         self._wanted = False
@@ -115,7 +123,16 @@ class Frame(object):
         palettegroup.popdown_all()
         self._animator = animator.Animator(0.5, widget=self._top_panel)
         self._animator.add(_Animation(self, 0.0))
+        if hidden_cb is not None:
+            self._animator.connect('completed', self.__hidden_cb, hidden_cb)
         self._animator.start()
+
+    def __hidden_cb(self, animator_, hidden_cb):
+        # Animator.stop() emits completed just as a finished run does,
+        # so a show() partway through the retract lands here with the
+        # frame on its way back up. Only report it gone if it is.
+        if not self._wanted:
+            hidden_cb()
 
     def show(self):
         if self._wanted:

--- a/src/jarabe/journal/Makefile.am
+++ b/src/jarabe/journal/Makefile.am
@@ -23,6 +23,7 @@ sugar_PYTHON =				\
 	timeline.py			\
 	palettes.py			\
 	joglyph.py			\
+	reflectguard.py			\
 	reflection.py			\
 	reflectstyle.py			\
 	volumestoolbar.py

--- a/src/jarabe/journal/Makefile.am
+++ b/src/jarabe/journal/Makefile.am
@@ -22,6 +22,7 @@ sugar_PYTHON =				\
 	projectview.py			\
 	timeline.py			\
 	palettes.py			\
+	joglyph.py			\
 	reflection.py			\
 	reflectstyle.py			\
 	volumestoolbar.py

--- a/src/jarabe/journal/Makefile.am
+++ b/src/jarabe/journal/Makefile.am
@@ -23,6 +23,7 @@ sugar_PYTHON =				\
 	timeline.py			\
 	palettes.py			\
 	joglyph.py			\
+	momentcard.py			\
 	reflectguard.py			\
 	reflection.py			\
 	reflectstyle.py			\

--- a/src/jarabe/journal/Makefile.am
+++ b/src/jarabe/journal/Makefile.am
@@ -23,4 +23,5 @@ sugar_PYTHON =				\
 	timeline.py			\
 	palettes.py			\
 	reflection.py			\
+	reflectstyle.py			\
 	volumestoolbar.py

--- a/src/jarabe/journal/joglyph.py
+++ b/src/jarabe/journal/joglyph.py
@@ -1,0 +1,224 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Jo's one face, shared by every surface.
+
+Jo is the little robot: an unpainted body on a quiet cool disc,
+wearing its one warm light as the visor. This module keeps the
+panel, the entry view, the tray and the invite drawing the same one.
+"""
+
+import math
+
+import cairo
+from gi.repository import Gdk
+from gi.repository import GLib
+from gi.repository import Gtk
+
+from jarabe.journal import reflectstyle
+
+# All geometry lives in the 75-unit box data/icons/reflectjo.svg uses.
+_VISOR_X = 37.5
+_VISOR_Y = 40.0
+_VISOR_W = 29.0
+_VISOR_H = 13.0
+_VISOR_ARC = 6.5
+_EYE_DX = 6.5
+_EYE_R = 3.2
+_GLOW_R = 26.0
+
+_BREATH_PERIOD_US = 2000000.0
+
+MOOD_RESTING = 'resting'
+MOOD_THINKING = 'thinking'
+MOOD_QUIET = 'quiet'
+
+_MOODS = {
+    # (ember scale, core alpha, glow alpha, room alpha, body alpha,
+    #  breathes, ghost rings)
+    MOOD_RESTING: (1.0, 0.95, 0.30, 1.0, 1.0, True, 0),
+    MOOD_THINKING: (1.12, 1.0, 0.42, 1.0, 1.0, False, 2),
+    MOOD_QUIET: (0.90, 0.95, 0.16, 0.35, 0.50, False, 0),
+}
+
+# The thinking rings' alphas, innermost first.
+_RING_ALPHAS = (0.28, 0.12)
+
+
+def animations_enabled():
+    settings = Gtk.Settings.get_default()
+    if settings is None:
+        return False
+    return bool(settings.get_property('gtk-enable-animations'))
+
+
+def _set_source(cr, color, alpha=1.0):
+    rgba = Gdk.RGBA()
+    rgba.parse(color)
+    rgba.alpha = alpha
+    Gdk.cairo_set_source_rgba(cr, rgba)
+
+
+class JoGlyph(Gtk.DrawingArea):
+    """Jo, drawn live. breathing=True is for the one Jo present in
+    the room (a header); avatars riding old turns stay still.
+    """
+
+    def __init__(self, pixel_size, breathing=False):
+        Gtk.DrawingArea.__init__(self)
+        self.set_size_request(pixel_size, pixel_size)
+        self._breathing = breathing
+        self._mood = MOOD_RESTING
+        self._tick_id = None
+        self._breath = 0.0
+        self.connect('draw', self.__draw_cb)
+        self.connect('map', self.__map_cb)
+        self.connect('unmap', self.__unmap_cb)
+
+    def set_mood(self, mood):
+        if mood not in _MOODS or mood == self._mood:
+            return
+        self._mood = mood
+        self.__sync_tick()
+        self.queue_draw()
+
+    def __wants_tick(self):
+        if not self._breathing or not _MOODS[self._mood][5]:
+            return False
+        return self.get_mapped() and animations_enabled()
+
+    def __sync_tick(self):
+        if self.__wants_tick():
+            if self._tick_id is None:
+                self._tick_id = self.add_tick_callback(self.__tick_cb)
+        elif self._tick_id is not None:
+            self.remove_tick_callback(self._tick_id)
+            self._tick_id = None
+            self._breath = 0.0
+
+    def __map_cb(self, widget):
+        self.__sync_tick()
+
+    def __unmap_cb(self, widget):
+        self.__sync_tick()
+
+    def __tick_cb(self, widget, frame_clock):
+        t = frame_clock.get_frame_time() % _BREATH_PERIOD_US
+        self._breath = math.sin(2 * math.pi * t / _BREATH_PERIOD_US)
+        self.queue_draw()
+        return GLib.SOURCE_CONTINUE
+
+    def __draw_cb(self, widget, cr):
+        allocation = widget.get_allocation()
+        size = min(allocation.width, allocation.height)
+        cr.translate((allocation.width - size) / 2.0,
+                     (allocation.height - size) / 2.0)
+        cr.scale(size / 75.0, size / 75.0)
+
+        scale, core_alpha, glow_alpha, room_alpha, body_alpha, \
+            _breathes, rings = _MOODS[self._mood]
+
+        _set_source(cr, reflectstyle.JO_DISC_FILL, room_alpha)
+        cr.arc(37.5, 37.5, 35, 0, 2 * math.pi)
+        cr.fill_preserve()
+        _set_source(cr, reflectstyle.JO_DISC_LINE, room_alpha)
+        cr.set_line_width(1.5)
+        cr.stroke()
+
+        # The body's optical mass sits below its geometric center;
+        # lift the whole robot so it reads centered in the disc.
+        cr.translate(0, -2.0)
+
+        self.__body_path(cr)
+        _set_source(cr, reflectstyle.CARD, body_alpha)
+        cr.fill_preserve()
+        _set_source(cr, reflectstyle.INK_PANEL, body_alpha)
+        cr.set_line_width(3.5)
+        cr.stroke()
+
+        cr.save()
+        cr.set_line_cap(cairo.LINE_CAP_ROUND)
+        cr.set_line_width(2.5)
+        cr.move_to(37.5, 13.4)
+        cr.line_to(37.5, 18.0)
+        cr.stroke()
+        cr.move_to(29.5, 55.0)
+        cr.curve_to(34.8, 58.3, 40.2, 58.3, 45.5, 55.0)
+        cr.stroke()
+        cr.restore()
+
+        scale += 0.06 * self._breath
+        core_alpha = min(1.0, core_alpha + 0.05 * self._breath)
+
+        ember = Gdk.RGBA()
+        ember.parse(reflectstyle.EMBER)
+        glow = cairo.RadialGradient(
+            _VISOR_X, _VISOR_Y, _GLOW_R * 0.25 * scale,
+            _VISOR_X, _VISOR_Y, _GLOW_R * scale)
+        glow.add_color_stop_rgba(0.0, ember.red, ember.green, ember.blue,
+                                 glow_alpha)
+        glow.add_color_stop_rgba(1.0, ember.red, ember.green, ember.blue,
+                                 0.0)
+        cr.set_source(glow)
+        cr.arc(_VISOR_X, _VISOR_Y, _GLOW_R * scale, 0, 2 * math.pi)
+        cr.fill()
+
+        cr.set_line_width(1.8)
+        for step in range(rings):
+            cr.set_source_rgba(ember.red, ember.green, ember.blue,
+                               _RING_ALPHAS[step])
+            cr.arc(_VISOR_X, _VISOR_Y, 27.5 + step * 5.0,
+                   0, 2 * math.pi)
+            cr.stroke()
+
+        cr.save()
+        cr.translate(_VISOR_X, _VISOR_Y)
+        cr.scale(scale, scale)
+        cr.translate(-_VISOR_X, -_VISOR_Y)
+        self.__visor_path(cr)
+        cr.set_source_rgba(ember.red, ember.green, ember.blue, core_alpha)
+        cr.fill()
+        _set_source(cr, reflectstyle.CARD, core_alpha)
+        for side in (-1, 1):
+            cr.arc(_VISOR_X + side * _EYE_DX, _VISOR_Y, _EYE_R,
+                   0, 2 * math.pi)
+            cr.fill()
+        cr.restore()
+        return False
+
+    def __body_path(self, cr):
+        cr.arc(37.5, 9.2, 4.2, 0, 2 * math.pi)
+        cr.new_sub_path()
+        cr.move_to(17.5, 38.0)
+        cr.arc(37.5, 38.0, 20.0, math.pi, 2 * math.pi)
+        cr.line_to(57.5, 60.0)
+        cr.arc(52.7, 60.0, 4.8, 0, 0.5 * math.pi)
+        cr.line_to(22.3, 64.8)
+        cr.arc(22.3, 60.0, 4.8, 0.5 * math.pi, math.pi)
+        cr.close_path()
+
+    def __visor_path(self, cr):
+        left = _VISOR_X - _VISOR_W / 2.0
+        top = _VISOR_Y - _VISOR_H / 2.0
+        arc = _VISOR_ARC
+        cr.new_sub_path()
+        cr.arc(left + arc, top + arc, arc, math.pi, 1.5 * math.pi)
+        cr.arc(left + _VISOR_W - arc, top + arc, arc,
+               1.5 * math.pi, 2 * math.pi)
+        cr.arc(left + _VISOR_W - arc, top + _VISOR_H - arc, arc,
+               0, 0.5 * math.pi)
+        cr.arc(left + arc, top + _VISOR_H - arc, arc,
+               0.5 * math.pi, math.pi)
+        cr.close_path()

--- a/src/jarabe/journal/momentcard.py
+++ b/src/jarabe/journal/momentcard.py
@@ -1,0 +1,994 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Taking a moment: the quick in-activity card that replaced the bench
+talk on this dial.
+
+A snapshot of the work right now, a caption, three marks - all
+optional. The activity behind is never paused; it stays exactly as it
+was.
+"""
+
+import base64
+import logging
+import math
+import time
+from gettext import gettext as _
+
+import cairo
+from gi.repository import Gdk
+from gi.repository import GdkPixbuf
+from gi.repository import GLib
+from gi.repository import Gtk
+from gi.repository import Pango
+from gi.repository import PangoCairo
+
+from sugar3 import profile
+from sugar3.datastore import datastore
+from sugar3.graphics import style
+
+from jarabe.journal import model
+from jarabe.journal import reflectguard
+from jarabe.journal import reflection
+from jarabe.journal.joglyph import JoGlyph
+from jarabe.journal import reflectstyle
+from jarabe.journal import timeline
+
+
+_CARD_WIDTH = style.zoom(600)
+_CARD_BORDER = style.zoom(20)
+_CARD_RADIUS = style.zoom(24)
+_JO_HEADER = style.zoom(45)
+_MAT_PAD = style.zoom(12)
+_BAND_HEIGHT = style.zoom(86)
+_ROTATE_MARGIN = style.zoom(10)
+_TILT = -1.2 * math.pi / 180.0
+_DISC_SIZE = style.zoom(64)
+_CONTROL_HEIGHT = style.zoom(52)
+
+# Big enough to stand in for the artwork when the entry view stages a
+# moment, small enough that a shelf of these never dents the entry.
+_SNAP_WIDTH = 960
+_SNAP_HEIGHT = 600
+_SNAP_QUALITY = '85'
+
+SNAP_KEY = reflectguard.SNAP_KEY
+
+_MAX_MOMENTS = reflectguard.MAX_MOMENTS
+
+_MARKS = (('proud', _('proud')), ('tricky', _('tricky')),
+          ('wonder', _('wonder')))
+
+_TITLE = _('Taking a moment')
+_CAPTION_HINT = _('write about this bit')
+_MARK_LEAD = _('leave a mark, if you want')
+_DISCARD_LABEL = _("Don't keep it")
+_KEEP_LABEL = _('Keep it in my Journal')
+
+_css_registered = False
+
+
+def _register_css():
+    global _css_registered
+    if _css_registered:
+        return
+    _css_registered = True
+
+    xo_color = profile.get_color()
+    stroke = xo_color.get_stroke_color()
+    r, g, b = (int(stroke.lstrip('#')[i:i + 2], 16) for i in (0, 2, 4))
+    tint = '#%02X%02X%02X' % (r + (255 - r) * 9 // 10,
+                              g + (255 - g) * 9 // 10,
+                              b + (255 - b) * 9 // 10)
+
+    px = reflectstyle.px
+
+    css = ('''
+.mc-card {
+    background-color: %(paper)s;
+    border: %(z1)dpx solid %(rim)s; border-radius: %(radius)dpx;
+}
+.mc-title {
+    font-family: %(font_clear)s;
+    font-weight: 700; font-size: %(z24)dpx; color: %(ink)s;
+}
+.mc-lead {
+    font-family: %(font_clear)s;
+    font-weight: 600; font-size: %(z16)dpx; color: %(ink_soft)s;
+}
+.mc-mark-label {
+    font-family: %(font_clear)s;
+    font-weight: 700; font-size: %(z17)dpx; color: %(ink_soft)s;
+}
+.mc-mark-label.selected { color: %(stroke)s; }
+.mc-disc {
+    background-color: %(card)s;
+    border: %(z2)dpx solid %(rim)s; border-radius: %(z999)dpx;
+}
+.mc-disc.selected {
+    background-color: %(tint)s; border: %(z3)dpx solid %(stroke)s;
+}
+.mc-caption {
+    font-family: %(font_hand)s;
+    font-size: %(z32)dpx; color: %(ink)s;
+    background-color: transparent;
+    border: none; box-shadow: none;
+    caret-color: %(ink)s;
+}
+.mc-chip {
+    background-color: transparent; background-image: none;
+    border: none; box-shadow: none; padding: 0;
+}
+.mc-chip:active .mc-disc {
+    background-color: %(tint)s; border-color: %(stroke)s;
+}
+.mc-discard {
+    font-family: %(font_clear)s;
+    font-weight: 700; font-size: %(z18)dpx; color: %(ink_soft)s;
+    background-color: %(card)s; background-image: none;
+    border: %(z2)dpx solid %(rim)s; border-radius: %(z999)dpx;
+    padding: %(z12)dpx %(z22)dpx;
+}
+.mc-discard:active { background-color: %(rim)s; }
+.mc-keep {
+    font-family: %(font_clear)s;
+    font-weight: 700; font-size: %(z18)dpx; color: %(card)s;
+    background-color: %(stroke)s; background-image: none;
+    border: none; border-radius: %(z999)dpx;
+    padding: %(z12)dpx %(z26)dpx;
+}
+.mc-keep:active { background-color: %(tint)s; color: %(ink)s; }
+''' % {
+        'paper': reflectstyle.PAPER_PAGE,
+        'card': reflectstyle.CARD,
+        'ink': reflectstyle.INK_PAGE,
+        'ink_soft': reflectstyle.INK_SOFT_PAGE,
+        'rim': reflectstyle.RIM_MOMENT,
+        'stroke': stroke,
+        'tint': tint,
+        'radius': _CARD_RADIUS,
+        'font_hand': reflectstyle.FONT_HAND,
+        'font_clear': reflectstyle.FONT_CLEAR,
+        'z1': px(1), 'z2': px(2), 'z3': px(3), 'z12': px(12),
+        'z16': px(16), 'z17': px(17), 'z18': px(18), 'z22': px(22),
+        'z24': px(24), 'z26': px(26), 'z32': px(32), 'z999': px(999),
+    }).encode('utf-8')
+
+    provider = Gtk.CssProvider()
+    provider.load_from_data(css)
+    Gtk.StyleContext.add_provider_for_screen(
+        Gdk.Screen.get_default(), provider,
+        Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+
+
+def _class(widget, name):
+    widget.get_style_context().add_class(name)
+    return widget
+
+
+def _set_source(cr, color):
+    rgba = Gdk.RGBA()
+    rgba.parse(color)
+    Gdk.cairo_set_source_rgba(cr, rgba)
+
+
+def _capture_screen():
+    """Grab the whole screen right now. None on any failure - the card
+    falls back to a plain paper placeholder rather than crash.
+    """
+    try:
+        screen = Gdk.Screen.get_default()
+        width, height = screen.get_width(), screen.get_height()
+        root = Gdk.get_default_root_window()
+        return Gdk.pixbuf_get_from_window(root, 0, 0, width, height)
+    except Exception:
+        logging.exception('momentcard: screen capture failed')
+        return None
+
+
+def _trim_activity(raw):
+    """The activity alone: the Frame's toolbar row and the window's
+    own edges cut away.
+    """
+    if raw is None:
+        return None
+    try:
+        inset = style.zoom(4)
+        top = style.GRID_CELL_SIZE + inset
+        w = max(1, raw.get_width() - inset * 2)
+        h = max(1, raw.get_height() - top - inset * 3)
+        return raw.new_subpixbuf(inset, top, w, h)
+    except Exception:
+        logging.exception('momentcard: capture trim failed')
+        return None
+
+
+def _blur(pixbuf):
+    """A cheap, convincing blur: collapse the image and stretch it
+    back, letting bilinear filtering soften it both ways.
+    """
+    if pixbuf is None:
+        return None
+    w, h = pixbuf.get_width(), pixbuf.get_height()
+    small = pixbuf.scale_simple(max(1, w // 8), max(1, h // 8),
+                                GdkPixbuf.InterpType.BILINEAR)
+    if small is None:
+        return pixbuf
+    soft = small.scale_simple(w, h, GdkPixbuf.InterpType.BILINEAR)
+    return soft if soft is not None else pixbuf
+
+
+def _encode_snap(pixbuf):
+    """Scale the capture down to a shelf-sized JPEG, base64-wrapped so
+    it survives the datastore's UTF-8-only metadata (all but 'preview').
+    """
+    if pixbuf is None:
+        return None
+    try:
+        w, h = pixbuf.get_width(), pixbuf.get_height()
+        scale = min(_SNAP_WIDTH / float(w), _SNAP_HEIGHT / float(h))
+        new_w = max(1, int(w * scale))
+        new_h = max(1, int(h * scale))
+        scaled = pixbuf.scale_simple(new_w, new_h,
+                                     GdkPixbuf.InterpType.BILINEAR)
+        if scaled is None:
+            return None
+        ok, buf = scaled.save_to_bufferv('jpeg', ['quality'],
+                                         [_SNAP_QUALITY])
+        if not ok:
+            return None
+        return base64.b64encode(bytes(buf)).decode('ascii')
+    except Exception:
+        logging.exception('momentcard: snap encode failed')
+        return None
+
+
+def _add_moment(data, caption, mark):
+    """Append a moment to the reflections record and return
+    (moment, evicted_seqs). evicted_seqs lists every snap key
+    number to drop from metadata, oldest first.
+    """
+    moments = list(data.get('moments', []))
+    seq = data.get('moment_seq', 0)
+    moment = {'caption': caption, 'mark': mark, 'ts': time.time(),
+              'snap_seq': seq}
+    moments.append(moment)
+    evicted = []
+    while len(moments) > _MAX_MOMENTS:
+        evicted.append(moments.pop(0).get('snap_seq'))
+    data['moments'] = moments
+    data['moment_seq'] = seq + 1
+    return moment, evicted
+
+
+# Traced from sugarlabs/maze-activity's icon; re-traced to stay in sync.
+_MAZE_WALLS = (
+    (8.01, 6.04), (8.01, 2.09), (15.91, 2.09), (15.91, 8.01),
+    (11.96, 8.01), (11.96, 6.04), (13.94, 6.04), (13.94, 4.06),
+    (9.99, 4.06), (9.99, 8.01), (6.04, 8.01), (6.04, 11.96), (4.06, 11.96),
+    (4.06, 13.94), (8.01, 13.94), (8.01, 9.99), (15.91, 9.99),
+    (15.91, 15.91), (13.94, 15.91), (13.94, 11.96), (9.99, 11.96),
+    (9.99, 13.94), (11.96, 13.94), (11.96, 15.91), (2.09, 15.91),
+    (2.09, 9.99), (4.06, 9.99), (4.06, 4.06), (2.09, 4.06), (2.09, 2.09),
+    (6.04, 2.09), (6.04, 6.04))
+
+
+def draw_mark(cr, kind, color):
+    """Draw a proud / tricky / wonder mark into an 18x18 unit box.
+
+    The caller owns the transform: translate and scale cr so that the
+    box lands where the mark should sit. Shared with the entry view,
+    so a mark reads identically wherever the child left it. Tricky and
+    wonder borrow Sugar's own artwork (the Maze activity icon and
+    sugar-artwork's emblem-question); proud is ours in the same
+    icon grammar - upstream has no flag.
+    """
+    _set_source(cr, color)
+    if kind == 'proud':
+        # Not a star: the Journal already spends the star on keep.
+        cr.set_line_width(1.6)
+        cr.set_line_cap(cairo.LineCap.SQUARE)
+        cr.set_line_join(cairo.LineJoin.MITER)
+        cr.move_to(4.8, 15.2)
+        cr.line_to(4.8, 3.0)
+        cr.stroke()
+        cr.move_to(4.8, 3.2)
+        cr.line_to(13.6, 5.9)
+        cr.line_to(4.8, 8.6)
+        cr.close_path()
+        cr.fill_preserve()
+        cr.set_line_width(1.2)
+        cr.stroke()
+    elif kind == 'tricky':
+        cr.set_line_width(0.9)
+        cr.set_line_cap(cairo.LineCap.SQUARE)
+        cr.set_line_join(cairo.LineJoin.MITER)
+        cr.move_to(*_MAZE_WALLS[0])
+        for point in _MAZE_WALLS[1:]:
+            cr.line_to(*point)
+        cr.close_path()
+        cr.stroke()
+    else:
+        # sugar-artwork's own question mark, filled, dot and all.
+        cr.move_to(7.24, 8.67)
+        cr.curve_to(7.24, 7.94, 8.05, 7.82, 8.89, 7.59)
+        cr.curve_to(9.7, 7.37, 10.52, 7.04, 10.52, 5.86)
+        cr.curve_to(10.52, 4.97, 9.68, 4.31, 8.83, 4.31)
+        cr.curve_to(7.12, 4.31, 6.85, 6.33, 5.55, 6.33)
+        cr.curve_to(4.81, 6.33, 4.3, 5.76, 4.3, 4.86)
+        cr.curve_to(4.3, 2.72, 6.99, 1.5, 8.83, 1.5)
+        cr.curve_to(11.46, 1.5, 13.7, 3.13, 13.7, 5.86)
+        cr.curve_to(13.7, 8.12, 12.27, 9.45, 10.17, 9.98)
+        cr.line_to(10.17, 10.71)
+        cr.curve_to(10.17, 11.53, 9.56, 12.12, 8.71, 12.12)
+        cr.curve_to(7.79, 12.12, 7.24, 11.53, 7.24, 10.71)
+        cr.close_path()
+        cr.fill()
+        cr.arc(8.71, 14.91, 1.59, 0, 2 * math.pi)
+        cr.fill()
+
+
+def draw_star(cr, cx, cy, radius, lit, color):
+    """The keep-star, shared across the Journal's surfaces."""
+    points = []
+    for i in range(10):
+        r = radius if i % 2 == 0 else radius * 0.44
+        angle = -math.pi / 2 + i * math.pi / 5
+        points.append((cx + r * math.cos(angle),
+                       cy + r * math.sin(angle)))
+    cr.set_line_join(cairo.LineJoin.ROUND)
+    cr.move_to(*points[0])
+    for point in points[1:]:
+        cr.line_to(*point)
+    cr.close_path()
+    # One outline weight at every size, scaled like the board's svg.
+    line = max(1.2, radius * 0.17)
+    if lit:
+        _set_source(cr, color)
+        cr.fill_preserve()
+        _set_source(cr, reflectstyle.PAPER_PAGE)
+        cr.set_line_width(line)
+        cr.stroke()
+    else:
+        _set_source(cr, reflectstyle.INK_FAINT)
+        cr.set_line_width(line)
+        cr.stroke()
+
+
+class FoldGlyph(Gtk.DrawingArea):
+    """Two stacked cards: the Journal's shared "more underneath" sign."""
+
+    def __init__(self):
+        Gtk.DrawingArea.__init__(self)
+        self.set_size_request(style.zoom(24), style.zoom(22))
+        stroke = profile.get_color().get_stroke_color()
+        red, green, blue = (int(stroke.lstrip('#')[i:i + 2], 16)
+                            for i in (0, 2, 4))
+        self._stroke = stroke
+        self._tint = '#%02X%02X%02X' % (
+            int(red + (255 - red) * 0.88),
+            int(green + (255 - green) * 0.88),
+            int(blue + (255 - blue) * 0.88))
+        self.connect('draw', self.__draw_cb)
+
+    def __draw_cb(self, widget, cr):
+        alloc = widget.get_allocation()
+        cr.scale(alloc.width / 26.0, alloc.height / 24.0)
+        cr.set_line_width(2)
+        _set_source(cr, reflectstyle.PAPER_PAGE)
+        timeline.rounded_rect_path(cr, 5, 2, 18, 14, 3)
+        cr.fill_preserve()
+        _set_source(cr, reflectstyle.INK_SOFT_PAGE)
+        cr.stroke()
+        _set_source(cr, self._tint)
+        timeline.rounded_rect_path(cr, 2, 7, 18, 14, 3)
+        cr.fill_preserve()
+        _set_source(cr, self._stroke)
+        cr.stroke()
+        return False
+
+
+class _MarkGlyph(Gtk.DrawingArea):
+    """A mark as a widget, for the card's own mark chips."""
+
+    def __init__(self, kind, size):
+        Gtk.DrawingArea.__init__(self)
+        self._kind = kind
+        self._color = reflectstyle.INK_PAGE
+        self.set_size_request(size, size)
+        self.connect('draw', self.__draw_cb)
+
+    def set_color(self, color):
+        self._color = color
+        self.queue_draw()
+
+    def __draw_cb(self, widget, cr):
+        alloc = widget.get_allocation()
+        s = min(alloc.width, alloc.height)
+        cr.translate((alloc.width - s) / 2.0, (alloc.height - s) / 2.0)
+        cr.scale(s / 18.0, s / 18.0)
+        draw_mark(cr, self._kind, self._color)
+        return False
+
+
+class _Polaroid(Gtk.DrawingArea):
+    """A just-taken photo: white frame, thick bottom band, a slight
+    tilt - drawn whole in cairo, since GTK 3.24 has no CSS transform.
+    """
+
+    def __init__(self, width):
+        Gtk.DrawingArea.__init__(self)
+        self._pixbuf = None
+        self._hint_visible = True
+        self._dots_phase = 0
+        self._dots_id = None
+        self._pw = width
+        self._snap_w = width - 2 * _MAT_PAD
+        self.__set_ratio(322.0 / 548.0)
+        self.connect('draw', self.__draw_cb)
+
+    def __set_ratio(self, ratio):
+        self._snap_h = int(self._snap_w * ratio)
+        self._ph = _MAT_PAD * 2 + self._snap_h + _BAND_HEIGHT
+        self.set_size_request(self._pw + 2 * _ROTATE_MARGIN,
+                              self._ph + 2 * _ROTATE_MARGIN)
+
+    def set_hint_visible(self, visible):
+        if self._hint_visible != visible:
+            self._hint_visible = visible
+            self.queue_draw()
+        if visible and self._dots_id is None:
+            self._dots_id = GLib.timeout_add(350, self.__dots_tick_cb)
+        elif not visible and self._dots_id is not None:
+            GLib.source_remove(self._dots_id)
+            self._dots_id = None
+
+    def __dots_tick_cb(self):
+        # Only the band strip repaints on a tick; the photo and
+        # its shadow stack stay untouched between hops.
+        self._dots_phase = (self._dots_phase + 1) % 4
+        bx, by, bw, bh = self.band_rect()
+        pad = style.zoom(12)
+        self.queue_draw_area(int(bx - pad), int(by - pad),
+                             int(bw + 2 * pad), int(bh + 2 * pad))
+        return True
+
+    def band_rect(self):
+        """The band's rectangle in the widget's own (unrotated)
+        coordinates, for the caption entry laid over this widget.
+        """
+        x = _ROTATE_MARGIN + _MAT_PAD
+        y = _ROTATE_MARGIN + _MAT_PAD + self._snap_h
+        w = self._pw - 2 * _MAT_PAD
+        h = _BAND_HEIGHT
+        return x, y, w, h
+
+    def set_pixbuf(self, pixbuf):
+        self._pixbuf = pixbuf
+        if pixbuf is not None and pixbuf.get_width() > 0:
+            # The mat takes the photo's own shape, within reason - a
+            # polaroid never letterboxes its picture.
+            ratio = pixbuf.get_height() / float(pixbuf.get_width())
+            self.__set_ratio(max(0.30, min(0.75, ratio)))
+        self.queue_draw()
+
+    def __draw_cb(self, widget, cr):
+        alloc = widget.get_allocation()
+        cx, cy = alloc.width / 2.0, alloc.height / 2.0
+        cr.save()
+        cr.translate(cx, cy)
+        cr.rotate(_TILT)
+        cr.translate(-self._pw / 2.0, -self._ph / 2.0)
+        self.__draw_card(cr)
+        cr.restore()
+        return False
+
+    def __draw_card(self, cr):
+        pw, ph = self._pw, self._ph
+        cr.set_source_rgba(0.227, 0.192, 0.149, 0.045)
+        for i in range(1, 6):
+            cr.rectangle(-i * 0.5, style.zoom(2) + i * 1.4,
+                         pw + i, ph)
+            cr.fill()
+
+        _set_source(cr, reflectstyle.CARD)
+        cr.rectangle(0, 0, pw, ph)
+        cr.fill()
+        _set_source(cr, reflectstyle.RIM_MOMENT)
+        cr.set_line_width(1.0)
+        cr.rectangle(0.5, 0.5, pw - 1, ph - 1)
+        cr.stroke()
+
+        cr.save()
+        cr.rectangle(_MAT_PAD, _MAT_PAD, self._snap_w, self._snap_h)
+        cr.clip()
+        _set_source(cr, reflectstyle.PAPER_PAGE)
+        cr.paint()
+        if self._pixbuf is not None:
+            sw = self._pixbuf.get_width()
+            sh = self._pixbuf.get_height()
+            # The whole canvas, undistorted and centred: cropping or
+            # stretching would misrepresent what the child just made.
+            scale = min(self._snap_w / float(sw), self._snap_h / float(sh))
+            cr.translate(_MAT_PAD + (self._snap_w - sw * scale) / 2.0,
+                         _MAT_PAD + (self._snap_h - sh * scale) / 2.0)
+            cr.scale(scale, scale)
+            Gdk.cairo_set_source_pixbuf(cr, self._pixbuf, 0, 0)
+            cr.get_source().set_filter(cairo.Filter.GOOD)
+            cr.paint()
+        cr.restore()
+
+        # The band is where a polaroid gets written on: a warm wash,
+        # a pencil waiting at its left, the invitation painted here
+        # (not an entry placeholder) so the ready caret never hides
+        # it.
+        band_x = _MAT_PAD
+        band_y = _MAT_PAD + self._snap_h
+        band_w = self._pw - 2 * _MAT_PAD
+        _set_source(cr, '#FDF6E8')
+        cr.rectangle(band_x, band_y, band_w, _BAND_HEIGHT)
+        cr.fill()
+
+        pencil = style.zoom(24)
+        cr.save()
+        cr.translate(band_x + style.zoom(8),
+                     band_y + (_BAND_HEIGHT - pencil) / 2.0)
+        cr.scale(pencil / 18.0, pencil / 18.0)
+        _set_source(cr, '#B97A1E')
+        cr.set_line_width(1.8)
+        cr.set_line_join(cairo.LineJoin.ROUND)
+        cr.move_to(3.2, 14.8)
+        cr.line_to(4.0, 11.8)
+        cr.line_to(12.6, 3.2)
+        cr.line_to(14.8, 5.4)
+        cr.line_to(6.2, 14.0)
+        cr.close_path()
+        cr.stroke()
+        cr.move_to(11.4, 4.4)
+        cr.line_to(13.6, 6.6)
+        cr.stroke()
+        cr.restore()
+
+        if self._hint_visible:
+            layout = PangoCairo.create_layout(cr)
+            layout.set_font_description(Pango.FontDescription(
+                '%s 22' % reflectstyle.FONT_HAND_FAMILY))
+            layout.set_text(_CAPTION_HINT, -1)
+            _tw, th = layout.get_pixel_size()
+            _set_source(cr, reflectstyle.INK_SOFT_PAGE)
+            cr.move_to(band_x + style.zoom(52),
+                       band_y + (_BAND_HEIGHT - th) / 2.0)
+            PangoCairo.show_layout(cr, layout)
+
+            dot_r = style.zoom(5)
+            base_x = band_x + style.zoom(52) + _tw + style.zoom(18)
+            base_y = band_y + _BAND_HEIGHT / 2.0 + style.zoom(3)
+            _set_source(cr, '#B97A1E')
+            for k in range(3):
+                hop = style.zoom(6) if self._dots_phase == k else 0
+                cr.arc(base_x + k * style.zoom(17), base_y - hop,
+                       dot_r, 0, 2 * math.pi)
+                cr.fill()
+
+
+class MomentCard(Gtk.Window):
+    """The moment card: a snapshot, a caption, three marks, two honest
+    choices. One fullscreen toplevel, the same shape as the shell's
+    LaunchWindow: the backdrop paints the activity blurred and
+    quieted (Sugar runs no compositor), and the card itself is an
+    ordinary child box - no second window to stack, shape or race.
+    """
+
+    def __init__(self):
+        Gtk.Window.__init__(self, type=Gtk.WindowType.TOPLEVEL)
+        self.set_decorated(False)
+        self.set_resizable(False)
+        self.set_skip_taskbar_hint(True)
+        self.set_skip_pager_hint(True)
+        self.set_app_paintable(True)
+        self.add_events(Gdk.EventMask.BUTTON_PRESS_MASK)
+        self.connect('realize', lambda w: self.set_type_hint(
+            Gdk.WindowTypeHint.DIALOG))
+        self.connect('key-press-event', self.__key_press_cb)
+        self.connect('button-press-event', self.__backdrop_press_cb)
+        self.connect('draw', self.__draw_backdrop_cb)
+
+        _register_css()
+
+        self._object_id = None
+        self._metadata = None
+        self._pixbuf = None
+        self._backdrop = None
+        self._card_rest = None
+        self._mark = None
+        self._mark_glyphs = {}
+        self._mark_discs = {}
+        self._mark_labels = {}
+        self._settle_id = None
+        self._departing = False
+        self.connect('focus-out-event', self.__focus_out_cb)
+
+        # The polaroid already carries _ROTATE_MARGIN of clearance on
+        # every side, so the column's own spacing stays small or the
+        # gaps around it read double.
+        outer = Gtk.VBox()
+        outer.set_border_width(_CARD_BORDER)
+        outer.set_spacing(style.zoom(8))
+
+        outer.pack_start(self.__build_header(), False, False, 0)
+        outer.pack_start(self.__build_polaroid(), False, False, 0)
+        outer.pack_start(self.__build_marks(), False, False, 0)
+        footer = self.__build_footer()
+        footer.set_margin_top(style.zoom(4))
+        outer.pack_start(footer, False, False, 0)
+
+        self._card_box = _class(Gtk.VBox(), 'mc-card')
+        self._card_box.pack_start(outer, False, False, 0)
+        self._card_box.set_size_request(_CARD_WIDTH, -1)
+        self._fixed = Gtk.Fixed()
+        self._fixed.put(self._card_box, 0, 0)
+        self.add(self._fixed)
+
+    def __build_header(self):
+        bar = Gtk.HBox()
+        bar.set_spacing(style.zoom(12))
+        jo = JoGlyph(_JO_HEADER, breathing=True)
+        jo.set_valign(Gtk.Align.CENTER)
+        bar.pack_start(jo, False, False, 0)
+        title = _class(Gtk.Label(label=_TITLE), 'mc-title')
+        title.set_xalign(0.0)
+        title.set_valign(Gtk.Align.CENTER)
+        bar.pack_start(title, False, False, 0)
+        return bar
+
+    def __build_polaroid(self):
+        # _Polaroid pads its own request by _ROTATE_MARGIN on every
+        # side for tilt clearance, so its logical width must come in
+        # narrower than the column or the card would overshoot
+        # _CARD_WIDTH by twice that margin.
+        width = _CARD_WIDTH - 2 * _CARD_BORDER - 2 * _ROTATE_MARGIN
+        self._polaroid = _Polaroid(width)
+        overlay = Gtk.Overlay()
+        overlay.set_halign(Gtk.Align.CENTER)
+        overlay.add(self._polaroid)
+
+        entry = _class(Gtk.Entry(), 'mc-caption')
+        entry.set_max_length(120)
+        entry.connect('changed', self.__caption_changed_cb)
+        entry.set_has_frame(False)
+        entry.set_halign(Gtk.Align.START)
+        entry.set_valign(Gtk.Align.START)
+        entry.connect('activate', self.__keep_cb)
+        self._caption_entry = entry
+        self.__place_caption()
+        overlay.add_overlay(entry)
+        return overlay
+
+    def __caption_changed_cb(self, entry):
+        # The painted invitation steps aside the moment real words
+        # arrive, and comes back if they are all deleted.
+        self._polaroid.set_hint_visible(not entry.get_text())
+
+    def __place_caption(self):
+        # The mat resizes to each capture, so the caption chases the
+        # band wherever it lands; the pencil prop keeps the left edge.
+        band_x, band_y, band_w, band_h = self._polaroid.band_rect()
+        self._caption_entry.set_margin_start(band_x + style.zoom(44))
+        self._caption_entry.set_margin_top(
+            band_y + (band_h - _CONTROL_HEIGHT) // 2)
+        self._caption_entry.set_size_request(
+            band_w - style.zoom(16), _CONTROL_HEIGHT)
+
+    def __build_marks(self):
+        col = Gtk.VBox()
+        col.set_spacing(style.zoom(12))
+        lead = _class(Gtk.Label(label=_MARK_LEAD), 'mc-lead')
+        col.pack_start(lead, False, False, 0)
+
+        row = Gtk.HBox()
+        row.set_spacing(style.zoom(18))
+        row.set_halign(Gtk.Align.CENTER)
+        for mark_id, label in _MARKS:
+            chip = _class(Gtk.Button(), 'mc-chip')
+            chip.set_relief(Gtk.ReliefStyle.NONE)
+            chip.mark_id = mark_id
+            chip_col = Gtk.VBox()
+            chip_col.set_spacing(style.zoom(4))
+            disc = _class(Gtk.EventBox(), 'mc-disc')
+            disc.set_size_request(_DISC_SIZE, _DISC_SIZE)
+            glyph = _MarkGlyph(mark_id, style.zoom(48))
+            glyph.set_halign(Gtk.Align.CENTER)
+            glyph.set_valign(Gtk.Align.CENTER)
+            disc.add(glyph)
+            chip_col.pack_start(disc, False, False, 0)
+            mark_label = _class(Gtk.Label(label=label), 'mc-mark-label')
+            chip_col.pack_start(mark_label, False, False, 0)
+            chip.add(chip_col)
+            chip.connect('clicked', self.__mark_clicked_cb)
+            self._mark_glyphs[mark_id] = glyph
+            self._mark_discs[mark_id] = disc
+            self._mark_labels[mark_id] = mark_label
+            row.pack_start(chip, False, False, 0)
+        col.pack_start(row, False, False, 0)
+        return col
+
+    def __build_footer(self):
+        row = Gtk.HBox()
+        row.set_spacing(style.zoom(16))
+        discard = _class(Gtk.Button(label=_DISCARD_LABEL), 'mc-discard')
+        discard.set_relief(Gtk.ReliefStyle.NONE)
+        discard.set_size_request(-1, _CONTROL_HEIGHT)
+        discard.connect('clicked', self.__discard_cb)
+        row.pack_start(discard, False, False, 0)
+
+        keep = _class(Gtk.Button(label=_KEEP_LABEL), 'mc-keep')
+        keep.set_relief(Gtk.ReliefStyle.NONE)
+        keep.set_size_request(-1, _CONTROL_HEIGHT)
+        keep.connect('clicked', self.__keep_cb)
+        row.pack_end(keep, False, False, 0)
+        return row
+
+    def __deselect_marks(self):
+        for mark_id in self._mark_discs:
+            self._mark_discs[mark_id].get_style_context().remove_class(
+                'selected')
+            self._mark_labels[mark_id].get_style_context().remove_class(
+                'selected')
+            self._mark_glyphs[mark_id].set_color(reflectstyle.INK_PAGE)
+
+    def __mark_clicked_cb(self, button):
+        was_selected = self._mark == button.mark_id
+        self.__deselect_marks()
+        self._mark = None
+        if not was_selected:
+            self._mark = button.mark_id
+            stroke = profile.get_color().get_stroke_color()
+            self._mark_discs[self._mark].get_style_context().add_class(
+                'selected')
+            self._mark_labels[self._mark].get_style_context().add_class(
+                'selected')
+            self._mark_glyphs[self._mark].set_color(stroke)
+
+    def __close(self):
+        if self._settle_id is not None:
+            GLib.source_remove(self._settle_id)
+            self._settle_id = None
+        self.hide()
+        self._polaroid.set_hint_visible(False)
+        # The card lives for the whole session; parked, it must not
+        # keep two full-screen captures (~12MB) pinned in the shell.
+        self._pixbuf = None
+        self._backdrop = None
+        self._polaroid.set_pixbuf(None)
+        self._metadata = None
+
+    def __backdrop_press_cb(self, widget, event):
+        alloc = self._card_box.get_allocation()
+        if (alloc.x <= event.x <= alloc.x + alloc.width and
+                alloc.y <= event.y <= alloc.y + alloc.height):
+            return False
+        self.__close()
+        return True
+
+    def __focus_out_cb(self, widget, event):
+        # Anything that takes the screen away - a click outside, F3 to
+        # Home, another activity raising - ends the moment. Presenting
+        # is sequenced on the Frame's retract completing, so no late
+        # refocus is left to bounce against.
+        if self.get_visible():
+            self.__close()
+        return False
+
+    def __discard_cb(self, button):
+        self.__close()
+
+    def __keep_cb(self, button):
+        if self._departing:
+            return
+        self._departing = True
+        caption = self._caption_entry.get_text().strip()
+        try:
+            self.__store_moment(caption, self._mark)
+        except Exception:
+            # A failed keep must not strand the card with a dead
+            # button - let the child try again or discard.
+            logging.exception('momentcard: keep failed')
+            self._departing = False
+            return
+        self.__depart()
+
+    def __depart(self):
+        # Keeping files the card away: it sinks off its shadow while
+        # the scrim holds, then everything lets go. Discarding just
+        # closes - only keeping earns the beat.
+        if self._settle_id is not None:
+            GLib.source_remove(self._settle_id)
+            self._settle_id = None
+        fx, fy = self._card_rest[:2] if self._card_rest else (0, 0)
+        drop = style.zoom(40)
+        start = time.monotonic()
+
+        def tick():
+            t = min(1.0, (time.monotonic() - start) / 0.16)
+            self._fixed.move(self._card_box, fx, int(fy + drop * t * t))
+            if t >= 1.0:
+                self._settle_id = None
+                self.__close()
+                return False
+            return True
+
+        self._settle_id = GLib.timeout_add(16, tick)
+
+    def __key_press_cb(self, widget, event):
+        if event.keyval == Gdk.KEY_Escape:
+            self.__close()
+            return True
+        return False
+
+    def __resolve_entry(self, activity_id):
+        if not activity_id:
+            return None, None
+        try:
+            # the find() wrapper consumes 'uid' to build object_id, so
+            # it must be requested even though it never reaches metadata
+            results, count = datastore.find(
+                {'activity_id': activity_id, 'limit': 1},
+                sorting=['-mtime'], properties=['uid'])
+        except Exception:
+            logging.exception('momentcard: datastore lookup failed')
+            return None, None
+        if not results:
+            return None, None
+        object_id = results[0].object_id
+        results[0].destroy()
+        try:
+            return object_id, model.get(object_id)
+        except Exception:
+            logging.exception('momentcard: could not read entry %r',
+                              object_id)
+            return None, None
+
+    def __store_moment(self, caption, mark):
+        if not self._object_id or self._metadata is None:
+            return
+        # Merge onto the entry as it is NOW, not as it was when the
+        # card opened - the activity may have saved fresh work while
+        # the child typed, and update() prunes and reverts whatever
+        # the writer sends stale.
+        try:
+            metadata = model.get(self._object_id)
+        except Exception:
+            logging.exception('momentcard: could not re-read entry %r',
+                              self._object_id)
+            metadata = self._metadata
+        data = reflection.loads(metadata.get('reflections', ''))
+        moment, evicted = _add_moment(data, caption, mark)
+        metadata['reflections'] = reflection.dumps(data)
+        for seq in evicted:
+            if seq is not None:
+                metadata.pop(SNAP_KEY % seq, None)
+        snap = _encode_snap(self._pixbuf)
+        if snap is not None:
+            metadata[SNAP_KEY % moment['snap_seq']] = snap
+        # Held in shell memory too: the running activity will later
+        # save with the metadata it loaded at resume, wiping this
+        # write; the reflections guard puts the state back when it
+        # does.
+        snaps = {}
+        for m in data['moments']:
+            key = SNAP_KEY % m.get('snap_seq', -1)
+            if key in metadata:
+                snaps[key] = metadata[key]
+        reflectguard.get_guard().note_moments(self._object_id,
+                                              data['moments'], snaps)
+        try:
+            model.write(metadata, update_mtime=False)
+        except Exception:
+            logging.exception('momentcard: could not write entry %r',
+                              self._object_id)
+
+    def __draw_backdrop_cb(self, widget, cr):
+        if self._backdrop is not None:
+            Gdk.cairo_set_source_pixbuf(cr, self._backdrop, 0, 0)
+            cr.paint()
+        cr.set_source_rgba(0.227, 0.192, 0.149, 0.40)
+        cr.paint()
+        # No compositor means no real shadow; paint one where the
+        # card rests, heavier below.
+        if self._card_rest is not None:
+            x, y, w, h = self._card_rest
+            rings = 16
+            for i in range(rings, 0, -1):
+                grow = i * 2
+                alpha = 0.10 * (1.0 - i / float(rings + 1)) ** 2
+                cr.set_source_rgba(0, 0, 0, alpha)
+                cr.set_line_width(2.6)
+                gx = x - grow
+                gy = y - grow + i * 0.7
+                gw = w + grow * 2
+                gh = h + grow * 2
+                gr = _CARD_RADIUS + grow
+                timeline.rounded_rect_path(cr, gx, gy, gw, gh, gr)
+                cr.stroke()
+        return False
+
+    def present_over_activity(self, event_time=0, activity_id=None):
+        if self.get_visible():
+            # A second tap through the re-raised Frame must not
+            # photograph the card itself; just come forward.
+            self.present_with_time(self.__server_time(event_time))
+            return
+        self._object_id, self._metadata = self.__resolve_entry(activity_id)
+
+        self._mark = None
+        self.__deselect_marks()
+        self._caption_entry.set_text('')
+
+        self._departing = False
+        raw = _capture_screen()
+        self._pixbuf = _trim_activity(raw)
+        self._backdrop = _blur(raw)
+        self._polaroid.set_pixbuf(self._pixbuf)
+        self.__place_caption()
+
+        screen = Gdk.Screen.get_default()
+        sw, sh = screen.get_width(), screen.get_height()
+        self.set_size_request(sw, sh)
+        self.resize(sw, sh)
+        self.move(0, 0)
+        self.show_all()
+        _minimum, natural = self._card_box.get_preferred_size()
+        rest_x = (sw - natural.width) // 2
+        rest_y = (sh - natural.height) // 2
+        self._card_rest = (rest_x, rest_y, natural.width, natural.height)
+        self.__settle(rest_x, rest_y)
+        # A fresh server timestamp: the tap's own is stale once the
+        # Frame has finished retracting, and a stale present loses to
+        # focus-stealing prevention.
+        self.present_with_time(self.__server_time(event_time))
+        self.set_keep_above(True)
+        self._polaroid.set_hint_visible(True)
+        self._caption_entry.grab_focus()
+
+    def __server_time(self, fallback):
+        # Only X11 keeps a server clock; anywhere else the caller's own
+        # stamp is already the right one. Silent on purpose - on a
+        # Wayland session that is the normal answer, not a failure, and
+        # a traceback would only mislead whoever reads the log.
+        try:
+            from gi.repository import GdkX11
+            return GdkX11.x11_get_server_time(self.get_window())
+        except Exception:
+            return fallback
+
+    def __settle(self, fx, fy):
+        if self._settle_id is not None:
+            GLib.source_remove(self._settle_id)
+            self._settle_id = None
+        rise = style.zoom(24)
+        start = time.monotonic()
+
+        def tick():
+            t = min(1.0, (time.monotonic() - start) / 0.2)
+            ease = 1.0 - (1.0 - t) ** 3
+            self._fixed.move(self._card_box, fx,
+                             int(fy + rise * (1.0 - ease)))
+            if t >= 1.0:
+                self._settle_id = None
+                return False
+            return True
+
+        self._fixed.move(self._card_box, fx, fy + rise)
+        self._settle_id = GLib.timeout_add(16, tick)

--- a/src/jarabe/journal/reflectguard.py
+++ b/src/jarabe/journal/reflectguard.py
@@ -1,0 +1,180 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Shell-memory guard for the reflections record.
+
+The datastore's update() prunes any metadata key a writer does not
+send, and a running activity saves with the metadata it loaded at
+resume - erasing a moment, snapshot or session written here
+mid-session. The last written state is held in shell memory and put
+back the instant an update wipes it from the entry.
+
+The guard retires if the datastore ever merges updates instead of
+deleting omitted keys.
+"""
+
+import logging
+import time
+
+from gi.repository import GLib
+
+from jarabe.journal import model
+from jarabe.journal import reflection
+
+
+SNAP_KEY = reflection.SNAP_KEY_PREFIX + '%d'
+
+# Past a couple dozen, the oldest moment is dropped with its snapshot key.
+MAX_MOMENTS = 24
+
+# How long a write's expected model.updated echo stays credited.
+# Past this, a stale echo could swallow the next real clobber.
+ECHO_TTL = 30
+
+
+class ReflectionsGuard(object):
+    def __init__(self):
+        self._entries = {}
+        self._warned_sidless = False
+        model.updated.connect(self.__updated_cb)
+
+    def note_moments(self, uid, moments, snaps):
+        """The canonical post-write state for an entry's moments and
+        their snapshots. REPLACES what was held, not an append - a
+        moment the cap evicted is never fought back in.
+        """
+        self.__replace(uid, moments=moments, snaps=snaps)
+
+    def note_sessions(self, uid, sessions):
+        """The canonical post-write state for an entry's sessions. A
+        session with no 'sid' can't be recognised later, so it's never held.
+        """
+        self.__replace(uid, sessions=sessions)
+
+    def __replace(self, uid, moments=None, snaps=None, sessions=None):
+        held = self._entries.setdefault(uid, {
+            'moments': [], 'snaps': {}, 'sessions': [],
+            'echoes': 0, 'echo_born': 0.0, 'pending': False,
+        })
+        if moments is not None:
+            held['moments'] = list(moments)
+        if snaps is not None:
+            held['snaps'] = dict(snaps)
+        if sessions is not None:
+            held['sessions'] = self.__hold_sessions(sessions)
+        held['echoes'] += 1
+        held['echo_born'] = time.monotonic()
+
+    def __hold_sessions(self, sessions):
+        held = []
+        for session in sessions:
+            if not session.get('sid'):
+                if not self._warned_sidless:
+                    logging.warning(
+                        'reflectguard: session without sid cannot be '
+                        'recognised later, dropped from the hold')
+                    self._warned_sidless = True
+                continue
+            copy = dict(session)
+            if 'turns' in copy:
+                copy['turns'] = list(copy['turns'])
+            held.append(copy)
+        return held
+
+    def __updated_cb(self, sender, object_id=None, **kwargs):
+        held = self._entries.get(object_id)
+        if held is None:
+            return
+        if held['echoes'] > 0:
+            if time.monotonic() - held['echo_born'] <= ECHO_TTL:
+                held['echoes'] -= 1
+                return
+            held['echoes'] = 0
+        if held['pending']:
+            return
+        held['pending'] = True
+        GLib.idle_add(self.__remerge, object_id)
+
+    def __remerge(self, uid):
+        held = self._entries.get(uid)
+        if held is None:
+            return False
+        held['pending'] = False
+        try:
+            metadata = model.get(uid)
+        except Exception:
+            logging.exception('reflectguard: could not re-read %r', uid)
+            return False
+        data = reflection.loads(metadata.get('reflections', ''))
+        current = data.get('moments', [])
+        lost = [m for m in held['moments'] if m not in current]
+        lost_snaps = [k for k in held['snaps'] if k not in metadata]
+        lost_sessions = [
+            s for s in held['sessions']
+            if reflection.find_session(data, s.get('sid')) is None]
+        if not lost and not lost_snaps and not lost_sessions:
+            return False
+
+        merged = sorted(current + lost, key=lambda m: m.get('ts', 0))
+        evicted = []
+        while len(merged) > MAX_MOMENTS:
+            evicted.append(merged.pop(0).get('snap_seq'))
+        data['moments'] = merged
+        seqs = [m.get('snap_seq', 0) + 1 for m in merged]
+        data['moment_seq'] = max([data.get('moment_seq', 0)] + seqs)
+
+        for session in lost_sessions:
+            data = reflection.merge_session(data, session)
+        if lost_sessions:
+            data['sessions'] = sorted(
+                data.get('sessions', []), key=lambda s: s.get('ts', 0))
+
+        metadata['reflections'] = reflection.dumps(data)
+        for key in lost_snaps:
+            metadata[key] = held['snaps'][key]
+        for seq in evicted:
+            if seq is not None:
+                metadata.pop(SNAP_KEY % seq, None)
+        try:
+            model.write(metadata, update_mtime=False)
+        except Exception:
+            logging.exception(
+                'reflectguard: could not restore state on %r', uid)
+            return False
+
+        # dumps() may itself have evicted a session past the byte
+        # budget, so hold what actually landed, not what this function
+        # merged (or dropped sessions get fought back in forever).
+        # Re-holding the whole disk list would adopt every sid-bearing
+        # session, resurrecting ones legitimately removed.
+        written = reflection.loads(metadata['reflections'])
+        kept_snaps = {
+            k: v for k, v in held['snaps'].items() if k in metadata}
+        held_sids = {s['sid'] for s in held['sessions']}
+        kept_sessions = [s for s in written['sessions']
+                         if s.get('sid') in held_sids]
+        self.__replace(uid, moments=written['moments'], snaps=kept_snaps,
+                       sessions=kept_sessions)
+        return False
+
+
+_guard = None
+
+
+def get_guard():
+    global _guard
+    if _guard is None:
+        _guard = ReflectionsGuard()
+    return _guard

--- a/src/jarabe/journal/reflectstyle.py
+++ b/src/jarabe/journal/reflectstyle.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The paper design language, in one place.
+
+Every surface the reflection feature draws - the entry page's desk, the
+talk rail, Jo's own face, the moment card, the invite note - shares
+this module as the single source of color and font values.
+
+Two color families exist because two surfaces genuinely differ: the
+entry page's desk (expandedentry, reflectionview, and momentcard's own
+card) reads slightly warmer than the bench tones the invite note and
+Jo's glyph wear (reflectiontrigger, joglyph). Names carry a _PAGE /
+_PANEL suffix wherever the two disagree; where every surface already
+used the same value, they share one name.
+"""
+
+from sugar3.graphics import style
+
+
+def px(n):
+    return style.zoom(n)
+
+
+def pxf(n):
+    return style.ZOOM_FACTOR * n
+
+
+INK_PAGE = '#3A3226'
+INK_SOFT_PAGE = '#8A8070'
+PAPER_PAGE = '#FFFDF7'
+RIM_PAGE = '#E7DECB'
+RULE_PAGE = '#C9E0EE'
+
+INK_PANEL = '#2B2B2B'
+MOUNT_LINE = '#DDD8C9'
+CHIP_LINE = '#DCDFE6'
+
+CARD = '#FFFFFF'
+EMBER = '#E8A33D'
+INK_FAINT = '#B9B0A0'
+
+# momentcard's own rim value - kept separate, not folded into RIM_PAGE.
+RIM_MOMENT = '#E9E4D8'
+
+KRAFT = '#E8DCC8'
+KRAFT_DEEP = '#DFD0B6'
+ART_BG = '#FCFBF7'
+TAG_LINE = '#CBBC9E'
+TAG_ADD = '#A79B82'
+
+MARK_INK = '#C4BAA3'
+MARGIN_RED = '#F0A8A0'
+
+JO_DISC_FILL = '#EDEEF1'
+JO_DISC_LINE = '#D5D6DA'
+
+FONT_HAND = "'Patrick Hand', cursive"
+FONT_ROUND = "'Quicksand', 'Sans Serif', sans-serif"
+FONT_CLEAR = "'Andika', 'Sans Serif', sans-serif"
+
+# Plain family name, for call sites that build a Pango.FontDescription
+# string - Pango parses comma lists fine, but would take FONT_HAND's
+# quotes and CSS generic 'cursive' literally as part of the name.
+FONT_HAND_FAMILY = 'Patrick Hand'

--- a/tests/journal/test_momentcard_keepsakes.py
+++ b/tests/journal/test_momentcard_keepsakes.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+import unittest
+
+# gi is an apt-installed system package, not something `uvx pytest`'s
+# own managed interpreter has -- skip rather than error when it isn't
+# importable.
+#
+# Gtk/Gdk must be pinned to 3.0 before jarabe.journal.momentcard pulls
+# them in bare (via jarabe.journal.model), or PyGObject resolves Gdk to
+# 4.0 first and the later Gtk 3.0 import conflicts with it.
+try:
+    import gi
+    gi.require_version('Gtk', '3.0')
+    gi.require_version('Gdk', '3.0')
+except (ImportError, ValueError):
+    raise unittest.SkipTest('gi is not available')
+
+# jarabe isn't on sys.path outside a built/installed tree.
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
+
+from jarabe.journal import momentcard  # noqa: E402
+
+
+# --- _add_moment: the moment record and its cap, owned by momentcard
+# itself. The shell-memory guarding of a written moment now lives in
+# reflectguard.ReflectionsGuard; see test_reflectguard.py. ---
+
+class TestAddMoment(unittest.TestCase):
+
+    def test_add_moment_appends_a_moment_with_no_eviction_under_the_cap(
+            self):
+        data = {}
+        moment, evicted = momentcard._add_moment(
+            data, 'a dragon wing', 'proud')
+
+        self.assertEqual(evicted, [])
+        self.assertEqual(data['moments'], [moment])
+        self.assertEqual(moment['caption'], 'a dragon wing')
+        self.assertEqual(moment['mark'], 'proud')
+        self.assertEqual(moment['snap_seq'], 0)
+        self.assertEqual(data['moment_seq'], 1)
+
+    def test_add_moment_evicts_the_oldest_past_the_cap(self):
+        data = {}
+        last_evicted = None
+        for i in range(momentcard._MAX_MOMENTS + 1):
+            _moment, last_evicted = momentcard._add_moment(
+                data, 'caption-%d' % i, 'proud')
+
+        # the call that crossed the cap evicted snap_seq 0, the oldest
+        self.assertEqual(last_evicted, [0])
+        self.assertEqual(len(data['moments']), momentcard._MAX_MOMENTS)
+        self.assertEqual(
+            [m['snap_seq'] for m in data['moments']],
+            list(range(1, momentcard._MAX_MOMENTS + 1)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/journal/test_reflectguard.py
+++ b/tests/journal/test_reflectguard.py
@@ -1,0 +1,481 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+import sys
+
+import time
+
+import unittest
+from unittest import mock
+
+# gi is an apt-installed system package, not something `uvx pytest`'s
+# own managed interpreter has -- skip rather than error when it isn't
+# importable.
+#
+# Gtk/Gdk must be pinned to 3.0 before jarabe.journal.reflectguard pulls
+# them in bare (via jarabe.journal.model), or PyGObject resolves Gdk to
+# 4.0 first and the later Gtk 3.0 import conflicts with it.
+try:
+    import gi
+    gi.require_version('Gtk', '3.0')
+    gi.require_version('Gdk', '3.0')
+except (ImportError, ValueError):
+    raise unittest.SkipTest('gi is not available')
+
+# jarabe isn't on sys.path outside a built/installed tree.
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
+
+from jarabe.journal import model  # noqa: E402
+from jarabe.journal import momentcard  # noqa: E402
+from jarabe.journal import reflectguard  # noqa: E402
+from jarabe.journal import reflection  # noqa: E402
+
+
+def _run_idle(test):
+    # Stand in for the real GLib main loop: run the idle callback
+    # __updated_cb schedules immediately, synchronously.
+    patcher = mock.patch.object(
+        reflectguard.GLib, 'idle_add', lambda func, *args: func(*args))
+    patcher.start()
+    test.addCleanup(patcher.stop)
+
+
+def _forbid_model_access(test):
+    def boom(*args, **kwargs):
+        raise AssertionError('model touched when it should not be')
+    for target, attr in (
+            (model, 'get'),
+            (model, 'write'),
+            (reflectguard.GLib, 'idle_add')):
+        patcher = mock.patch.object(target, attr, boom)
+        patcher.start()
+        test.addCleanup(patcher.stop)
+
+
+# --- note_moments: replaces, never merges ---
+
+class TestNoteMomentsReplacesHeldState(unittest.TestCase):
+
+    def test_note_moments_replaces_held_state_rather_than_merging(self):
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_moments(
+            'uid-1', [{'caption': 'first', 'snap_seq': 0}],
+            {'moment-snap-0': 'AAA'})
+        guard.note_moments(
+            'uid-1', [{'caption': 'second', 'snap_seq': 1}],
+            {'moment-snap-1': 'BBB'})
+
+        held = guard._entries['uid-1']
+        self.assertEqual(
+            held['moments'], [{'caption': 'second', 'snap_seq': 1}])
+        self.assertEqual(held['snaps'], {'moment-snap-1': 'BBB'})
+        self.assertEqual(held['echoes'], 2)
+
+
+# --- the echo counter: our own write's Updated signal is swallowed ---
+
+class TestEchoCounterSwallowsOwnUpdate(unittest.TestCase):
+
+    def test_updated_signal_right_after_note_moments_is_swallowed_as_echo(
+            self):
+        _forbid_model_access(self)
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_moments(
+            'uid-echo', [{'caption': 'x', 'ts': 1, 'snap_seq': 0}], {})
+
+        model.updated.send(None, object_id='uid-echo')
+
+        self.assertEqual(guard._entries['uid-echo']['echoes'], 0)
+
+    def test_stale_echo_expires_and_the_update_triggers_a_remerge(self):
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_moments('uid-stale', [{'snap_seq': 1}], {})
+        scheduled = []
+        patcher = mock.patch.object(
+            reflectguard.GLib, 'idle_add',
+            lambda cb, *a: scheduled.append((cb, a)))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        real_monotonic = time.monotonic
+        patcher = mock.patch.object(
+            reflectguard.time, 'monotonic',
+            lambda: real_monotonic() + reflectguard.ECHO_TTL + 1)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        model.updated.send(None, object_id='uid-stale')
+        self.assertEqual(len(scheduled), 1)
+        self.assertEqual(guard._entries['uid-stale']['echoes'], 0)
+
+    def test_updated_signal_for_untracked_uid_is_ignored(self):
+        _forbid_model_access(self)
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_moments('held-uid', [], {})
+
+        model.updated.send(None, object_id='never-held')
+
+        self.assertEqual(guard._entries['held-uid']['echoes'], 1)
+
+
+# --- the re-merge: restore what a clobbering write erased ---
+
+class TestRemergeRestoresClobberedWrite(unittest.TestCase):
+
+    def test_remerge_restores_moments_and_snaps_lost_to_a_clobbering_write(
+            self):
+        _run_idle(self)
+        uid = 'uid-remerge'
+        moment = {'caption': 'a dragon wing', 'mark': 'proud', 'ts': 100,
+                  'snap_seq': 0}
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_moments(
+            uid, [moment], {reflectguard.SNAP_KEY % 0: 'AAA=='})
+        # our own write's echo arrives first and must not be treated as a
+        # clobber
+        model.updated.send(None, object_id=uid)
+
+        written = []
+        # the activity resumed and saved with metadata that never mentions
+        # our moment or its snapshot -- a real clobbering write
+        patcher = mock.patch.object(model, 'get', lambda object_id: {})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch.object(
+            model, 'write',
+            lambda metadata, **kwargs: written.append(dict(metadata)))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        model.updated.send(None, object_id=uid)
+
+        self.assertEqual(len(written), 1)
+        data = reflection.loads(written[0]['reflections'])
+        self.assertEqual(data['moments'], [moment])
+        self.assertEqual(written[0][reflectguard.SNAP_KEY % 0], 'AAA==')
+
+    def test_remerge_noop_when_nothing_was_actually_lost(self):
+        _run_idle(self)
+        uid = 'uid-noop'
+        moment = {'caption': 'x', 'ts': 1, 'snap_seq': 0}
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_moments(uid, [moment], {reflectguard.SNAP_KEY % 0: 'AAA'})
+        model.updated.send(None, object_id=uid)  # swallow our own echo
+
+        def boom(*args, **kwargs):
+            raise AssertionError('write touched when nothing was lost')
+        intact = {
+            'reflections': reflection.dumps({'moments': [moment]}),
+            reflectguard.SNAP_KEY % 0: 'AAA',
+        }
+        patcher = mock.patch.object(model, 'get', lambda object_id: intact)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch.object(model, 'write', boom)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        # a genuine but unrelated Updated signal -- neither the moment nor
+        # its snapshot is actually missing from the datastore's copy
+        model.updated.send(None, object_id=uid)
+
+        self.assertIs(guard._entries[uid]['pending'], False)
+
+    def test_remerge_evicts_oldest_moments_past_the_cap(self):
+        _run_idle(self)
+        uid = 'uid-evict'
+        cap = reflectguard.MAX_MOMENTS
+        moments = [
+            {'caption': 'm%d' % i, 'ts': i, 'snap_seq': i}
+            for i in range(cap + 1)]
+        snaps = {reflectguard.SNAP_KEY % i: 'data%d' % i
+                 for i in range(cap + 1)}
+
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_moments(uid, moments, snaps)
+        model.updated.send(None, object_id=uid)  # swallow our own echo
+
+        written = []
+        # the moments never reached the datastore at all; the snapshots did
+        metadata = dict(snaps)
+        patcher = mock.patch.object(model, 'get', lambda object_id: metadata)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch.object(
+            model, 'write',
+            lambda md, **kwargs: written.append(dict(md)))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        model.updated.send(None, object_id=uid)
+
+        self.assertEqual(len(written), 1)
+        data = reflection.loads(written[0]['reflections'])
+        self.assertEqual(len(data['moments']), cap)
+        # the oldest (ts=0 / snap_seq=0) is the one the cap dropped
+        self.assertEqual(
+            [m['snap_seq'] for m in data['moments']], list(range(1, cap + 1)))
+        self.assertNotIn(reflectguard.SNAP_KEY % 0, written[0])
+        self.assertIn(reflectguard.SNAP_KEY % 1, written[0])
+
+
+# --- the echo counter also guards the re-merge's own follow-up write ---
+
+class TestRemergeOwnWriteEchoSwallowed(unittest.TestCase):
+
+    def test_remerges_own_write_echo_is_swallowed_next_time(self):
+        _run_idle(self)
+        uid = 'uid-loop-guard'
+        moment = {'caption': 'x', 'mark': 'wonder', 'ts': 1, 'snap_seq': 0}
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_moments(uid, [moment], {})
+        model.updated.send(None, object_id=uid)  # swallow our own echo
+
+        written = []
+        patcher = mock.patch.object(model, 'get', lambda object_id: {})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch.object(
+            model, 'write',
+            lambda md, **kwargs: written.append(dict(md)))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        model.updated.send(None, object_id=uid)  # the real clobber -> remerge
+        self.assertEqual(len(written), 1)
+
+        # the Updated signal the remerge's own model.write() just emitted is
+        # the next one in -- it must be swallowed, not chased as another
+        # clobber, or every remerge would retrigger itself forever.
+        model.updated.send(None, object_id=uid)
+        self.assertEqual(len(written), 1)
+
+
+# --- the pending flag: only one re-merge in flight per entry ---
+
+class TestPendingFlagLimitsInFlightRemerge(unittest.TestCase):
+
+    def test_second_updated_signal_while_pending_does_not_reschedule(self):
+        scheduled = []
+        patcher = mock.patch.object(
+            reflectguard.GLib, 'idle_add',
+            lambda func, *args: scheduled.append((func, args)))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        uid = 'uid-pending'
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_moments(uid, [{'caption': 'x', 'ts': 1, 'snap_seq': 0}], {})
+        model.updated.send(None, object_id=uid)  # swallow our own echo
+
+        model.updated.send(None, object_id=uid)  # real signal: schedules once
+        # a second real signal, arriving before the idle callback above runs
+        model.updated.send(None, object_id=uid)
+
+        self.assertEqual(len(scheduled), 1)
+        self.assertIs(guard._entries[uid]['pending'], True)
+
+
+# --- get_guard(): one guard for the whole shell ---
+
+class TestGetGuardSingleton(unittest.TestCase):
+
+    def test_get_guard_returns_the_same_instance_every_time(self):
+        self.assertIs(reflectguard.get_guard(), reflectguard.get_guard())
+
+
+# --- note_sessions: sid required to be held at all ---
+
+class TestNoteSessionsRequiresSid(unittest.TestCase):
+
+    def test_note_sessions_drops_sessions_without_a_sid_and_warns_once(self):
+        guard = reflectguard.ReflectionsGuard()
+        kept = {'sid': 'sid-a', 'ts': 1, 'turns': [{'role': 'child',
+                                                    'text': 'hi'}]}
+        with self.assertLogs(level=logging.WARNING) as cm:
+            guard.note_sessions('uid-a', [kept, {'ts': 2, 'turns': []}])
+            guard.note_sessions('uid-b', [{'ts': 3, 'turns': []}])
+
+        held_a = guard._entries['uid-a']['sessions']
+        self.assertEqual(len(held_a), 1)
+        self.assertEqual(held_a[0]['sid'], 'sid-a')
+        self.assertEqual(guard._entries['uid-b']['sessions'], [])
+        # one warning for the whole guard's lifetime, not one per offence
+        sidless_warnings = [r for r in cm.records if 'sid' in r.getMessage()]
+        self.assertEqual(len(sidless_warnings), 1)
+
+        # a deep-ish copy: mutating the caller's turns afterwards must not
+        # reach into what the guard is holding
+        kept['turns'].append({'role': 'child', 'text': 'later'})
+        self.assertEqual(len(held_a[0]['turns']), 1)
+
+
+# --- the re-merge: restore a session lost to a clobbering write ---
+
+class TestRemergeRestoresLostSession(unittest.TestCase):
+
+    def test_remerge_restores_a_lost_session_and_keeps_the_fresh_blobs_content(
+            self):
+        _run_idle(self)
+        uid = 'uid-session-remerge'
+        lost = {
+            'sid': 'sid-lost', 'ts': 100,
+            'turns': [{'role': 'child', 'text': 'a dragon wing'}]}
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_sessions(uid, [lost])
+        model.updated.send(None, object_id=uid)  # swallow our own echo
+
+        fresh_session = {
+            'sid': 'sid-fresh', 'ts': 200,
+            'turns': [{'role': 'child', 'text': 'something else'}]}
+        fresh_reflections = reflection.dumps(
+            {'version': 1, 'sessions': [fresh_session]})
+        written = []
+        patcher = mock.patch.object(
+            model, 'get',
+            lambda object_id: {'reflections': fresh_reflections,
+                               'title': 'Untitled'})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch.object(
+            model, 'write',
+            lambda metadata, **kwargs: written.append(dict(metadata)))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        model.updated.send(None, object_id=uid)
+
+        self.assertEqual(len(written), 1)
+        data = reflection.loads(written[0]['reflections'])
+        self.assertEqual(reflection.find_session(data, 'sid-lost'), lost)
+        self.assertEqual(
+            reflection.find_session(data, 'sid-fresh'), fresh_session)
+        # sessions come back in chronological order after the merge
+        self.assertEqual(
+            [s['sid'] for s in data['sessions']], ['sid-lost', 'sid-fresh'])
+        # the fresh blob's other metadata is untouched by the restore
+        self.assertEqual(written[0]['title'], 'Untitled')
+
+
+# --- the re-merge: what dumps() itself evicts must not loop forever ---
+
+class TestRemergeRespectsDumpsEvictionBound(unittest.TestCase):
+
+    def test_remerge_holds_what_dumps_actually_wrote_when_it_evicts_a_session(
+            self):
+        _run_idle(self)
+        patcher = mock.patch.object(reflection, 'MAX_REFLECTIONS_BYTES', 400)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        uid = 'uid-dumps-bound'
+        lost = {
+            'sid': 'sid-lost', 'ts': 1,
+            'turns': [{'role': 'child', 'text': 'x' * 200}]}
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_sessions(uid, [lost])
+        model.updated.send(None, object_id=uid)  # swallow our own echo
+
+        newer = {
+            'sid': 'sid-newer', 'ts': 2,
+            'turns': [{'role': 'child', 'text': 'y' * 200}]}
+        fresh_reflections = reflection.dumps(
+            {'version': 1, 'sessions': [newer]})
+        written = []
+        patcher = mock.patch.object(
+            model, 'get', lambda object_id: {'reflections': fresh_reflections})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch.object(
+            model, 'write',
+            lambda metadata, **kwargs: written.append(dict(metadata)))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        model.updated.send(None, object_id=uid)
+
+        self.assertEqual(len(written), 1)
+        data = reflection.loads(written[0]['reflections'])
+        # the tiny budget leaves room for only the newest session -- the
+        # just-restored one is the one dumps() drops right back out
+        self.assertEqual([s['sid'] for s in data['sessions']], ['sid-newer'])
+
+        # dumps() dropped the restored session past the tiny budget, so
+        # the guard stops holding it -- and it never adopts sid-newer,
+        # which nobody asked it to guard in the first place
+        self.assertEqual(guard._entries[uid]['sessions'], [])
+
+        # the remerge's own write emitted its own Updated -- swallowed as
+        # an echo -- and a genuine follow-up after that must not re-trigger
+        # a write, since held state and disk now agree
+        model.updated.send(None, object_id=uid)  # the write's own echo
+        model.updated.send(None, object_id=uid)  # a real, unrelated signal
+        self.assertEqual(len(written), 1)
+
+
+# --- the shared echo counter across a mixed moments+sessions remerge ---
+
+class TestMixedMomentsAndSessionsEchoSuppression(unittest.TestCase):
+
+    def test_echo_suppression_holds_across_a_mixed_moments_and_sessions_write(
+            self):
+        _run_idle(self)
+        uid = 'uid-mixed'
+        moment = {'caption': 'x', 'mark': 'wonder', 'ts': 1, 'snap_seq': 0}
+        session = {
+            'sid': 'sid-x', 'ts': 1,
+            'turns': [{'role': 'child', 'text': 'hi'}]}
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_moments(uid, [moment], {})
+        guard.note_sessions(uid, [session])
+        # both prior writes' echoes must be swallowed before the clobber
+        model.updated.send(None, object_id=uid)
+        model.updated.send(None, object_id=uid)
+
+        written = []
+        patcher = mock.patch.object(model, 'get', lambda object_id: {})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch.object(
+            model, 'write',
+            lambda md, **kwargs: written.append(dict(md)))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        model.updated.send(None, object_id=uid)  # the real clobber -> remerge
+        self.assertEqual(len(written), 1)
+        data = reflection.loads(written[0]['reflections'])
+        self.assertEqual(data['moments'], [moment])
+        self.assertIsNotNone(reflection.find_session(data, 'sid-x'))
+
+        # one physical write touching both moments and sessions must cost
+        # exactly one echo, not two
+        self.assertEqual(guard._entries[uid]['echoes'], 1)
+
+        model.updated.send(None, object_id=uid)  # the write's own echo
+        self.assertEqual(guard._entries[uid]['echoes'], 0)
+        self.assertEqual(len(written), 1)
+
+
+# --- guarding against a naming drift between the two modules under test ---
+
+class TestModuleNamingDrift(unittest.TestCase):
+
+    def test_momentcard_still_uses_reflectguards_snap_key_and_cap(self):
+        self.assertEqual(momentcard.SNAP_KEY, reflectguard.SNAP_KEY)
+        self.assertEqual(momentcard._MAX_MOMENTS, reflectguard.MAX_MOMENTS)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Seven commits:
the first child-visible piece. Jo gets a frame icon; tapping it opens a moment card: a snap, a mark, and a line in the
child's own words. 
Also: reflectstyle (shared palette/type), the glyph, reflectguard, and Frame.hide() completion reporting.

Builds on #1112 (timeline helpers) and #1117.

- sugar-datastore PR [https://github.com/sugarlabs/sugar-datastore/pull/30] must land first: snaps are base64 JPEG in
  metadata; without it Xapian tokenises ~1.5 MB of junk per save at the moment cap.
- reflectguard is a declared workaround: datastore update() deletes omitted keys, so activity saves wipe shell-written reflections; the guard re-merges. Retires when the datastore merges instead.
- Frame.hide() gains a completion callback. Animator.stop() emits completed' like a finished run, so the callback checks real frame state, else the card opens over a returning frame.
- Nine broad `except Exception` in momentcard (X11, datastore, pixbuf); eight log. Not narrowed: PyGObject's raisable sets are undocumented, a wrong guess crashes instead of degrading. Third CssProvider of six.
- reflectstyle names Patrick Hand and Quicksand, Sans Serif fallback; neither ships here, no runtime check.

238 journal tests, 17 new (15 guard, 2 card). 
The mid-retract race isn't scriptable, the callback's check is reasoned, not observed; the rest walked live. 
New files in Makefile.am and POTFILES.in. 
Series notes in #1111.