### PR TITLE
journal: scale chooser previews to classic cells

### DIFF
--- a/src/jarabe/journal/iconview.py
+++ b/src/jarabe/journal/iconview.py
@@ -22,11 +22,15 @@ from gi.repository import Gtk
 from gi.repository import GLib
 
 from jarabe.journal.iconmodel import IconModel
+from sugar3.activity.activity import PREVIEW_SIZE
 from sugar3.graphics.icon import Icon
 from jarabe.journal import model
 from sugar3.graphics.objectchooser import get_preview_pixbuf
 from sugar3.graphics import style
-from sugar3.activity.activity import PREVIEW_SIZE
+
+# Previews are saved at PREVIEW_SIZE; the grid shows them at 5/12
+# scale so the chooser keeps its classic 300x225 cells.
+THUMB_SIZE = (PREVIEW_SIZE[0] * 5 // 12, PREVIEW_SIZE[1] * 5 // 12)
 
 
 class PreviewRenderer(Gtk.CellRendererPixbuf):
@@ -39,15 +43,16 @@ class PreviewRenderer(Gtk.CellRendererPixbuf):
         self._preview_data = data
 
     def do_render(self, cr, widget, background_area, cell_area, flags):
-        self.props.pixbuf = get_preview_pixbuf(self._preview_data)
+        self.props.pixbuf = get_preview_pixbuf(self._preview_data,
+                                               THUMB_SIZE[0], THUMB_SIZE[1])
         Gtk.CellRendererPixbuf.do_render(self, cr, widget, background_area,
                                          cell_area, flags)
 
     def do_get_size(self, widget, cell_area):
         x_offset, y_offset, width, height = Gtk.CellRendererPixbuf.do_get_size(
             self, widget, cell_area)
-        width = PREVIEW_SIZE[0]
-        height = PREVIEW_SIZE[1]
+        width = THUMB_SIZE[0]
+        height = THUMB_SIZE[1]
         return (x_offset, y_offset, width, height)
 
 


### PR DESCRIPTION
The Journal chooser sizes its grid cells from the toolkit's PREVIEW_SIZE, so when sugarlabs/sugar-toolkit-gtk3#520 raises that constant to 720x540 the chooser's cells grow with it. This will render previews at 5/12 scale instead, so the chooser keeps its classic 300x225 cells.

Independent of the #1111 stack.

**IMPORTANT** :
It needs #520 merged first. This is the sugar-side follow-up mentioned in #520's description.

Testing: 
the journal suite on my series branches (299 tests) passes with this change included; current master has no test covering the chooser renderer.