### PR TITLE
journal: ai server configuration panel on the settings menu

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ data/icons/Makefile
 data/Makefile
 extensions/cpsection/aboutcomputer/Makefile
 extensions/cpsection/aboutme/Makefile
+extensions/cpsection/ai/Makefile
 extensions/cpsection/background/Makefile
 extensions/cpsection/backup/Makefile
 extensions/cpsection/backup/backends/Makefile

--- a/data/icons/Makefile.am
+++ b/data/icons/Makefile.am
@@ -3,6 +3,7 @@ sugardir = $(pkgdatadir)/data/icons
 sugar_DATA =                        \
 	module-about_me.svg             \
 	module-about_my_computer.svg    \
+	module-ai.svg                   \
 	module-date_and_time.svg        \
 	module-frame.svg                \
 	module-keyboard.svg             \

--- a/data/icons/module-ai.svg
+++ b/data/icons/module-ai.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
+	<!ENTITY stroke_color "#666666">
+	<!ENTITY fill_color "#ffffff">
+]><svg enable-background="new 0 0 55 55" height="55px" version="1.1" viewBox="0 0 55 55" width="55px" xmlns="http://www.w3.org/2000/svg">
+<g id="module-ai">
+	<circle cx="27.5" cy="5" r="3" fill="&fill_color;" stroke="&stroke_color;" stroke-width="1.5"/>
+	<line x1="27.5" y1="8" x2="27.5" y2="14" stroke="&stroke_color;" stroke-width="2.5" stroke-linecap="round"/>
+	<path d="M13.5,28 a14,14 0 0 1 28,0 v17 a3.5,3.5 0 0 1 -3.5,3.5 h-21 a3.5,3.5 0 0 1 -3.5,-3.5 z" fill="&fill_color;" stroke="&stroke_color;" stroke-width="3"/>
+	<rect x="17.5" y="25" width="20" height="9" rx="4.5" fill="&stroke_color;"/>
+	<circle cx="23" cy="29.5" r="2.2" fill="&fill_color;"/>
+	<circle cx="32" cy="29.5" r="2.2" fill="&fill_color;"/>
+	<path d="M21.5,41 Q27.5,45 33.5,41" fill="none" stroke="&stroke_color;" stroke-width="2.5" stroke-linecap="round"/>
+</g></svg>

--- a/extensions/cpsection/Makefile.am
+++ b/extensions/cpsection/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = aboutme aboutcomputer background backup datetime frame keyboard language \
+SUBDIRS = aboutme aboutcomputer ai background backup datetime frame keyboard language \
     modemconfiguration network power updater webaccount
 
 sugardir = $(pkgdatadir)/extensions/cpsection

--- a/extensions/cpsection/ai/Makefile.am
+++ b/extensions/cpsection/ai/Makefile.am
@@ -1,0 +1,6 @@
+sugardir = $(pkgdatadir)/extensions/cpsection/ai
+
+sugar_PYTHON = 		\
+	__init__.py	\
+	model.py	\
+	view.py

--- a/extensions/cpsection/ai/__init__.py
+++ b/extensions/cpsection/ai/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gettext import gettext as _
+
+CLASS = 'AI'
+ICON = 'module-ai'
+TITLE = _('AI')
+KEYWORDS = ['ai', 'reflection', 'jo', 'journal', 'server', 'assistant']

--- a/extensions/cpsection/ai/model.py
+++ b/extensions/cpsection/ai/model.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import configparser
+import logging
+import os
+import tempfile
+
+from jarabe.journal import reflection
+
+_SECTION = 'reflection'
+
+
+def _read_parser():
+    # interpolation=None keeps '%' in urls and keys literal.
+    parser = configparser.ConfigParser(interpolation=None)
+    try:
+        parser.read(reflection.DEFAULT_CONFIG_PATH)
+    except (configparser.Error, OSError, ValueError):
+        # A file we cannot parse holds nothing we could edit, and a
+        # half-read parser is worse than an empty one: start over, so
+        # the panel opens and the next write lays down a sound file.
+        logging.exception('ai: error reading %r',
+                          reflection.DEFAULT_CONFIG_PATH)
+        parser = configparser.ConfigParser(interpolation=None)
+    if not parser.has_section(_SECTION):
+        parser.add_section(_SECTION)
+    return parser
+
+
+# The getters read the file itself, not reflection.read_config():
+# that merged view includes environment overrides, and an editor
+# that round-trips them through undo would bake them into the file.
+
+def get_enabled():
+    try:
+        return _read_parser().getboolean(
+            _SECTION, 'enabled', fallback=reflection.DEFAULT_ENABLED)
+    except ValueError:
+        return reflection.DEFAULT_ENABLED
+
+
+def get_url():
+    return _read_parser().get(_SECTION, 'url', fallback='')
+
+
+def get_api_key():
+    return _read_parser().get(_SECTION, 'api_key', fallback='')
+
+
+def set_enabled(enabled):
+    _write_option('enabled', 'true' if enabled else 'false')
+
+
+def set_url(url):
+    _write_option('url', url.strip())
+
+
+def set_api_key(api_key):
+    _write_option('api_key', api_key.strip())
+
+
+def _write_option(option, value):
+    path = reflection.DEFAULT_CONFIG_PATH
+    parser = _read_parser()
+    parser.set(_SECTION, option, value)
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        _write_parser(parser, path)
+    except OSError:
+        # A read-only home must not trap the child in the panel:
+        # Cancel walks the same setters back.
+        logging.exception('ai: error writing %r', path)
+
+
+def _write_parser(parser, path):
+    # The file may hold a server key; never leave it readable to
+    # others, not even between creation and a later chmod. The rename
+    # lands whole, so a failed write cannot leave a truncated key for
+    # the journal to read.
+    fd, temp_path = tempfile.mkstemp(dir=os.path.dirname(path),
+                                     prefix='reflection.conf.')
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, 'w') as config_file:
+            parser.write(config_file)
+        os.replace(temp_path, path)
+    except OSError:
+        os.unlink(temp_path)
+        raise

--- a/extensions/cpsection/ai/view.py
+++ b/extensions/cpsection/ai/view.py
@@ -1,0 +1,347 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import logging
+import ssl
+import threading
+import urllib.error
+import urllib.request
+
+from gi.repository import GLib
+from gi.repository import Gtk
+from gettext import gettext as _
+
+from sugar3 import profile
+from sugar3.graphics import style
+from sugar3.graphics.icon import Icon
+from sugar3.graphics.xocolor import XoColor
+
+from jarabe.controlpanel.sectionview import SectionView
+
+_NEUTRAL_COLOR = '#666666,%s' % style.COLOR_WHITE.get_html()
+
+
+class AI(SectionView):
+    def __init__(self, model, alerts):
+        SectionView.__init__(self)
+
+        self._model = model
+        self.restart_alerts = alerts
+        self._write_timeouts = {}
+        self._check_generation = 0
+        self._initial = {
+            'enabled': model.get_enabled(),
+            'url': model.get_url(),
+            'api_key': model.get_api_key(),
+        }
+
+        self.set_border_width(style.DEFAULT_SPACING * 2)
+        self.set_spacing(style.DEFAULT_SPACING)
+        group = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
+
+        label_about = Gtk.Label(
+            label=_('Jo asks short questions about Journal entries. '
+                    'With a server, Jo asks with AI help; without '
+                    'one, Jo uses its built-in questions.'))
+        label_about.set_alignment(0, 0)
+        label_about.set_line_wrap(True)
+        self.pack_start(label_about, False, True, 0)
+        label_about.show()
+
+        box_server = Gtk.VBox()
+        box_server.set_border_width(style.DEFAULT_SPACING * 2)
+        box_server.set_spacing(style.DEFAULT_SPACING)
+
+        frame = Gtk.Frame()
+        frame.set_halign(Gtk.Align.START)
+        box_card = Gtk.HBox(spacing=style.DEFAULT_SPACING * 4)
+        box_card.set_border_width(style.DEFAULT_SPACING * 2)
+
+        box_fields = Gtk.VBox(spacing=style.DEFAULT_SPACING)
+
+        box_enabled = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        self._enabled_button = Gtk.CheckButton()
+        label_enabled = Gtk.Label(label=_('Use the AI server'))
+        label_enabled.set_alignment(0, 0.5)
+        box_enabled.pack_start(self._enabled_button, False, True, 0)
+        box_enabled.pack_start(label_enabled, False, True, 0)
+        self._enabled_button.show()
+        label_enabled.show()
+        box_fields.pack_start(box_enabled, False, True, 0)
+        box_enabled.show()
+
+        css = Gtk.CssProvider()
+        css.load_from_data(
+            ('entry { caret-color: %s; }'
+             % style.COLOR_TOOLBAR_GREY.get_html()).encode())
+
+        box_url = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        label_url = Gtk.Label(label=_('Address'))
+        label_url.set_alignment(0, 0.5)
+        group.add_widget(label_url)
+        self._url_entry = Gtk.Entry()
+        self._url_entry.set_width_chars(30)
+        self._url_entry.get_style_context().add_provider(
+            css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+        box_url.pack_start(label_url, False, True, 0)
+        box_url.pack_start(self._url_entry, False, True, 0)
+        label_url.show()
+        self._url_entry.show()
+        box_fields.pack_start(box_url, False, True, 0)
+        box_url.show()
+
+        box_key = Gtk.HBox(spacing=style.DEFAULT_SPACING)
+        label_key = Gtk.Label(label=_('Key'))
+        label_key.set_alignment(0, 0.5)
+        group.add_widget(label_key)
+        self._key_entry = Gtk.Entry()
+        self._key_entry.set_width_chars(30)
+        self._key_entry.set_visibility(False)
+        self._key_entry.get_style_context().add_provider(
+            css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+        self._key_entry.set_icon_from_icon_name(
+            Gtk.EntryIconPosition.SECONDARY, 'view-reveal-symbolic')
+        self._key_entry.set_icon_tooltip_text(
+            Gtk.EntryIconPosition.SECONDARY, _('Show the key'))
+        self._key_entry.connect('icon-press', self.__key_icon_press_cb)
+        box_key.pack_start(label_key, False, True, 0)
+        box_key.pack_start(self._key_entry, False, True, 0)
+        label_key.show()
+        self._key_entry.show()
+        box_fields.pack_start(box_key, False, True, 0)
+        box_key.show()
+
+        box_card.pack_start(box_fields, False, True, 0)
+        box_fields.show()
+
+        box_status = Gtk.VBox(spacing=style.DEFAULT_SPACING // 2)
+        box_status.set_valign(Gtk.Align.CENTER)
+        # Fixed width so verdicts of different lengths cannot resize
+        # the card.
+        box_status.set_size_request(style.GRID_CELL_SIZE * 3, -1)
+        self._status_icon = Icon(icon_name='module-ai',
+                                 pixel_size=style.STANDARD_ICON_SIZE)
+        self._status_title = Gtk.Label()
+        self._status_label = Gtk.Label()
+        self._status_label.set_line_wrap(True)
+        self._status_label.set_max_width_chars(26)
+        self._status_label.set_justify(Gtk.Justification.CENTER)
+        self._status_label.set_selectable(True)
+        box_status.pack_start(self._status_icon, False, True, 0)
+        box_status.pack_start(self._status_title, False, True, 0)
+        box_status.pack_start(self._status_label, False, True, 0)
+        self._status_title.show()
+        self._status_label.show()
+        box_card.pack_start(box_status, True, True, 0)
+        box_status.show()
+
+        frame.add(box_card)
+        box_card.show()
+        box_server.pack_start(frame, False, True, 0)
+        frame.show()
+
+        self._pending_checks = 0
+        self._last_spawn = 0
+        self.connect('destroy', self.__destroy_cb)
+        self._poll_timer = GLib.timeout_add_seconds(10, self.__poll_cb)
+        self._oneshot_timer = GLib.timeout_add(500, self.__oneshot_check_cb)
+
+        self.pack_start(box_server, False, True, 0)
+        box_server.show()
+
+        self.setup()
+
+    def setup(self):
+        self._enabled_button.set_active(self._initial['enabled'])
+        self._url_entry.set_text(self._initial['url'])
+        self._key_entry.set_text(self._initial['api_key'])
+
+        self.needs_restart = False
+        self.props.is_valid = True
+
+        self._enabled_handler = self._enabled_button.connect(
+            'toggled', self.__enabled_toggled_cb)
+        self._url_handler = self._url_entry.connect(
+            'changed', self.__url_changed_cb)
+        self._key_handler = self._key_entry.connect(
+            'changed', self.__key_changed_cb)
+
+    def undo(self):
+        self._enabled_button.disconnect(self._enabled_handler)
+        self._url_entry.disconnect(self._url_handler)
+        self._key_entry.disconnect(self._key_handler)
+        for source_id in self._write_timeouts.values():
+            GLib.source_remove(source_id)
+        self._write_timeouts.clear()
+        self._check_generation += 1
+        self._model.set_enabled(self._initial['enabled'])
+        self._model.set_url(self._initial['url'])
+        self._model.set_api_key(self._initial['api_key'])
+
+    def __destroy_cb(self, widget):
+        self._check_generation += 1
+        if self._poll_timer is not None:
+            GLib.source_remove(self._poll_timer)
+            self._poll_timer = None
+        if self._oneshot_timer is not None:
+            GLib.source_remove(self._oneshot_timer)
+            self._oneshot_timer = None
+
+    def __oneshot_check_cb(self):
+        self._oneshot_timer = None
+        self.__poll_cb()
+        return False
+
+    def __poll_cb(self):
+        # Skip while a probe is in flight so slow servers cannot stack
+        # threads; the age check keeps one wedged probe from
+        # silencing the poll for good.
+        if self._pending_checks > 0 and \
+                GLib.get_monotonic_time() - self._last_spawn < 60000000:
+            return True
+        url = self._url_entry.get_text().strip()
+        if not url:
+            self._status_title.set_text('')
+            self._status_label.set_text('')
+            self._status_icon.hide()
+        elif not url.startswith(('http://', 'https://')):
+            self._status_title.set_text('')
+            self._status_label.set_text(
+                _('The address should start with http:// or https://'))
+            self._status_icon.hide()
+        elif not self._key_entry.get_text().strip():
+            # The journal asks for both, so a green light on the
+            # address alone would promise a talk it will not have.
+            self._show_status(
+                _('This server needs a key too. Ask whoever set '
+                  'it up for one.'), False)
+        else:
+            self.__start_check(url, self._check_generation)
+        return True
+
+    def __enabled_toggled_cb(self, widget):
+        self._model.set_enabled(widget.get_active())
+
+    def __key_icon_press_cb(self, entry, position, event):
+        visible = not entry.get_visibility()
+        entry.set_visibility(visible)
+        entry.set_icon_from_icon_name(
+            Gtk.EntryIconPosition.SECONDARY,
+            'view-conceal-symbolic' if visible else 'view-reveal-symbolic')
+        entry.set_icon_tooltip_text(
+            Gtk.EntryIconPosition.SECONDARY,
+            _('Hide the key') if visible else _('Show the key'))
+
+    def __url_changed_cb(self, widget):
+        self._invalidate_check()
+        self._schedule_write('url', widget.get_text())
+
+    def __key_changed_cb(self, widget):
+        self._invalidate_check()
+        self._schedule_write('api_key', widget.get_text())
+
+    def _invalidate_check(self):
+        # A result for the old address or key must not land on the new
+        # one; the stale thread's reply is dropped by generation.
+        self._check_generation += 1
+        self._status_title.set_text('')
+        self._status_label.set_text('')
+        self._status_icon.hide()
+        if self._oneshot_timer is not None:
+            GLib.source_remove(self._oneshot_timer)
+        self._oneshot_timer = GLib.timeout_add(
+            1200, self.__oneshot_check_cb)
+
+    def _schedule_write(self, option, value):
+        # Coalesce keystrokes so half-typed values rarely reach the
+        # file the journal rail reads live.
+        source_id = self._write_timeouts.pop(option, None)
+        if source_id is not None:
+            GLib.source_remove(source_id)
+        self._write_timeouts[option] = GLib.timeout_add(
+            600, self.__write_cb, option, value)
+
+    def __write_cb(self, option, value):
+        self._write_timeouts.pop(option, None)
+        if option == 'url':
+            self._model.set_url(value)
+        else:
+            self._model.set_api_key(value)
+        return False
+
+    def __start_check(self, url, generation):
+        self._pending_checks += 1
+        self._last_spawn = GLib.get_monotonic_time()
+        thread = threading.Thread(
+            target=self.__check_health,
+            args=(url, self._key_entry.get_text().strip(), generation))
+        thread.daemon = True
+        thread.start()
+
+    def __check_health(self, url, key, generation):
+        connected = False
+        try:
+            request = urllib.request.Request(url.rstrip('/') + '/health')
+            if key:
+                request.add_header('X-API-Key', key)
+            response = urllib.request.urlopen(request, timeout=5)
+            payload = json.loads(response.read(65536).decode())
+            if not isinstance(payload, dict):
+                raise ValueError('unexpected health reply')
+        except urllib.error.HTTPError:
+            message = _('That address does not look like a Sugar AI server.')
+        except urllib.error.URLError as error:
+            if isinstance(getattr(error, 'reason', None), ssl.SSLError):
+                message = _('Could not make a secure connection '
+                            'to the server.')
+            else:
+                message = _('Could not reach the server. '
+                            'Check the address.')
+        except (ValueError, UnicodeDecodeError):
+            message = _('That address does not look like a Sugar AI server.')
+        except Exception:
+            logging.exception('ai: unexpected failure probing %r', url)
+            message = _('Could not reach the server. Check the address.')
+        else:
+            if payload.get('status') == 'healthy':
+                connected = True
+                model = payload.get('model')
+                if model:
+                    message = _('The server is ready (%s).') % model
+                else:
+                    message = _('The server is ready.')
+            else:
+                message = _('The server answered, but its AI is not ready.')
+        GLib.idle_add(self.__check_done_cb, message, generation, connected)
+
+    def __check_done_cb(self, message, generation, connected):
+        self._pending_checks = max(0, self._pending_checks - 1)
+        if generation != self._check_generation:
+            return False
+        self._show_status(message, connected)
+        return False
+
+    def _show_status(self, message, connected):
+        if connected:
+            self._status_icon.props.xo_color = profile.get_color()
+            title = _('Connected')
+        else:
+            self._status_icon.props.xo_color = XoColor(_NEUTRAL_COLOR)
+            title = _('Not connected')
+        self._status_icon.show()
+        self._status_title.set_markup(
+            '<b>%s</b>' % GLib.markup_escape_text(title))
+        self._status_label.set_text(message)

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -5,6 +5,8 @@ extensions/cpsection/aboutme/view.py
 extensions/cpsection/aboutcomputer/__init__.py
 extensions/cpsection/aboutcomputer/model.py
 extensions/cpsection/aboutcomputer/view.py
+extensions/cpsection/ai/__init__.py
+extensions/cpsection/ai/view.py
 extensions/cpsection/background/__init__.py
 extensions/cpsection/background/view.py
 extensions/cpsection/datetime/__init__.py

--- a/src/jarabe/journal/reflection.py
+++ b/src/jarabe/journal/reflection.py
@@ -184,14 +184,18 @@ def kept_lines(raw, description, limit=2):
     return lines
 
 
-def add_turn(session, role, text, peer=False, q=None, local=False):
+def add_turn(session, role, text, peer=False, q=None, local=False,
+             typed=None):
     """Append a turn to a session and return it. peer marks a Jo turn
     voicing another child's comment, and rides the stored turn so
     later sessions still read it as a people question. q is the
     scripted question's stable id, stamped from the text or passed in
     when a composed line stands in for a script slot. local marks a Jo
     turn whose text must never reach the wire, and latches the child's
-    answer off the wire with it.
+    answer off the wire with it. typed carries the engine's stamped
+    fields for a server turn (kind, engagement, and the flags), so
+    the next request rebuilds the engine's record exactly instead of
+    re-deriving anything from text.
     """
     if role not in (ROLE_JO, ROLE_CHILD):
         raise ValueError('Unknown role: %r' % (role,))
@@ -205,6 +209,12 @@ def add_turn(session, role, text, peer=False, q=None, local=False):
             turn['q'] = q
         if local:
             turn['local'] = True
+        if typed:
+            turn['kind'] = typed.get('kind', 'question')
+            turn['engagement'] = typed.get('engagement', 'engaged')
+            for name in ('open', 'simplified', 'people_adjacent'):
+                if typed.get(name):
+                    turn[name] = True
     session.setdefault('turns', []).append(turn)
     return session
 
@@ -215,6 +225,11 @@ def _asks_about_people(text):
 
 
 def _people_turn(turn):
+    if turn.get('people_adjacent'):
+        # The engine stamps its own turns; the sniffing below only
+        # ever covers floor questions and turns stored before the
+        # stamp existed.
+        return True
     if turn.get('peer'):
         return True
     qid = turn.get('q')
@@ -223,64 +238,30 @@ def _people_turn(turn):
     return _asks_about_people(turn.get('text', ''))
 
 
-# Memory is the server's alone. When the AI asked something
-# forward-looking and the child answered, that answer rides the next
-# request as previous_next_steps for the server to weave in - Jo
-# herself never quotes it. Floor questions carry a 'q' stamp, so an
-# offline talk can never produce one; the marker sniff below only
-# ever reads the server's own question text.
-_FORWARD_RE = re.compile(
-    r'\b(next|would|will|if you|try|wish|want)\b')
-
-
-def _asked_about_people(turns, index):
-    """Whether the Jo question the index-th turn answers - walking
-    back over the child's consecutive lines - was about people.
-    """
-    j = index - 1
-    while j >= 0 and turns[j].get('role') != ROLE_JO:
-        j -= 1
-    return j >= 0 and _people_turn(turns[j])
-
-
-def extract_next_steps(session):
-    """The child's answer to a server-asked forward question, or ''.
-    """
-    turns = session.get('turns', [])
-    for i in range(len(turns) - 1, -1, -1):
-        turn = turns[i]
-        if turn.get('role') != ROLE_CHILD:
-            continue
-        if _asked_about_people(turns, i):
-            # An answer about who was there tends to carry a peer's
-            # name; it must never persist or ride a request.
-            continue
-        if i > 0 and turns[i - 1].get('role') == ROLE_JO:
-            prev = turns[i - 1]
-            if prev.get('q') is not None or prev.get('peer'):
-                continue
-            if _FORWARD_RE.search(prev.get('text', '').lower()):
-                # Clipped at the write so a paste cannot grow the
-                # metadata property without bound.
-                return clip_line(turn.get('text', ''), 120)
-    return ''
+# Memory is the server's alone. The engine types the child's
+# forward answer now: a session_end carries next_step (the child's
+# words, verbatim, or null) and asked. The old marker regex that
+# sniffed which question was forward-looking is gone with the wire
+# that needed it.
 
 
 def resolve_next_steps(session, previous):
     """What metadata['next_steps'] should hold after this session.
 
-    A fresh answer replaces the note. A server session that renewed
-    nothing retires it - carrying it further would be nagging. An
-    offline session leaves it alone: the floor never saw it.
+    A fresh answer replaces the note. A server session that closed
+    with nothing retires it - carrying it further would be nagging.
+    An offline session never closes server-side and leaves it alone:
+    the floor never saw it.
     """
-    fresh = extract_next_steps(session)
-    if fresh:
-        return fresh
-    for turn in session.get('turns', []):
-        if turn.get('role') == ROLE_JO and turn.get('q') is None and \
-                not turn.get('peer'):
-            return ''
-    return previous or ''
+    end = session.get('end')
+    if not isinstance(end, dict):
+        return previous or ''
+    step = end.get('next_step')
+    if isinstance(step, str) and step.strip():
+        # Clipped at the write so a paste cannot grow the metadata
+        # property without bound.
+        return clip_line(step, 120)
+    return ''
 
 
 def get_next_steps(metadata):
@@ -851,9 +832,27 @@ def _post_json(url, api_key, payload):
 STATUS_OK = 'ok'
 
 
-# The wire roles are the server schema's; the storage roles stay
-# jo/child so metadata never depends on another project's naming.
-_WIRE_ROLE = {ROLE_JO: 'assistant', ROLE_CHILD: 'user'}
+# The wire carries the engine's own trace records (engine spec,
+# section 1); the storage roles stay jo/child so metadata never
+# depends on another project's naming. Server turns are stored with
+# their typed fields and rebuild exactly; a floor question or a turn
+# stored before the typed fields existed becomes a plain engine
+# question - that is what the child saw, and the engine's budgets
+# should count it.
+
+
+def _engine_turn_record(turn):
+    return {
+        'type': 'engine_turn', 'by': 'engine',
+        'kind': turn.get('kind', 'question'),
+        'text': turn.get('text', ''),
+        'flags': {
+            'open': bool(turn.get('open')),
+            'simplified': bool(turn.get('simplified')),
+            'people_adjacent': _people_turn(turn),
+        },
+        'engagement': turn.get('engagement', 'engaged'),
+    }
 
 
 def _build_payload(title, description, activity_id, turns,
@@ -865,7 +864,7 @@ def _build_payload(title, description, activity_id, turns,
     one among these turns empties it here, and
     people_kept_in_description() covers the sessions already stored.
     """
-    wire_turns = []
+    records = []
     people = False
     starred_people = False
     for turn in turns:
@@ -879,16 +878,16 @@ def _build_payload(title, description, activity_id, turns,
                     has_kept_line(description, turn.get('text', '')):
                 starred_people = True
             continue
-        wire_role = _WIRE_ROLE.get(role)
-        if wire_role is None:
-            continue
-        wire_turns.append({'role': wire_role,
-                           'content': turn.get('text', '')})
+        if role == ROLE_JO:
+            records.append(_engine_turn_record(turn))
+        elif role == ROLE_CHILD:
+            records.append({'type': 'child_turn', 'by': 'host',
+                            'text': turn.get('text', '')})
     payload = {
         'title': title,
         'description': '' if starred_people else description,
         'activity_id': activity_id,
-        'turns': wire_turns,
+        'records': records,
     }
     if next_steps:
         payload['previous_next_steps'] = next_steps
@@ -896,10 +895,13 @@ def _build_payload(title, description, activity_id, turns,
 
 
 def _result(object_id, generation, status, turn=None,
-            should_continue=True):
-    return {'object_id': object_id, 'generation': generation,
-            'status': status, 'turn': turn,
-            'should_continue': should_continue}
+            should_continue=True, end=None):
+    result = {'object_id': object_id, 'generation': generation,
+              'status': status, 'turn': turn,
+              'should_continue': should_continue}
+    if end is not None:
+        result['end'] = end
+    return result
 
 
 # The nearby follow-up is only honest after real time away - no
@@ -1063,19 +1065,57 @@ def request_turn(object_id, generation, activity_id, title, description,
                              conversation, turns, artifact_visible,
                              opener=opener)
 
-    question = body.get('question') if isinstance(body, dict) else None
-    if not isinstance(question, str) or not question.strip():
-        logging.warning('Reflection server reply missing question; '
+    record = body.get('record') if isinstance(body, dict) else None
+    rtype = record.get('type') if isinstance(record, dict) else None
+
+    if rtype == 'session_end':
+        return _result(object_id, generation, STATUS_OK,
+                       should_continue=False,
+                       end={'reason': record.get('reason'),
+                            'next_step': record.get('next_step'),
+                            'asked': bool(record.get('asked'))})
+
+    if rtype != 'engine_turn':
+        logging.warning('Reflection server reply carried no turn; '
                         'floor answers')
         return _floor_result(object_id, generation, activity_id,
                              conversation, turns, artifact_visible,
                              opener=opener)
 
-    if not turn_acceptable(question):
+    if record.get('kind') == 'floor_request':
+        # The engine could not produce a usable turn and says so in
+        # the open; the local floor bank answers, same as an outage.
+        return _floor_result(object_id, generation, activity_id,
+                             conversation, turns, artifact_visible,
+                             opener=opener)
+
+    text = record.get('text')
+    # The engine guards its own turns (single question, its own
+    # length cap); this is a transport-sanity bound, not a second
+    # shape judge - the old one is retired with the free-text wire.
+    if not isinstance(text, str) or not text.strip() or \
+            len(text) > 200 or '\n' in text:
+        logging.warning('Reflection server turn unusable; '
+                        'floor answers')
         return _floor_result(object_id, generation, activity_id,
                              conversation, turns, artifact_visible,
                              opener=opener)
 
     return _result(object_id, generation, STATUS_OK,
-                   turn={'role': ROLE_JO, 'text': question.strip()},
-                   should_continue=bool(body.get('should_continue', True)))
+                   turn=_turn_from_record(record),
+                   should_continue=True)
+
+
+def _turn_from_record(record):
+    """A stored jo turn from one engine_turn record. The typed fields
+    ride the stored turn so the next request rebuilds this record
+    exactly - never re-derived from the text.
+    """
+    turn = {'role': ROLE_JO, 'text': record['text'].strip(),
+            'kind': record.get('kind', 'question'),
+            'engagement': record.get('engagement', 'engaged')}
+    flags = record.get('flags') or {}
+    for name in ('open', 'simplified', 'people_adjacent'):
+        if flags.get(name):
+            turn[name] = True
+    return turn

--- a/src/jarabe/journal/reflection.py
+++ b/src/jarabe/journal/reflection.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import configparser
+import base64
 import json
 import logging
 import os
@@ -855,13 +856,82 @@ def _engine_turn_record(turn):
     }
 
 
+# Mirrors of the engine's decode ceilings (its spec, section 1), so a
+# packed context is never refused whole at the far end. The tag and
+# caption clips lose almost nothing; an oversized snap is skipped.
+_CONTEXT_MAX_TAGS = 16
+_CONTEXT_MAX_TAG_CHARS = 60
+_CONTEXT_MAX_CAPTION_CHARS = 120
+_CONTEXT_MAX_IMAGE_B64 = 8 * 1024 * 1024 * 4 // 3
+# The server refuses a work_context bigger than 6 MB of JSON; staying
+# a megabyte under leaves room for the rest of the payload.
+_CONTEXT_BUDGET = 5 * 1024 * 1024
+
+
+def build_work_context(metadata):
+    """Pack the entry's own context for the wire: the preview, the
+    moment snaps with the child's line on each, tags, and time spent.
+    Everything here is optional - an entry with none of it returns {}
+    and the payload reads as before. Marks never travel: the far side
+    knows pictures and the child's words, not moments.
+    """
+    context = {}
+
+    spent = 0
+    for part in str(metadata.get('spent-times') or '').split(','):
+        try:
+            spent += int(part)
+        except ValueError:
+            continue
+    if spent > 0:
+        context['spent_seconds'] = spent
+
+    tags = str(metadata.get('tags') or '').split()
+    if tags:
+        context['tags'] = [tag[:_CONTEXT_MAX_TAG_CHARS]
+                           for tag in tags[:_CONTEXT_MAX_TAGS]]
+
+    budget = _CONTEXT_BUDGET
+    preview = metadata.get('preview')
+    if isinstance(preview, (bytes, bytearray)) and len(preview):
+        data = base64.b64encode(bytes(preview)).decode('ascii')
+        if len(data) <= budget:
+            context['preview'] = {'mime': 'image/png', 'data': data}
+            budget -= len(data)
+
+    images = []
+    for moment in loads(metadata.get('reflections', '')).get('moments', []):
+        if not isinstance(moment, dict):
+            continue
+        snap = metadata.get('%s%s' % (SNAP_KEY_PREFIX,
+                                      moment.get('snap_seq')))
+        if isinstance(snap, (bytes, bytearray)):
+            snap = bytes(snap).decode('ascii', errors='replace')
+        if not isinstance(snap, str) or not snap or \
+                len(snap) > _CONTEXT_MAX_IMAGE_B64:
+            continue
+        image = {'mime': 'image/jpeg', 'data': snap}
+        caption = moment.get('caption')
+        if isinstance(caption, str) and caption.strip():
+            image['caption'] = caption[:_CONTEXT_MAX_CAPTION_CHARS]
+        images.append(image)
+    while images and sum(len(i['data']) for i in images) > budget:
+        # Oldest snap goes first; what stays is still in story order.
+        images.pop(0)
+    if images:
+        context['images'] = images
+
+    return context
+
+
 def _build_payload(title, description, activity_id, turns,
-                   next_steps=None):
+                   next_steps=None, work_context=None):
     """The whitelisted body for /reflect/chat - never the reflections
-    blob, a preview, or the full metadata dict. A people question and
-    its answers stay off the wire: they name someone in the room. The
-    child can star such an answer into the description, so a starred
-    one among these turns empties it here, and
+    blob or the full metadata dict; the entry's context crosses only
+    as what build_work_context() deliberately packs. A people question
+    and its answers stay off the wire: they name someone in the room.
+    The child can star such an answer into the description, so a
+    starred one among these turns empties it here, and
     people_kept_in_description() covers the sessions already stored.
     """
     records = []
@@ -891,6 +961,8 @@ def _build_payload(title, description, activity_id, turns,
     }
     if next_steps:
         payload['previous_next_steps'] = next_steps
+    if work_context:
+        payload['work_context'] = work_context
     return payload
 
 
@@ -1019,7 +1091,7 @@ def _floor_result(object_id, generation, activity_id, conversation, turns,
 
 def request_turn(object_id, generation, activity_id, title, description,
                  turns, next_steps=None, config=None, conversation=None,
-                 artifact_visible=False, opener=None):
+                 artifact_visible=False, opener=None, work_context=None):
     """Ask the reflect endpoint for Jo's next turn. The result carries
     (object_id, generation), so a caller with several requests in
     flight can place a late reply. Every road away lands on the floor.
@@ -1038,7 +1110,7 @@ def request_turn(object_id, generation, activity_id, title, description,
                              opener=opener)
 
     payload = _build_payload(title, description, activity_id, turns,
-                             next_steps)
+                             next_steps, work_context=work_context)
     url = config['url'].rstrip('/') + _CHAT_PATH
 
     try:

--- a/src/jarabe/journal/reflection.py
+++ b/src/jarabe/journal/reflection.py
@@ -13,13 +13,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import configparser
 import json
 import logging
 import os
 import random
 import re
+import socket
 import time
 import unicodedata
+import urllib.error
+import urllib.parse
+import urllib.request
 import uuid
 from gettext import gettext as _
 
@@ -296,6 +301,31 @@ def unkeep_from_description(description, text):
             del lines[i]
             return '\n'.join(lines)
     return description
+
+
+def people_kept_in_description(raw, description):
+    """Whether an answer to a people question - from any session the
+    record holds, not only the open one - is kept in this description.
+    A starred answer names someone in the room, so its description
+    cannot ride a request.
+    """
+    if not description:
+        return False
+    for session in loads(raw).get('sessions', []):
+        turns = session.get('turns')
+        if not isinstance(turns, list):
+            continue
+        people = False
+        for turn in turns:
+            if not isinstance(turn, dict):
+                continue
+            role = turn.get('role')
+            if role == ROLE_JO:
+                people = _people_turn(turn) or bool(turn.get('local'))
+            if people and role == ROLE_CHILD and \
+                    has_kept_line(description, turn.get('text', '')):
+                return True
+    return False
 
 
 # Activities grouped into the five categories the offline floor asks
@@ -640,6 +670,50 @@ def _collect_used(turn, used):
         used.add(turn['text'])
 
 
+# A server is something a school opts into: until somebody ticks the
+# switch, Jo asks from the floor and nothing leaves the laptop.
+DEFAULT_ENABLED = False
+
+DEFAULT_CONFIG_PATH = os.path.expanduser('~/.sugar/default/reflection.conf')
+
+_CONFIG_SECTION = 'reflection'
+_ENV_URL = 'SUGAR_AI_URL'
+_ENV_API_KEY = 'SUGAR_AI_KEY'
+_ENV_ENABLED = 'SUGAR_AI_REFLECTION_ENABLED'
+
+
+def read_config(path=DEFAULT_CONFIG_PATH):
+    """Read the reflection endpoint's url, api_key and enabled flag."""
+    config = {'url': '', 'api_key': '', 'enabled': DEFAULT_ENABLED}
+
+    parser = configparser.ConfigParser(interpolation=None)
+    try:
+        parser.read([path])
+    except (configparser.Error, OSError, ValueError):
+        logging.exception('Error reading reflection config %r', path)
+    else:
+        if parser.has_option(_CONFIG_SECTION, 'url'):
+            config['url'] = parser.get(_CONFIG_SECTION, 'url')
+        if parser.has_option(_CONFIG_SECTION, 'api_key'):
+            config['api_key'] = parser.get(_CONFIG_SECTION, 'api_key')
+        if parser.has_option(_CONFIG_SECTION, 'enabled'):
+            try:
+                config['enabled'] = parser.getboolean(_CONFIG_SECTION,
+                                                      'enabled')
+            except ValueError:
+                logging.warning('Invalid enabled value in %r', path)
+
+    if os.environ.get(_ENV_URL):
+        config['url'] = os.environ[_ENV_URL]
+    if os.environ.get(_ENV_API_KEY):
+        config['api_key'] = os.environ[_ENV_API_KEY]
+    if os.environ.get(_ENV_ENABLED):
+        config['enabled'] = os.environ[_ENV_ENABLED].strip().lower() in \
+            ('1', 'true', 'yes', 'on')
+
+    return config
+
+
 # Jo introduces itself once, on whichever surface the child meets
 # first. That fact lives here, not in any entry's metadata.
 STATE_PATH = os.path.expanduser('~/.sugar/default/reflection-state.json')
@@ -673,7 +747,152 @@ def mark_state(key, path=STATE_PATH):
         logging.exception('Error writing reflection state %r', path)
 
 
+READ_TIMEOUT = 30
+
+# A reply is one question: past this the body is no shape we can use,
+# and reading it on would spend the laptop's memory to throw it away.
+_MAX_RESPONSE_BYTES = 64 * 1024
+
+_PROBE_TIMEOUT = 5
+
+_CHAT_PATH = '/reflect/chat'
+
+
+class ReflectionOffline(Exception):
+    """No network, or the reflect endpoint was unreachable."""
+
+
+class ReflectionTimeout(Exception):
+    """The reflect endpoint did not answer within READ_TIMEOUT."""
+
+
+class ReflectionHTTPError(Exception):
+    """The reflect endpoint answered with a non-2xx status."""
+
+    def __init__(self, status, reason):
+        Exception.__init__(self, '%s %s' % (status, reason))
+        self.status = status
+        self.reason = reason
+
+
+class ReflectionBadResponse(Exception):
+    """The response body was not the expected shape."""
+
+
+def _probe_address(url):
+    """Host and port to knock on for a configured url, or None when
+    the url is not one we could post to at all.
+    """
+    try:
+        parts = urllib.parse.urlsplit(url)
+        port = parts.port or (443 if parts.scheme == 'https' else 80)
+    except ValueError:
+        return None
+    if not parts.hostname:
+        return None
+    return parts.hostname, port
+
+
+def is_online(url):
+    """Cheap knock on the configured server's own host. It answers
+    reachable, never fast: a slow endpoint still passes here, which is
+    what keeps an outage off READ_TIMEOUT.
+    """
+    address = _probe_address(url)
+    if address is None:
+        return False
+    try:
+        probe = socket.create_connection(address, timeout=_PROBE_TIMEOUT)
+        probe.close()
+        return True
+    except OSError:
+        return False
+
+
+def _post_json(url, api_key, payload):
+    """POST payload as JSON; raises only Reflection* errors. Connect
+    and read share one socket timeout - plain urllib cannot split
+    them - so is_online() keeps an outage off READ_TIMEOUT.
+    """
+    try:
+        request = urllib.request.Request(
+            url,
+            data=json.dumps(payload).encode('utf-8'),
+            headers={
+                'Content-Type': 'application/json',
+                'X-API-Key': api_key,
+            },
+            method='POST')
+        with urllib.request.urlopen(request, timeout=READ_TIMEOUT) as resp:
+            raw = resp.read(_MAX_RESPONSE_BYTES + 1)
+    except urllib.error.HTTPError as e:
+        raise ReflectionHTTPError(e.code, e.reason)
+    except socket.timeout:
+        raise ReflectionTimeout()
+    except urllib.error.URLError as e:
+        if isinstance(e.reason, socket.timeout):
+            raise ReflectionTimeout()
+        raise ReflectionOffline()
+    except ValueError:
+        # An address with no scheme never gets a socket; unreachable
+        # is the honest reading of it.
+        raise ReflectionOffline()
+
+    if len(raw) > _MAX_RESPONSE_BYTES:
+        raise ReflectionBadResponse('response was over %d bytes'
+                                    % _MAX_RESPONSE_BYTES)
+
+    try:
+        return json.loads(raw.decode('utf-8'))
+    except (ValueError, UnicodeDecodeError):
+        raise ReflectionBadResponse('response was not valid JSON')
+
+
 STATUS_OK = 'ok'
+
+
+# The wire roles are the server schema's; the storage roles stay
+# jo/child so metadata never depends on another project's naming.
+_WIRE_ROLE = {ROLE_JO: 'assistant', ROLE_CHILD: 'user'}
+
+
+def _build_payload(title, description, activity_id, turns,
+                   next_steps=None):
+    """The whitelisted body for /reflect/chat - never the reflections
+    blob, a preview, or the full metadata dict. A people question and
+    its answers stay off the wire: they name someone in the room. The
+    child can star such an answer into the description, so a starred
+    one among these turns empties it here, and
+    people_kept_in_description() covers the sessions already stored.
+    """
+    wire_turns = []
+    people = False
+    starred_people = False
+    for turn in turns:
+        if not isinstance(turn, dict):
+            continue
+        role = turn.get('role')
+        if role == ROLE_JO:
+            people = _people_turn(turn) or bool(turn.get('local'))
+        if people:
+            if role == ROLE_CHILD and \
+                    has_kept_line(description, turn.get('text', '')):
+                starred_people = True
+            continue
+        wire_role = _WIRE_ROLE.get(role)
+        if wire_role is None:
+            continue
+        wire_turns.append({'role': wire_role,
+                           'content': turn.get('text', '')})
+    payload = {
+        'title': title,
+        'description': '' if starred_people else description,
+        'activity_id': activity_id,
+        'turns': wire_turns,
+    }
+    if next_steps:
+        payload['previous_next_steps'] = next_steps
+    return payload
 
 
 def _result(object_id, generation, status, turn=None,
@@ -797,16 +1016,66 @@ def _floor_result(object_id, generation, activity_id, conversation, turns,
 
 
 def request_turn(object_id, generation, activity_id, title, description,
-                 turns, next_steps=None, conversation=None,
+                 turns, next_steps=None, config=None, conversation=None,
                  artifact_visible=False, opener=None):
-    """Compose Jo's next turn from the floor bank.
-
-    The result carries (object_id, generation), so a caller with
-    several requests in flight can place a late reply. A dry bank
-    comes back as STATUS_OK with turn None: Jo has nothing new to
-    open with and stays silent. title, description and next_steps
-    are unused here; the server layer consumes them.
+    """Ask the reflect endpoint for Jo's next turn. The result carries
+    (object_id, generation), so a caller with several requests in
+    flight can place a late reply. Every road away lands on the floor.
     """
-    return _floor_result(object_id, generation, activity_id,
-                         conversation, turns, artifact_visible,
-                         opener=opener)
+    if config is None:
+        config = read_config()
+
+    if not config['enabled'] or not config['api_key'] or not config['url']:
+        return _floor_result(object_id, generation, activity_id,
+                             conversation, turns, artifact_visible,
+                             opener=opener)
+
+    if not is_online(config['url']):
+        return _floor_result(object_id, generation, activity_id,
+                             conversation, turns, artifact_visible,
+                             opener=opener)
+
+    payload = _build_payload(title, description, activity_id, turns,
+                             next_steps)
+    url = config['url'].rstrip('/') + _CHAT_PATH
+
+    try:
+        body = _post_json(url, config['api_key'], payload)
+    except ReflectionOffline:
+        return _floor_result(object_id, generation, activity_id,
+                             conversation, turns, artifact_visible,
+                             opener=opener)
+    except ReflectionTimeout:
+        logging.warning('Reflection server timed out; floor answers')
+        return _floor_result(object_id, generation, activity_id,
+                             conversation, turns, artifact_visible,
+                             opener=opener)
+    except ReflectionHTTPError as e:
+        logging.warning('Reflection server error %s %s; floor answers',
+                        e.status, e.reason)
+        return _floor_result(object_id, generation, activity_id,
+                             conversation, turns, artifact_visible,
+                             opener=opener)
+    except ReflectionBadResponse as e:
+        logging.warning('Reflection server reply unusable (%s); '
+                        'floor answers', e)
+        return _floor_result(object_id, generation, activity_id,
+                             conversation, turns, artifact_visible,
+                             opener=opener)
+
+    question = body.get('question') if isinstance(body, dict) else None
+    if not isinstance(question, str) or not question.strip():
+        logging.warning('Reflection server reply missing question; '
+                        'floor answers')
+        return _floor_result(object_id, generation, activity_id,
+                             conversation, turns, artifact_visible,
+                             opener=opener)
+
+    if not turn_acceptable(question):
+        return _floor_result(object_id, generation, activity_id,
+                             conversation, turns, artifact_visible,
+                             opener=opener)
+
+    return _result(object_id, generation, STATUS_OK,
+                   turn={'role': ROLE_JO, 'text': question.strip()},
+                   should_continue=bool(body.get('should_continue', True)))

--- a/src/jarabe/journal/reflectionview.py
+++ b/src/jarabe/journal/reflectionview.py
@@ -1117,11 +1117,14 @@ class ReflectionView(Gtk.EventBox):
         # The engine floors every server death itself, so a result is
         # always STATUS_OK: a turn to speak, or silence.
         turn = result['turn']
+        end = result.get('end')
         if turn is not None:
             self._ensure_session()
+            typed = turn if turn.get('kind') else None
             reflection.add_turn(self._session, reflection.ROLE_JO,
                                 turn['text'], q=turn.get('q'),
-                                local=bool(turn.get('local')))
+                                local=bool(turn.get('local')),
+                                typed=typed)
             self._set_now(turn['text'])
             self._persist()
             self._scroll_to_newest()
@@ -1129,6 +1132,14 @@ class ReflectionView(Gtk.EventBox):
                 self._set_input_active(True)
             else:
                 self._enter_session_over()
+        elif end is not None:
+            # The engine closed the session with a typed end; the
+            # child's forward answer (or its absence) persists from
+            # it, and the talk rests here for next time.
+            self._ensure_session()
+            self._session['end'] = end
+            self._persist()
+            self._enter_session_over()
         elif self._session is not None:
             nudge = None
             if result['should_continue']:

--- a/src/jarabe/journal/reflectionview.py
+++ b/src/jarabe/journal/reflectionview.py
@@ -1081,19 +1081,21 @@ class ReflectionView(Gtk.EventBox):
                 self._activity_id(), self._metadata.get('title', ''),
                 description, turns,
                 reflection.get_next_steps(self._metadata), self._data,
-                self._artifact_visible, self._opener_hint)
+                self._artifact_visible, self._opener_hint,
+                reflection.build_work_context(self._metadata))
         thread = threading.Thread(target=self.__request_worker, args=args)
         thread.daemon = True
         thread.start()
 
     def __request_worker(self, object_id, generation, activity_id, title,
                          description, turns, next_steps, conversation,
-                         artifact_visible, opener):
+                         artifact_visible, opener, work_context):
         try:
             result = reflection.request_turn(
                 object_id, generation, activity_id, title, description,
                 turns, next_steps=next_steps, conversation=conversation,
-                artifact_visible=artifact_visible, opener=opener)
+                artifact_visible=artifact_visible, opener=opener,
+                work_context=work_context)
         except Exception:
             # The rail must never stay wedged in "thinking": a dying
             # worker still reports, as Jo quietly bowing out.

--- a/src/jarabe/journal/reflectionview.py
+++ b/src/jarabe/journal/reflectionview.py
@@ -1071,9 +1071,15 @@ class ReflectionView(Gtk.EventBox):
         turns = []
         if self._session is not None:
             turns = list(self._session.get('turns', []))
+        description = self._metadata.get('description', '')
+        if reflection.people_kept_in_description(
+                self._metadata.get('reflections', ''), description):
+            # An older talk's starred answer names someone in the
+            # room, and the description carries it verbatim.
+            description = ''
         args = (self._metadata.get('uid', ''), self._generation,
                 self._activity_id(), self._metadata.get('title', ''),
-                self._metadata.get('description', ''), turns,
+                description, turns,
                 reflection.get_next_steps(self._metadata), self._data,
                 self._artifact_visible, self._opener_hint)
         thread = threading.Thread(target=self.__request_worker, args=args)

--- a/tests/journal/test_reflection.py
+++ b/tests/journal/test_reflection.py
@@ -413,6 +413,87 @@ class TestPayload(unittest.TestCase):
             self.assertNotIn(forbidden, payload)
 
 
+class TestWorkContext(unittest.TestCase):
+
+    @staticmethod
+    def _metadata(moments=(), snaps=(), **extra):
+        metadata = {'reflections': json.dumps(
+            {'version': 1, 'sessions': [], 'moments': list(moments)})}
+        for seq, data in snaps:
+            metadata['moment-snap-%d' % seq] = data
+        metadata.update(extra)
+        return metadata
+
+    def test_full_entry_packs_every_field(self):
+        import base64
+        metadata = self._metadata(
+            moments=[{'caption': 'the jump worked', 'mark': 'proud',
+                      'ts': 1, 'snap_seq': 0},
+                     {'caption': '', 'mark': None, 'ts': 2,
+                      'snap_seq': 1}],
+            snaps=[(0, 'QUFBQQ=='), (1, 'QkJCQg==')],
+            preview=b'png-bytes', tags='dragon maze',
+            **{'spent-times': '120,60,bad'})
+        context = reflection.build_work_context(metadata)
+        self.assertEqual(context['spent_seconds'], 180)
+        self.assertEqual(context['tags'], ['dragon', 'maze'])
+        self.assertEqual(context['preview'], {
+            'mime': 'image/png',
+            'data': base64.b64encode(b'png-bytes').decode('ascii')})
+        self.assertEqual(context['images'], [
+            {'mime': 'image/jpeg', 'data': 'QUFBQQ==',
+             'caption': 'the jump worked'},
+            {'mime': 'image/jpeg', 'data': 'QkJCQg=='}])
+
+    def test_bare_entry_packs_nothing(self):
+        self.assertEqual(reflection.build_work_context({}), {})
+        payload = reflection._build_payload('T', 'd', 'x', [],
+                                            work_context={})
+        self.assertNotIn('work_context', payload)
+
+    def test_payload_carries_the_context_it_is_given(self):
+        context = {'tags': ['dragon']}
+        payload = reflection._build_payload('T', 'd', 'x', [],
+                                            work_context=context)
+        self.assertEqual(payload['work_context'], context)
+
+    def test_marks_never_travel(self):
+        context = reflection.build_work_context(self._metadata(
+            moments=[{'caption': 'hi', 'mark': 'proud', 'ts': 1,
+                      'snap_seq': 0}],
+            snaps=[(0, 'QQ==')]))
+        self.assertNotIn('mark', json.dumps(context))
+
+    def test_snapless_moment_is_skipped(self):
+        context = reflection.build_work_context(self._metadata(
+            moments=[{'caption': 'gone', 'ts': 1, 'snap_seq': 7}]))
+        self.assertNotIn('images', context)
+
+    def test_tags_clip_to_the_far_ceiling(self):
+        context = reflection.build_work_context(
+            {'tags': ' '.join('t%d' % i + 'x' * 100 for i in range(20))})
+        self.assertEqual(len(context['tags']), 16)
+        for tag in context['tags']:
+            self.assertLessEqual(len(tag), 60)
+
+    def test_budget_drops_oldest_snaps_and_keeps_story_order(self):
+        metadata = self._metadata(
+            moments=[{'caption': 'old', 'ts': 1, 'snap_seq': 0},
+                     {'caption': 'mid', 'ts': 2, 'snap_seq': 1},
+                     {'caption': 'new', 'ts': 3, 'snap_seq': 2}],
+            snaps=[(0, 'A' * 40), (1, 'B' * 40), (2, 'C' * 40)])
+        with mock.patch.object(reflection, '_CONTEXT_BUDGET', 100):
+            context = reflection.build_work_context(metadata)
+        self.assertEqual([i['caption'] for i in context['images']],
+                         ['mid', 'new'])
+
+    def test_malformed_reflections_and_junk_never_crash(self):
+        context = reflection.build_work_context({
+            'reflections': 'not json', 'preview': 'not-bytes',
+            'tags': None, 'spent-times': None})
+        self.assertEqual(context, {})
+
+
 class TestConfig(unittest.TestCase):
 
     # --- Config ---

--- a/tests/journal/test_reflection.py
+++ b/tests/journal/test_reflection.py
@@ -379,18 +379,32 @@ class TestPayload(unittest.TestCase):
     # --- Payload whitelist ---
 
     def test_build_payload_matches_server_schema(self):
-        turns = [{'role': 'jo', 'text': 'Hi'},
+        turns = [{'role': 'jo', 'text': 'Hi', 'kind': 'question',
+                  'open': True, 'engagement': 'engaged'},
                  {'role': 'child', 'text': 'A rocket'}]
         payload = reflection._build_payload(
             'My Title', 'a description', 'org.laptop.TurtleArtActivity',
             turns)
         self.assertEqual(set(payload.keys()), {
-            'title', 'description', 'activity_id', 'turns'})
+            'title', 'description', 'activity_id', 'records'})
         self.assertEqual(
             payload['activity_id'], 'org.laptop.TurtleArtActivity')
-        self.assertEqual(payload['turns'], [
-            {'role': 'assistant', 'content': 'Hi'},
-            {'role': 'user', 'content': 'A rocket'}])
+        self.assertEqual(payload['records'], [
+            {'type': 'engine_turn', 'by': 'engine', 'kind': 'question',
+             'text': 'Hi',
+             'flags': {'open': True, 'simplified': False,
+                       'people_adjacent': False},
+             'engagement': 'engaged'},
+            {'type': 'child_turn', 'by': 'host', 'text': 'A rocket'}])
+
+    def test_a_stored_turn_without_typed_fields_becomes_a_question(self):
+        # Floor questions and turns stored before the typed fields
+        # existed are what the child saw; the engine counts them.
+        payload = reflection._build_payload(
+            'T', 'd', 'x', [{'role': 'jo', 'text': 'What broke?'}])
+        record = payload['records'][0]
+        self.assertEqual(record['kind'], 'question')
+        self.assertEqual(record['engagement'], 'engaged')
 
     def test_build_payload_never_carries_forbidden_keys(self):
         payload = reflection._build_payload('T', 'd', 'x', [])
@@ -558,7 +572,12 @@ class TestHttpClient(unittest.TestCase):
         p = mock.patch.object(reflection, 'is_online', lambda url: True)
         p.start()
         self.addCleanup(p.stop)
-        body = json.dumps({'question': 'What was tricky?'}).encode('utf-8')
+        body = json.dumps({'record': {
+            'type': 'engine_turn', 'by': 'engine', 'kind': 'question',
+            'text': 'What was tricky?',
+            'flags': {'open': True, 'simplified': False,
+                      'people_adjacent': False},
+            'engagement': 'engaged'}}).encode('utf-8')
         p = mock.patch.object(
             reflection.urllib.request, 'urlopen', fake_urlopen(body))
         p.start()
@@ -571,9 +590,53 @@ class TestHttpClient(unittest.TestCase):
         self.assertEqual(result, {
             'object_id': 'obj-1', 'generation': 3,
             'status': reflection.STATUS_OK,
-            'turn': {'role': 'jo', 'text': 'What was tricky?'},
+            'turn': {'role': 'jo', 'text': 'What was tricky?',
+                     'kind': 'question', 'engagement': 'engaged',
+                     'open': True},
             'should_continue': True,
         })
+
+    def test_request_turn_session_end_closes_with_the_typed_answer(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: True)
+        p.start()
+        self.addCleanup(p.stop)
+        body = json.dumps({'record': {
+            'type': 'session_end', 'by': 'engine', 'reason': 'child_done',
+            'next_step': 'teach my dog to paint',
+            'asked': True}}).encode('utf-8')
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', fake_urlopen(body))
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-1', 3, 'x', 't', 'd', [], config=VALID_CONFIG)
+
+        self.assertIsNone(result['turn'])
+        self.assertFalse(result['should_continue'])
+        self.assertEqual(result['end'], {
+            'reason': 'child_done',
+            'next_step': 'teach my dog to paint', 'asked': True})
+
+    def test_request_turn_engine_floor_lands_on_the_local_bank(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: True)
+        p.start()
+        self.addCleanup(p.stop)
+        body = json.dumps({'record': {
+            'type': 'engine_turn', 'by': 'engine', 'kind': 'floor_request',
+            'text': None,
+            'flags': {'open': False, 'simplified': False,
+                      'people_adjacent': False},
+            'engagement': 'engaged'}}).encode('utf-8')
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', fake_urlopen(body))
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-9', 2, 'x', 't', 'd', [], config=VALID_CONFIG)
+        self.assertEqual(
+            result['turn']['text'], reflection.DEFAULT_FLOOR_BANK[0])
 
     def test_request_turn_timeout(self):
         p = mock.patch.object(reflection, 'is_online', lambda url: True)
@@ -760,12 +823,18 @@ class TestHttpClient(unittest.TestCase):
         self.assertEqual(result['status'], reflection.STATUS_OK)
         self.assertIsNone(result['turn'])
 
-    def test_request_turn_carries_should_continue_false(self):
+    def test_request_turn_only_a_typed_end_stops_the_session(self):
+        # The old wire let a truthy flag beside a question stop the
+        # talk; on the typed wire only a session_end record does.
         p = mock.patch.object(reflection, 'is_online', lambda url: True)
         p.start()
         self.addCleanup(p.stop)
-        body = json.dumps({'question': 'One last thought?',
-                           'should_continue': False}).encode('utf-8')
+        body = json.dumps({'record': {
+            'type': 'engine_turn', 'by': 'engine', 'kind': 'wrap_offer',
+            'text': 'Keep going or stop here?',
+            'flags': {'open': False, 'simplified': False,
+                      'people_adjacent': False},
+            'engagement': 'engaged'}}).encode('utf-8')
         p = mock.patch.object(
             reflection.urllib.request, 'urlopen', fake_urlopen(body))
         p.start()
@@ -773,8 +842,8 @@ class TestHttpClient(unittest.TestCase):
 
         result = reflection.request_turn(
             'obj-13', 1, 'x', 't', 'd', [], config=VALID_CONFIG)
-        self.assertIs(result['should_continue'], False)
-        self.assertEqual(result['turn']['text'], 'One last thought?')
+        self.assertIs(result['should_continue'], True)
+        self.assertEqual(result['turn']['kind'], 'wrap_offer')
 
     def test_request_turn_should_continue_defaults_true(self):
         p = mock.patch.object(reflection, 'is_online', lambda url: True)
@@ -1117,7 +1186,7 @@ class TestQuestionBanks(unittest.TestCase):
             {'role': 'jo', 'text': 'What will you try next time?'},
             {'role': 'child', 'text': 'a beam'}]
         payload = reflection._build_payload('t', 'd', 'a', turns)
-        contents = [t['content'] for t in payload['turns']]
+        contents = [t.get('text', '') for t in payload['records']]
         self.assertNotIn('Ana says it needs a beam', contents)
         self.assertNotIn('she liked the roof', contents)
         self.assertNotIn(reflection.NEARBY_MIDFLOW, contents)
@@ -1217,7 +1286,7 @@ class TestPeerQuestions(unittest.TestCase):
             {'role': 'jo', 'text': 'What will you try next time?'},
             {'role': 'child', 'text': 'a beam'}]
         payload = reflection._build_payload('t', 'd', 'a', turns)
-        contents = [t['content'] for t in payload['turns']]
+        contents = [t.get('text', '') for t in payload['records']]
         self.assertNotIn(voiced, contents)
         self.assertNotIn('I will tell Ana about the beam', contents)
         self.assertIn('the roof', contents)
@@ -1405,7 +1474,7 @@ class TestQuestionIds(unittest.TestCase):
             {'role': 'child', 'text': 'Maya likes the wing'},
         ]
         payload = reflection._build_payload('t', 'd', 'x', turns)
-        self.assertEqual(payload['turns'], [])
+        self.assertEqual(payload['records'], [])
 
 
 class TestTitledOpener(unittest.TestCase):
@@ -1444,7 +1513,7 @@ class TestTitledOpener(unittest.TestCase):
         reflection.add_turn(session, reflection.ROLE_CHILD, 'more stars')
         payload = reflection._build_payload(
             't', 'd', 'x', session['turns'])
-        contents = [t['content'] for t in payload['turns']]
+        contents = [t.get('text', '') for t in payload['records']]
         self.assertNotIn('it is about my dad', contents)
         self.assertIn('more stars', contents)
 
@@ -1518,44 +1587,30 @@ class TestServerMemory(unittest.TestCase):
 
     # --- memory is the server's alone ---
 
-    def test_floor_questions_never_produce_a_note(self):
+    def test_a_typed_end_produces_the_note(self):
         session = reflection.new_session('creative_spiral')
-        reflection.add_turn(session, reflection.ROLE_JO,
-                            reflection.FLOOR_BANK['creative'][1])
-        reflection.add_turn(session, reflection.ROLE_CHILD, 'more stars')
-        self.assertEqual(reflection.extract_next_steps(session), '')
-
-    def test_a_server_forward_question_produces_one(self):
-        session = reflection.new_session('creative_spiral')
-        reflection.add_turn(session, reflection.ROLE_JO,
-                            'What will you try tomorrow?')
-        reflection.add_turn(session, reflection.ROLE_CHILD, 'more stars')
-        self.assertEqual(reflection.extract_next_steps(session), 'more stars')
-
-    def test_people_answers_never_ride_a_request(self):
-        session = reflection.new_session('creative_spiral')
-        reflection.add_turn(session, reflection.ROLE_JO,
-                            reflection.NEARBY_MIDFLOW)
-        reflection.add_turn(session, reflection.ROLE_CHILD,
-                            'Ana would try a beam next')
-        self.assertEqual(reflection.extract_next_steps(session), '')
+        session['end'] = {'reason': 'child_done',
+                          'next_step': 'more stars', 'asked': True}
+        self.assertEqual(
+            reflection.resolve_next_steps(session, 'old'), 'more stars')
 
     def test_a_giant_answer_is_clipped_at_the_write(self):
         session = reflection.new_session('creative_spiral')
-        reflection.add_turn(session, reflection.ROLE_JO,
-                            'What will you try tomorrow?')
-        reflection.add_turn(session, reflection.ROLE_CHILD, 'wing ' * 200)
-        note = reflection.extract_next_steps(session)
+        session['end'] = {'reason': 'child_done',
+                          'next_step': 'wing ' * 200, 'asked': True}
+        note = reflection.resolve_next_steps(session, '')
         self.assertLessEqual(len(note), 121)
 
-    def test_resolve_replaces_or_keeps(self):
+    def test_a_session_with_no_end_keeps_the_note(self):
         session = reflection.new_session('creative_spiral')
         self.assertEqual(reflection.resolve_next_steps(session, 'old'), 'old')
         reflection.add_turn(session, reflection.ROLE_JO,
                             'What will you try tomorrow?')
         reflection.add_turn(session, reflection.ROLE_CHILD, 'a moon')
+        # No typed end means no server close: the engine owns the
+        # note now, and nothing here re-derives it from text.
         self.assertEqual(
-            reflection.resolve_next_steps(session, 'old'), 'a moon')
+            reflection.resolve_next_steps(session, 'old'), 'old')
 
     def test_payload_carries_the_previous_note_online(self):
         payload = reflection._build_payload(
@@ -1569,20 +1624,10 @@ class TestSeverePassFixes(unittest.TestCase):
 
     # --- the severe pass's catches, pinned ---
 
-    def test_marker_needs_a_word_boundary(self):
-        for q in ('What country is your story set in?',
-                  'What did the poetry sound like?',
-                  'Was it a willow tree or an oak?'):
-            session = reflection.new_session('creative_spiral')
-            reflection.add_turn(session, reflection.ROLE_JO, q)
-            reflection.add_turn(session, reflection.ROLE_CHILD, 'a secret')
-            self.assertEqual(reflection.extract_next_steps(session), '', q)
-
-    def test_a_server_session_retires_an_unrenewed_note(self):
+    def test_a_closed_session_retires_an_unrenewed_note(self):
         session = reflection.new_session('creative_spiral')
-        reflection.add_turn(session, reflection.ROLE_JO,
-                            'What was the best part?')
-        reflection.add_turn(session, reflection.ROLE_CHILD, 'the sky')
+        session['end'] = {'reason': 'disengaged',
+                          'next_step': None, 'asked': False}
         self.assertEqual(
             reflection.resolve_next_steps(session, 'old note'), '')
 
@@ -1593,16 +1638,6 @@ class TestSeverePassFixes(unittest.TestCase):
         reflection.add_turn(session, reflection.ROLE_CHILD, 'the sky')
         self.assertEqual(reflection.resolve_next_steps(
             session, 'old note'), 'old note')
-
-    def test_the_intro_is_never_a_server_question(self):
-        session = reflection.new_session('creative_spiral')
-        reflection.add_turn(session, reflection.ROLE_JO,
-                            reflection.INTRO_LINE)
-        reflection.add_turn(session, reflection.ROLE_CHILD,
-                            'I will try a dragon')
-        self.assertEqual(reflection.extract_next_steps(session), '')
-        self.assertEqual(
-            reflection.resolve_next_steps(session, 'kept'), 'kept')
 
     def test_a_corrupt_session_element_is_dropped(self):
         raw = json.dumps({'version': 1, 'sessions': ['corrupt', {
@@ -1702,7 +1737,8 @@ class TestReviewPassFixes(unittest.TestCase):
                  {'role': 'child', 'text': 'a rocket'}]
         payload = reflection._build_payload('t', 'd', 'a', turns)
         self.assertEqual(
-            payload['turns'], [{'role': 'user', 'content': 'a rocket'}])
+            payload['records'],
+            [{'type': 'child_turn', 'by': 'host', 'text': 'a rocket'}])
 
     def test_a_starred_people_answer_empties_the_description(self):
         answer = 'Ana says it needs a beam'
@@ -1711,7 +1747,7 @@ class TestReviewPassFixes(unittest.TestCase):
         description = reflection.keep_in_description('My tower.', answer)
         payload = reflection._build_payload('t', description, 'a', turns)
         self.assertEqual(payload['description'], '')
-        self.assertEqual(payload['turns'], [])
+        self.assertEqual(payload['records'], [])
 
     def test_an_unstarred_people_answer_leaves_the_description(self):
         turns = [{'role': 'jo', 'text': reflection.NEARBY_MIDFLOW},

--- a/tests/journal/test_reflection.py
+++ b/tests/journal/test_reflection.py
@@ -17,9 +17,11 @@ import contextlib
 import json
 import os
 import pathlib
+import socket
 import sys
 import tempfile
 import unittest
+import urllib.error
 from unittest import mock
 
 # jarabe/__init__.py and jarabe/journal/__init__.py are both gi-free, but
@@ -28,6 +30,31 @@ sys.path.insert(
     0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from jarabe.journal import reflection  # noqa: E402
+
+
+VALID_CONFIG = {'url': 'https://ai.example.org', 'api_key': 'k',
+                'enabled': True}
+
+
+class FakeResponse:
+
+    def __init__(self, body):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def read(self, size=None):
+        return self._body if size is None else self._body[:size]
+
+
+def fake_urlopen(body):
+    def opener(request, timeout=None):
+        return FakeResponse(body)
+    return opener
 
 
 class TestConversationModel(unittest.TestCase):
@@ -347,13 +374,487 @@ class TestKeepDescription(unittest.TestCase):
             'it flies\nmore words')
 
 
+class TestPayload(unittest.TestCase):
+
+    # --- Payload whitelist ---
+
+    def test_build_payload_matches_server_schema(self):
+        turns = [{'role': 'jo', 'text': 'Hi'},
+                 {'role': 'child', 'text': 'A rocket'}]
+        payload = reflection._build_payload(
+            'My Title', 'a description', 'org.laptop.TurtleArtActivity',
+            turns)
+        self.assertEqual(set(payload.keys()), {
+            'title', 'description', 'activity_id', 'turns'})
+        self.assertEqual(
+            payload['activity_id'], 'org.laptop.TurtleArtActivity')
+        self.assertEqual(payload['turns'], [
+            {'role': 'assistant', 'content': 'Hi'},
+            {'role': 'user', 'content': 'A rocket'}])
+
+    def test_build_payload_never_carries_forbidden_keys(self):
+        payload = reflection._build_payload('T', 'd', 'x', [])
+        for forbidden in ('reflections', 'preview', 'metadata', 'uid',
+                          'category', 'activity', 'next_steps'):
+            self.assertNotIn(forbidden, payload)
+
+
+class TestConfig(unittest.TestCase):
+
+    # --- Config ---
+
+    def test_read_config_file_absent(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        tmp_path = pathlib.Path(tmp_dir.name)
+        path = str(tmp_path / 'missing.conf')
+        config = reflection.read_config(path)
+        self.assertEqual(
+            config,
+            {'url': '', 'api_key': '',
+             'enabled': reflection.DEFAULT_ENABLED})
+
+    def test_read_config_file_partial(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        tmp_path = pathlib.Path(tmp_dir.name)
+        path = tmp_path / 'reflection.conf'
+        path.write_text('[reflection]\nurl = https://ai.example.org\n')
+        config = reflection.read_config(str(path))
+        self.assertEqual(config['url'], 'https://ai.example.org')
+        self.assertEqual(config['api_key'], '')
+        self.assertEqual(config['enabled'], reflection.DEFAULT_ENABLED)
+
+    def test_read_config_file_full(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        tmp_path = pathlib.Path(tmp_dir.name)
+        path = tmp_path / 'reflection.conf'
+        path.write_text(
+            '[reflection]\n'
+            'url = https://ai.example.org\n'
+            'api_key = secret123\n'
+            'enabled = false\n')
+        config = reflection.read_config(str(path))
+        self.assertEqual(
+            config,
+            {'url': 'https://ai.example.org', 'api_key': 'secret123',
+             'enabled': False})
+
+    def test_read_config_enabled_flag_variants(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        tmp_path = pathlib.Path(tmp_dir.name)
+        cases = [
+            ('true', True), ('True', True), ('yes', True), ('1', True),
+            ('false', False), ('no', False), ('0', False),
+        ]
+        for value, expected in cases:
+            with self.subTest(value=value):
+                path = tmp_path / 'reflection.conf'
+                path.write_text('[reflection]\nenabled = %s\n' % value)
+                config = reflection.read_config(str(path))
+                self.assertIs(config['enabled'], expected)
+
+    def test_read_config_env_overrides_file(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        tmp_path = pathlib.Path(tmp_dir.name)
+        path = tmp_path / 'reflection.conf'
+        path.write_text(
+            '[reflection]\n'
+            'url = https://file.example.org\n'
+            'api_key = file-key\n'
+            'enabled = false\n')
+
+        p = mock.patch.dict(os.environ, {
+            'SUGAR_AI_URL': 'https://env.example.org',
+            'SUGAR_AI_KEY': 'env-key',
+            'SUGAR_AI_REFLECTION_ENABLED': 'true'})
+        p.start()
+        self.addCleanup(p.stop)
+
+        config = reflection.read_config(str(path))
+        self.assertEqual(
+            config,
+            {'url': 'https://env.example.org', 'api_key': 'env-key',
+             'enabled': True})
+
+    def test_read_config_env_override_without_file(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        tmp_path = pathlib.Path(tmp_dir.name)
+        path = str(tmp_path / 'missing.conf')
+        p = mock.patch.dict(os.environ, {
+            'SUGAR_AI_URL': 'https://env.example.org'})
+        p.start()
+        self.addCleanup(p.stop)
+        config = reflection.read_config(path)
+        self.assertEqual(config['url'], 'https://env.example.org')
+
+
 class TestHttpClient(unittest.TestCase):
 
     # --- HTTP client: _post_json ---
 
+    def test_post_json_happy_path(self):
+        body = json.dumps({'question': 'What did you build?'}).encode('utf-8')
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', fake_urlopen(body))
+        p.start()
+        self.addCleanup(p.stop)
+        result = reflection._post_json('https://ai.example.org/reflect/chat',
+                                       'key', {'title': 't'})
+        self.assertEqual(result, {'question': 'What did you build?'})
+
+    def test_post_json_timeout(self):
+        def raise_timeout(request, timeout=None):
+            raise socket.timeout()
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', raise_timeout)
+        p.start()
+        self.addCleanup(p.stop)
+        with self.assertRaises(reflection.ReflectionTimeout):
+            reflection._post_json('https://ai.example.org/reflect/chat', 'key',
+                                  {})
+
+    def test_post_json_http_error(self):
+        def raise_http_error(request, timeout=None):
+            raise urllib.error.HTTPError(
+                'https://ai.example.org/reflect/chat', 500,
+                'Internal Server Error', {}, None)
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', raise_http_error)
+        p.start()
+        self.addCleanup(p.stop)
+        with self.assertRaises(reflection.ReflectionHTTPError) as cm:
+            reflection._post_json('https://ai.example.org/reflect/chat', 'key',
+                                  {})
+        self.assertEqual(cm.exception.status, 500)
+
+    def test_post_json_connection_refused_is_offline(self):
+        def raise_url_error(request, timeout=None):
+            raise urllib.error.URLError('connection refused')
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', raise_url_error)
+        p.start()
+        self.addCleanup(p.stop)
+        with self.assertRaises(reflection.ReflectionOffline):
+            reflection._post_json('https://ai.example.org/reflect/chat', 'key',
+                                  {})
+
+    def test_post_json_garbage_response_is_bad_response(self):
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', fake_urlopen(b'not json'))
+        p.start()
+        self.addCleanup(p.stop)
+        with self.assertRaises(reflection.ReflectionBadResponse):
+            reflection._post_json('https://ai.example.org/reflect/chat', 'key',
+                                  {})
+
     # --- request_turn: end-to-end client behavior + identity contract ---
 
+    def test_request_turn_happy_path(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: True)
+        p.start()
+        self.addCleanup(p.stop)
+        body = json.dumps({'question': 'What was tricky?'}).encode('utf-8')
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', fake_urlopen(body))
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-1', 3, 'org.laptop.PippyActivity', 'My Program', 'desc', [],
+            config=VALID_CONFIG)
+
+        self.assertEqual(result, {
+            'object_id': 'obj-1', 'generation': 3,
+            'status': reflection.STATUS_OK,
+            'turn': {'role': 'jo', 'text': 'What was tricky?'},
+            'should_continue': True,
+        })
+
+    def test_request_turn_timeout(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: True)
+        p.start()
+        self.addCleanup(p.stop)
+
+        def raise_timeout(request, timeout=None):
+            raise socket.timeout()
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', raise_timeout)
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-2', 7, 'x', 't', 'd', [], config=VALID_CONFIG)
+        self.assertEqual(result['status'], reflection.STATUS_OK)
+        self.assertEqual(result['object_id'], 'obj-2')
+        self.assertEqual(result['generation'], 7)
+        self.assertEqual(
+            result['turn']['text'], reflection.DEFAULT_FLOOR_BANK[0])
+
+    def test_request_turn_http_500(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: True)
+        p.start()
+        self.addCleanup(p.stop)
+
+        def raise_http_error(request, timeout=None):
+            raise urllib.error.HTTPError(
+                'https://ai.example.org/reflect/chat', 500,
+                'Internal Server Error', {}, None)
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', raise_http_error)
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-3', 1, 'x', 't', 'd', [], config=VALID_CONFIG)
+        self.assertEqual(result['status'], reflection.STATUS_OK)
+        self.assertEqual(
+            result['turn']['text'], reflection.DEFAULT_FLOOR_BANK[0])
+
+    def test_request_turn_garbage_json(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: True)
+        p.start()
+        self.addCleanup(p.stop)
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', fake_urlopen(b'{not valid'))
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-4', 1, 'x', 't', 'd', [], config=VALID_CONFIG)
+        self.assertEqual(result['status'], reflection.STATUS_OK)
+        self.assertEqual(
+            result['turn']['text'], reflection.DEFAULT_FLOOR_BANK[0])
+
+    def test_request_turn_response_missing_question_is_bad_response(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: True)
+        p.start()
+        self.addCleanup(p.stop)
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen',
+            fake_urlopen(
+                json.dumps({'framework': 'creative_spiral'}).encode()))
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-5', 1, 'x', 't', 'd', [], config=VALID_CONFIG)
+        self.assertEqual(result['status'], reflection.STATUS_OK)
+        self.assertEqual(
+            result['turn']['text'], reflection.DEFAULT_FLOOR_BANK[0])
+
+    def test_request_turn_offline_short_circuits_before_urlopen(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: False)
+        p.start()
+        self.addCleanup(p.stop)
+
+        def fail_if_called(request, timeout=None):
+            raise AssertionError('urlopen must not be called while offline')
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', fail_if_called)
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-6', 2, 'org.laptop.Chat', 't', 'd', [], config=VALID_CONFIG)
+
+        self.assertEqual(result['status'], reflection.STATUS_OK)
+        self.assertEqual(result['turn']['role'], reflection.ROLE_JO)
+        self.assertEqual(result['turn']['text'], reflection.floor_question(
+            'org.laptop.Chat'))
+
+    def test_request_turn_not_configured_uses_floor_without_probing(self):
+        probed = []
+        p = mock.patch.object(
+            reflection, 'is_online', lambda url: probed.append(1) or True)
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-7', 1, 'org.laptop.TurtleArtActivity', 't', 'd', [],
+            config={'url': '', 'api_key': '', 'enabled': True})
+
+        self.assertEqual(result['status'], reflection.STATUS_OK)
+        self.assertEqual(result['turn']['role'], reflection.ROLE_JO)
+        self.assertFalse(probed)
+
+    def test_request_turn_disabled_uses_floor(self):
+        result = reflection.request_turn(
+            'obj-8', 1, 'org.laptop.TurtleArtActivity', 't', 'd', [],
+            config={'url': 'https://ai.example.org', 'api_key': 'k',
+                    'enabled': False})
+        self.assertEqual(result['status'], reflection.STATUS_OK)
+        self.assertEqual(result['turn']['role'], reflection.ROLE_JO)
+
+    def test_request_turn_server_unreachable_falls_back_to_floor(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: True)
+        p.start()
+        self.addCleanup(p.stop)
+
+        def raise_url_error(request, timeout=None):
+            raise urllib.error.URLError('no route to host')
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', raise_url_error)
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-9', 1, 'org.laptop.Chat', 't', 'd', [], config=VALID_CONFIG)
+        self.assertEqual(result['status'], reflection.STATUS_OK)
+        self.assertEqual(result['turn']['role'], reflection.ROLE_JO)
+
+    def test_request_turn_offline_never_repeats_a_floor_question(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: False)
+        p.start()
+        self.addCleanup(p.stop)
+        bank = reflection.FLOOR_BANK['communication']
+
+        data = reflection.empty_conversation()
+        session = reflection.new_session('communication')
+        reflection.add_turn(session, reflection.ROLE_JO, bank[0])
+        reflection.add_turn(session, reflection.ROLE_CHILD, 'my friend')
+        data['sessions'].append(session)
+
+        result = reflection.request_turn(
+            'obj-10', 1, 'org.laptop.Chat', 't', 'd', [], config=VALID_CONFIG,
+            conversation=data)
+        self.assertEqual(result['status'], reflection.STATUS_OK)
+        self.assertEqual(result['turn']['text'], bank[1])
+
+    def test_request_turn_offline_counts_current_session_turns(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: False)
+        p.start()
+        self.addCleanup(p.stop)
+        p = mock.patch.object(reflection.random, 'random', lambda: 0.99)
+        p.start()
+        self.addCleanup(p.stop)
+        bank = reflection.FLOOR_BANK['communication']
+        turns = [{'role': reflection.ROLE_JO, 'text': bank[0]},
+                 {'role': reflection.ROLE_CHILD, 'text': 'my friend'}]
+
+        result = reflection.request_turn(
+            'obj-11', 1, 'org.laptop.Chat', 't', 'd', turns,
+            config=VALID_CONFIG)
+        self.assertEqual(result['status'], reflection.STATUS_OK)
+        self.assertEqual(result['turn']['text'], bank[1])
+
+    def test_request_turn_dry_floor_bank_goes_silent(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: False)
+        p.start()
+        self.addCleanup(p.stop)
+        bank = reflection.FLOOR_BANK['communication']
+
+        data = reflection.empty_conversation()
+        session = reflection.new_session('communication')
+        for question in bank:
+            reflection.add_turn(session, reflection.ROLE_JO, question)
+        data['sessions'].append(session)
+
+        result = reflection.request_turn(
+            'obj-12', 1, 'org.laptop.Chat', 't', 'd', [], config=VALID_CONFIG,
+            conversation=data)
+        self.assertEqual(result['status'], reflection.STATUS_OK)
+        self.assertIsNone(result['turn'])
+
+    def test_request_turn_carries_should_continue_false(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: True)
+        p.start()
+        self.addCleanup(p.stop)
+        body = json.dumps({'question': 'One last thought?',
+                           'should_continue': False}).encode('utf-8')
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', fake_urlopen(body))
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-13', 1, 'x', 't', 'd', [], config=VALID_CONFIG)
+        self.assertIs(result['should_continue'], False)
+        self.assertEqual(result['turn']['text'], 'One last thought?')
+
+    def test_request_turn_should_continue_defaults_true(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: True)
+        p.start()
+        self.addCleanup(p.stop)
+        body = json.dumps({'question': 'q'}).encode('utf-8')
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', fake_urlopen(body))
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-14', 1, 'x', 't', 'd', [], config=VALID_CONFIG)
+        self.assertIs(result['should_continue'], True)
+
+    def test_request_turn_floor_path_should_continue_true(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: False)
+        p.start()
+        self.addCleanup(p.stop)
+        result = reflection.request_turn(
+            'obj-15', 1, 'org.laptop.Chat', 't', 'd', [], config=VALID_CONFIG)
+        self.assertIs(result['should_continue'], True)
+
     # --- Identity contract ---
+
+    def test_identity_tagging_survives_every_status(self):
+        setups = [
+            'happy', 'timeout', 'http_error', 'bad_response', 'offline',
+            'not_configured',
+        ]
+        for setup in setups:
+            with self.subTest(setup=setup), contextlib.ExitStack() as stack:
+                object_id = 'entry-uid-%s' % setup
+                generation = 42
+                config = dict(VALID_CONFIG)
+
+                if setup == 'happy':
+                    stack.enter_context(mock.patch.object(
+                        reflection, 'is_online', lambda url: True))
+                    body = json.dumps({'question': 'q'}).encode('utf-8')
+                    stack.enter_context(mock.patch.object(
+                        reflection.urllib.request, 'urlopen',
+                        fake_urlopen(body)))
+                elif setup == 'timeout':
+                    stack.enter_context(mock.patch.object(
+                        reflection, 'is_online', lambda url: True))
+
+                    def raise_timeout(request, timeout=None):
+                        raise socket.timeout()
+                    stack.enter_context(mock.patch.object(
+                        reflection.urllib.request, 'urlopen',
+                        raise_timeout))
+                elif setup == 'http_error':
+                    stack.enter_context(mock.patch.object(
+                        reflection, 'is_online', lambda url: True))
+
+                    def raise_http_error(request, timeout=None):
+                        raise urllib.error.HTTPError(
+                            'u', 503, 'Service Unavailable', {}, None)
+                    stack.enter_context(mock.patch.object(
+                        reflection.urllib.request, 'urlopen',
+                        raise_http_error))
+                elif setup == 'bad_response':
+                    stack.enter_context(mock.patch.object(
+                        reflection, 'is_online', lambda url: True))
+                    stack.enter_context(mock.patch.object(
+                        reflection.urllib.request, 'urlopen',
+                        fake_urlopen(b'garbage')))
+                elif setup == 'offline':
+                    stack.enter_context(mock.patch.object(
+                        reflection, 'is_online', lambda url: False))
+                elif setup == 'not_configured':
+                    config = {'url': '', 'api_key': '', 'enabled': True}
+
+                result = reflection.request_turn(
+                    object_id, generation, 'org.laptop.TurtleArtActivity',
+                    't', 'd', [], config=config)
+
+                self.assertEqual(result['object_id'], object_id)
+                self.assertEqual(result['generation'], generation)
 
     # --- turn_acceptable: the shape contract on Jo's own voice ---
 
@@ -385,6 +886,28 @@ class TestHttpClient(unittest.TestCase):
     def test_turn_acceptable_rejects_question_pile(self):
         self.assertFalse(reflection.turn_acceptable(
             'What is it? How did you make it? What comes next?'))
+
+    def test_request_turn_slop_reply_falls_back_to_floor(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: True)
+        p.start()
+        self.addCleanup(p.stop)
+        slop = ('The key to a great reflection is considering your process: '
+                'what worked, what did not, and what you might change.')
+        body = json.dumps({'question': slop}).encode('utf-8')
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', fake_urlopen(body))
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-20', 1, 'org.laptop.PippyActivity', 't', 'd', [],
+            config=VALID_CONFIG)
+
+        self.assertEqual(result['status'], reflection.STATUS_OK)
+        self.assertIsNotNone(result['turn'])
+        self.assertNotEqual(result['turn']['text'], slop)
+        self.assertTrue(result['turn']['text'].endswith('?'))
+
 
 def _held_data(last_role, text='make the middle rounder', ts=1000):
     return {'sessions': [{'ts': ts, 'turns': [
@@ -555,6 +1078,25 @@ class TestQuestionBanks(unittest.TestCase):
         self.assertEqual(reflection.nearby_followup(
             used={reflection.NEARBY_MIDFLOW}), reflection.NEARBY_FOLLOWUP)
 
+    def test_request_turn_rolls_the_midflow_on_the_floor(self):
+        config = {'enabled': False, 'api_key': '', 'url': ''}
+        p = mock.patch.object(reflection.random, 'random', lambda: 0.0)
+        p.start()
+        self.addCleanup(p.stop)
+        result = reflection.request_turn(
+            'obj-m', 1, 'org.example.Unknown', 't', 'd', list(WARM_TURNS),
+            config=config)
+        self.assertEqual(result['turn']['text'], reflection.NEARBY_MIDFLOW)
+        p = mock.patch.object(reflection.random, 'random', lambda: 0.99)
+        p.start()
+        self.addCleanup(p.stop)
+        result = reflection.request_turn(
+            'obj-m', 2, 'org.example.Unknown', 't', 'd', list(WARM_TURNS),
+            config=config)
+        self.assertEqual(
+            result['turn']['text'],
+            reflection.VISIBLE_WORK_OPENERS[reflection.DEFAULT_FLOOR_BANK[0]])
+
     def test_followup_waits_for_real_time_away(self):
         used = {reflection.NEARBY_MIDFLOW}
         fresh = {'sessions': [{'ts': 10000, 'turns': []}]}
@@ -564,6 +1106,43 @@ class TestQuestionBanks(unittest.TestCase):
                 used, fresh,
                 now=10000 + reflection.FEED_FORWARD_GAP + 1),
             reflection.NEARBY_FOLLOWUP)
+
+    def test_people_turns_stay_off_the_wire(self):
+        turns = [
+            {'role': 'jo', 'text': 'What was tricky about this one?'},
+            {'role': 'child', 'text': 'the roof'},
+            {'role': 'jo', 'text': reflection.NEARBY_MIDFLOW},
+            {'role': 'child', 'text': 'Ana says it needs a beam'},
+            {'role': 'child', 'text': 'she liked the roof'},
+            {'role': 'jo', 'text': 'What will you try next time?'},
+            {'role': 'child', 'text': 'a beam'}]
+        payload = reflection._build_payload('t', 'd', 'a', turns)
+        contents = [t['content'] for t in payload['turns']]
+        self.assertNotIn('Ana says it needs a beam', contents)
+        self.assertNotIn('she liked the roof', contents)
+        self.assertNotIn(reflection.NEARBY_MIDFLOW, contents)
+        self.assertIn('the roof', contents)
+        self.assertIn('a beam', contents)
+
+    def test_midflow_walks_the_real_floor_sequence(self):
+        config = {'enabled': False, 'api_key': '', 'url': ''}
+        bank = list(reflection.DEFAULT_FLOOR_BANK)
+        turns = [{'role': 'jo', 'text': bank[0]},
+                 {'role': 'child', 'text': 'the tower kept falling over'}]
+        p = mock.patch.object(reflection.random, 'random', lambda: 0.99)
+        p.start()
+        self.addCleanup(p.stop)
+        result = reflection.request_turn(
+            'obj-s', 1, 'org.example.Unknown', 't', 'd', list(turns),
+            config=config)
+        self.assertEqual(result['turn']['text'], bank[1])
+        p = mock.patch.object(reflection.random, 'random', lambda: 0.0)
+        p.start()
+        self.addCleanup(p.stop)
+        result = reflection.request_turn(
+            'obj-s', 2, 'org.example.Unknown', 't', 'd', list(turns),
+            config=config)
+        self.assertEqual(result['turn']['text'], reflection.NEARBY_MIDFLOW)
 
     def test_strip_private_drops_talk_and_snaps_only(self):
         metadata = {'reflections': '{"sessions": []}', 'next_steps': 'x',
@@ -626,6 +1205,23 @@ class TestPeerQuestions(unittest.TestCase):
         self.assertIsNone(reflection.peer_question(json.dumps(['x', 3])))
         self.assertIsNone(reflection.peer_question(
             json.dumps([{'from': 'Ana'}])))
+
+    def test_peer_turns_and_their_answers_stay_off_the_wire(self):
+        voiced = reflection.PEER_QUESTION_OPENER % {
+            'who': 'Ana', 'question': 'How did you build it?'}
+        turns = [
+            {'role': 'jo', 'text': 'What was tricky about this one?'},
+            {'role': 'child', 'text': 'the roof'},
+            {'role': 'jo', 'text': voiced, 'peer': True},
+            {'role': 'child', 'text': 'I will tell Ana about the beam'},
+            {'role': 'jo', 'text': 'What will you try next time?'},
+            {'role': 'child', 'text': 'a beam'}]
+        payload = reflection._build_payload('t', 'd', 'a', turns)
+        contents = [t['content'] for t in payload['turns']]
+        self.assertNotIn(voiced, contents)
+        self.assertNotIn('I will tell Ana about the beam', contents)
+        self.assertIn('the roof', contents)
+        self.assertIn('a beam', contents)
 
     def test_add_turn_keeps_ordinary_turns_flag_free(self):
         session = reflection.new_session('creative')
@@ -803,6 +1399,15 @@ class TestQuestionIds(unittest.TestCase):
         used = reflection.used_floor_questions(None, [foreign])
         self.assertIn(reflection.FLOOR_BANK['creative'][0], used)
 
+    def test_people_ids_latch_off_the_wire(self):
+        turns = [
+            {'role': 'jo', 'text': 'translated nudge', 'q': 'nearby:nudge'},
+            {'role': 'child', 'text': 'Maya likes the wing'},
+        ]
+        payload = reflection._build_payload('t', 'd', 'x', turns)
+        self.assertEqual(payload['turns'], [])
+
+
 class TestTitledOpener(unittest.TestCase):
 
     # --- the child's own words lead, safely quoted ---
@@ -826,6 +1431,53 @@ class TestTitledOpener(unittest.TestCase):
         opener = reflection.FLOOR_BANK['creative'][0]
         self.assertNotEqual(reflection.floor_question(
             'org.laptop.TurtleArtActivity', used), opener)
+
+    def test_local_turns_stay_off_the_wire_with_their_answers(self):
+        session = reflection.new_session('creative_spiral')
+        reflection.add_turn(session, reflection.ROLE_JO,
+                            reflection.titled_opener('my caption'),
+                            q='floor:creative:0', local=True)
+        reflection.add_turn(session, reflection.ROLE_CHILD,
+                            'it is about my dad')
+        reflection.add_turn(session, reflection.ROLE_JO,
+                            reflection.FLOOR_BANK['creative'][1])
+        reflection.add_turn(session, reflection.ROLE_CHILD, 'more stars')
+        payload = reflection._build_payload(
+            't', 'd', 'x', session['turns'])
+        contents = [t['content'] for t in payload['turns']]
+        self.assertNotIn('it is about my dad', contents)
+        self.assertIn('more stars', contents)
+
+
+class TestFloorFallback(unittest.TestCase):
+
+    # --- every server death lands on the floor, mid-talk included ---
+
+    def test_timeout_mid_talk_serves_the_beside_voice(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: True)
+        p.start()
+        self.addCleanup(p.stop)
+
+        def raise_timeout(request, timeout=None):
+            raise socket.timeout()
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', raise_timeout)
+        p.start()
+        self.addCleanup(p.stop)
+        p = mock.patch.object(reflection.random, 'random', lambda: 0.99)
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-f', 1, 'org.example.Unknown', 't', 'd',
+            [{'role': 'jo', 'text': 'A server question?'},
+             {'role': 'child', 'text': 'i made a robot out of a box'}],
+            config=VALID_CONFIG)
+        self.assertEqual(result['status'], reflection.STATUS_OK)
+        self.assertEqual(
+            result['turn']['text'],
+            reflection.VISIBLE_WORK_OPENERS[reflection.DEFAULT_FLOOR_BANK[0]])
+
 
 class TestQuotedChildText(unittest.TestCase):
 
@@ -860,6 +1512,57 @@ class TestQuotedChildText(unittest.TestCase):
         bad = [{'role': 'jo', 'text': 'x', 'q': ['a']}]
         self.assertEqual(reflection.used_floor_questions(None, bad), set())
         self.assertIs(reflection._people_turn(bad[0]), False)
+
+
+class TestServerMemory(unittest.TestCase):
+
+    # --- memory is the server's alone ---
+
+    def test_floor_questions_never_produce_a_note(self):
+        session = reflection.new_session('creative_spiral')
+        reflection.add_turn(session, reflection.ROLE_JO,
+                            reflection.FLOOR_BANK['creative'][1])
+        reflection.add_turn(session, reflection.ROLE_CHILD, 'more stars')
+        self.assertEqual(reflection.extract_next_steps(session), '')
+
+    def test_a_server_forward_question_produces_one(self):
+        session = reflection.new_session('creative_spiral')
+        reflection.add_turn(session, reflection.ROLE_JO,
+                            'What will you try tomorrow?')
+        reflection.add_turn(session, reflection.ROLE_CHILD, 'more stars')
+        self.assertEqual(reflection.extract_next_steps(session), 'more stars')
+
+    def test_people_answers_never_ride_a_request(self):
+        session = reflection.new_session('creative_spiral')
+        reflection.add_turn(session, reflection.ROLE_JO,
+                            reflection.NEARBY_MIDFLOW)
+        reflection.add_turn(session, reflection.ROLE_CHILD,
+                            'Ana would try a beam next')
+        self.assertEqual(reflection.extract_next_steps(session), '')
+
+    def test_a_giant_answer_is_clipped_at_the_write(self):
+        session = reflection.new_session('creative_spiral')
+        reflection.add_turn(session, reflection.ROLE_JO,
+                            'What will you try tomorrow?')
+        reflection.add_turn(session, reflection.ROLE_CHILD, 'wing ' * 200)
+        note = reflection.extract_next_steps(session)
+        self.assertLessEqual(len(note), 121)
+
+    def test_resolve_replaces_or_keeps(self):
+        session = reflection.new_session('creative_spiral')
+        self.assertEqual(reflection.resolve_next_steps(session, 'old'), 'old')
+        reflection.add_turn(session, reflection.ROLE_JO,
+                            'What will you try tomorrow?')
+        reflection.add_turn(session, reflection.ROLE_CHILD, 'a moon')
+        self.assertEqual(
+            reflection.resolve_next_steps(session, 'old'), 'a moon')
+
+    def test_payload_carries_the_previous_note_online(self):
+        payload = reflection._build_payload(
+            'T', 'd', 'org.laptop.Chat', [], 'try a bigger maze')
+        self.assertEqual(payload['previous_next_steps'], 'try a bigger maze')
+        bare = reflection._build_payload('T', 'd', 'org.laptop.Chat', [])
+        self.assertNotIn('previous_next_steps', bare)
 
 
 class TestSeverePassFixes(unittest.TestCase):
@@ -923,3 +1626,186 @@ class TestSeverePassFixes(unittest.TestCase):
         self.assertTrue(reflection.turn_acceptable('Ինչ սարքեցիր՞'))
         self.assertTrue(reflection.turn_acceptable('ምን ሠራህ፧'))
         self.assertFalse(reflection.turn_acceptable('a statement;'))
+
+
+class TestReviewPassFixes(unittest.TestCase):
+
+    # --- the review pass's catches, pinned ---
+
+    def test_the_ai_switch_ships_unticked(self):
+        self.assertIs(reflection.DEFAULT_ENABLED, False)
+
+    def test_a_read_waits_half_a_minute(self):
+        self.assertEqual(reflection.READ_TIMEOUT, 30)
+
+    def test_a_schemeless_address_lands_on_the_floor(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: True)
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-30', 1, 'org.laptop.Chat', 't', 'd', [],
+            config={'url': 'example.com', 'api_key': 'k', 'enabled': True})
+        self.assertEqual(result['status'], reflection.STATUS_OK)
+        self.assertEqual(result['turn']['text'], reflection.floor_question(
+            'org.laptop.Chat'))
+
+    def test_post_json_reads_a_schemeless_address_as_offline(self):
+        with self.assertRaises(reflection.ReflectionOffline):
+            reflection._post_json('example.com/reflect/chat', 'key', {})
+
+    def test_the_probe_knocks_on_the_configured_server(self):
+        self.assertEqual(
+            reflection._probe_address('https://ai.example.org'),
+            ('ai.example.org', 443))
+        self.assertEqual(
+            reflection._probe_address('http://ai.example.org/reflect'),
+            ('ai.example.org', 80))
+        self.assertEqual(
+            reflection._probe_address('http://localhost:8080'),
+            ('localhost', 8080))
+
+    def test_an_address_with_no_host_is_offline(self):
+        self.assertFalse(reflection.is_online(''))
+        self.assertFalse(reflection.is_online('example.com'))
+        self.assertFalse(reflection.is_online('https://'))
+        self.assertFalse(reflection.is_online('http://ai.example.org:port'))
+
+    def test_read_config_without_a_section_header_uses_defaults(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        tmp_path = pathlib.Path(tmp_dir.name)
+        path = tmp_path / 'reflection.conf'
+        path.write_text('url = https://ai.example.org\napi_key = k\n')
+        config = reflection.read_config(str(path))
+        self.assertEqual(
+            config,
+            {'url': '', 'api_key': '',
+             'enabled': reflection.DEFAULT_ENABLED})
+
+    def test_read_config_of_a_non_utf8_file_uses_defaults(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        tmp_path = pathlib.Path(tmp_dir.name)
+        path = tmp_path / 'reflection.conf'
+        path.write_bytes(b'[reflection]\nurl = https://ai.\xff\xfe.org\n')
+        config = reflection.read_config(str(path))
+        self.assertEqual(
+            config,
+            {'url': '', 'api_key': '',
+             'enabled': reflection.DEFAULT_ENABLED})
+
+    def test_a_corrupt_turn_never_reaches_the_wire(self):
+        turns = ['corrupt', 7, None,
+                 {'text': 'no role at all'},
+                 {'role': 'kangaroo', 'text': 'unknown role'},
+                 {'role': 'child', 'text': 'a rocket'}]
+        payload = reflection._build_payload('t', 'd', 'a', turns)
+        self.assertEqual(
+            payload['turns'], [{'role': 'user', 'content': 'a rocket'}])
+
+    def test_a_starred_people_answer_empties_the_description(self):
+        answer = 'Ana says it needs a beam'
+        turns = [{'role': 'jo', 'text': reflection.NEARBY_MIDFLOW},
+                 {'role': 'child', 'text': answer}]
+        description = reflection.keep_in_description('My tower.', answer)
+        payload = reflection._build_payload('t', description, 'a', turns)
+        self.assertEqual(payload['description'], '')
+        self.assertEqual(payload['turns'], [])
+
+    def test_an_unstarred_people_answer_leaves_the_description(self):
+        turns = [{'role': 'jo', 'text': reflection.NEARBY_MIDFLOW},
+                 {'role': 'child', 'text': 'Ana says it needs a beam'}]
+        payload = reflection._build_payload('t', 'My tower.', 'a', turns)
+        self.assertEqual(payload['description'], 'My tower.')
+
+    def test_a_people_answer_starred_in_an_older_session_is_seen(self):
+        raw = json.dumps({'sessions': [
+            {'ts': 1, 'turns': [
+                {'role': 'jo', 'text': reflection.NEARBY_MIDFLOW},
+                {'role': 'child', 'text': 'Ana says it needs a beam'}]},
+            {'ts': 2, 'turns': [
+                {'role': 'jo', 'text': 'What was tricky about this one?'},
+                {'role': 'child', 'text': 'the roof'}]},
+        ]})
+        description = reflection.keep_in_description(
+            'My tower.', 'Ana says it needs a beam')
+        self.assertTrue(
+            reflection.people_kept_in_description(raw, description))
+        self.assertFalse(
+            reflection.people_kept_in_description(raw, 'My tower.'))
+        self.assertFalse(reflection.people_kept_in_description(raw, ''))
+
+    def test_an_ordinary_starred_answer_is_not_a_people_answer(self):
+        raw = json.dumps({'sessions': [
+            {'ts': 1, 'turns': [
+                {'role': 'jo', 'text': 'What was tricky about this one?'},
+                {'role': 'child', 'text': 'the roof'}]},
+        ]})
+        description = reflection.keep_in_description('My tower.', 'the roof')
+        self.assertFalse(
+            reflection.people_kept_in_description(raw, description))
+
+    def test_a_people_stamp_is_read_before_the_stored_wording(self):
+        qid = reflection._QUESTION_ID[reflection.NEARBY_MIDFLOW]
+        raw = json.dumps({'sessions': [
+            {'ts': 1, 'turns': [
+                {'role': 'jo', 'text': 'the wording of another locale',
+                 'q': qid},
+                {'role': 'child', 'text': 'Ana says it needs a beam'}]},
+        ]})
+        description = reflection.keep_in_description(
+            'My tower.', 'Ana says it needs a beam')
+        self.assertTrue(
+            reflection.people_kept_in_description(raw, description))
+
+    def test_a_peer_answer_starred_in_an_older_session_is_seen(self):
+        voiced = reflection.PEER_QUESTION_OPENER % {
+            'who': 'Ana', 'question': 'How did you build it?'}
+        raw = json.dumps({'sessions': [
+            {'ts': 1, 'turns': [
+                {'role': 'jo', 'text': voiced, 'peer': True},
+                {'role': 'child', 'text': 'I will tell Ana about the beam'}]},
+        ]})
+        description = reflection.keep_in_description(
+            'My tower.', 'I will tell Ana about the beam')
+        self.assertTrue(
+            reflection.people_kept_in_description(raw, description))
+
+    def test_a_malformed_record_keeps_the_description_question_shut(self):
+        for raw in ('', None, 'not json', '{"sessions": "gone"}',
+                    json.dumps({'sessions': ['corrupt', {'turns': 5},
+                                             {'turns': ['x']}]})):
+            self.assertFalse(
+                reflection.people_kept_in_description(raw, 'My tower.'), raw)
+
+    def test_an_oversized_reply_is_a_bad_response(self):
+        body = json.dumps(
+            {'question': 'What did you make?',
+             'pad': 'x' * reflection._MAX_RESPONSE_BYTES}).encode('utf-8')
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', fake_urlopen(body))
+        p.start()
+        self.addCleanup(p.stop)
+        with self.assertRaises(reflection.ReflectionBadResponse):
+            reflection._post_json('https://ai.example.org/reflect/chat',
+                                  'key', {})
+
+    def test_an_oversized_reply_lands_on_the_floor(self):
+        p = mock.patch.object(reflection, 'is_online', lambda url: True)
+        p.start()
+        self.addCleanup(p.stop)
+        body = json.dumps(
+            {'question': 'What did you make?',
+             'pad': 'x' * reflection._MAX_RESPONSE_BYTES}).encode('utf-8')
+        p = mock.patch.object(
+            reflection.urllib.request, 'urlopen', fake_urlopen(body))
+        p.start()
+        self.addCleanup(p.stop)
+
+        result = reflection.request_turn(
+            'obj-31', 1, 'org.laptop.Chat', 't', 'd', [],
+            config=VALID_CONFIG)
+        self.assertEqual(result['status'], reflection.STATUS_OK)
+        self.assertEqual(result['turn']['text'], reflection.floor_question(
+            'org.laptop.Chat'))


### PR DESCRIPTION
## The online half:
- the journal can ask a configured AI server for Jo's next question, and a new AI section in the control panel holds the three settings:
  1. an enable switch
  2. the server address
  3. the key.

- The switch ships off; with nothing configured.
- The journal's built-in question bank stays the floor: when the server is slow (30 seconds), unreachable, or answers badly, the next question comes from the bank instead, mid-conversation included.

Builds on #1121.

## Notes:
- there is no public server to point this at yet; the address is meant for a school's own machine or a hosted deployment.
- **what goes out:** 
  - title, description, activity id, the conversation turns, and now the entry's context too (preview, moment snapshots, tags and time spent, added in the two newest commits).
  - Answers to Jo's "who was with you" questions stay on the machine, and if one was starred into the description, the description is not sent.
- the request and response use the reflection engine's wire format directly; the server half is sugarlabs/sugar-ai#163.
- the key is stored in a file only the user can read, and the panel only reports Connected once both address and key are set.
- most of the diff is tests: about 1,050 of 2,000 lines.
- the panel itself has no automated tests (GTK); it was checked in a running Sugar shell.

## Testing:
324 journal tests pass with unittest discover; flake8 clean on the new files.

Series notes in #1111.