### PR TITLE
share a journal entry with the neighborhood

### DIFF
--- a/src/jarabe/journal/Makefile.am
+++ b/src/jarabe/journal/Makefile.am
@@ -24,6 +24,7 @@ sugar_PYTHON =				\
 	palettes.py			\
 	joglyph.py			\
 	momentcard.py			\
+	peershare.py			\
 	reflectguard.py			\
 	reflection.py			\
 	reflectiontrigger.py		\

--- a/src/jarabe/journal/model.py
+++ b/src/jarabe/journal/model.py
@@ -712,6 +712,8 @@ def copy(metadata, mount_point, ready_callback=None):
 
     metadata['mountpoint'] = mount_point
     del metadata['uid']
+    # A copy is a new entry, so don't carry the original's sharing over
+    metadata.pop('shared', None)
 
     write(metadata, file_path, transfer_ownership=False,
           ready_callback=ready_callback)

--- a/src/jarabe/journal/peershare.py
+++ b/src/jarabe/journal/peershare.py
@@ -1,0 +1,904 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Advertise shared Journal entries to the neighborhood.
+
+An entry whose 'shared' metadata is '1' gets a salut room named by an
+activity id minted from its uid, and rides the same BuddyInfo and
+ActivityProperties wire that shared activities use. An older shell
+that doesn't know the entry type sees an unknown bundle and drops the
+advert.
+
+The room only carries the advert. The page itself, the request for
+it, and the visitor's question all travel over a plain one-to-one
+text channel, so every message has to name the entry it's about.
+Those channels are shared with whatever else the two friends say to
+each other, so anything that isn't ours gets left in the queue unread
+and unacknowledged for whoever else is reading.
+"""
+
+import base64
+import hashlib
+import json
+import logging
+import re
+import unicodedata
+from functools import partial
+
+import dbus
+import gi
+gi.require_version('TelepathyGLib', '0.12')
+from gi.repository import GLib
+from gi.repository import TelepathyGLib
+
+from sugar3 import profile
+from sugar3.bundle.activitybundle import ActivityBundle
+from sugar3.bundle.contentbundle import ContentBundle
+
+from jarabe.journal import model
+from jarabe.journal import reflectguard
+from jarabe.journal import reflection
+from jarabe.journal.journalentrybundle import JournalEntryBundle
+from jarabe.model import neighborhood
+from jarabe.model.neighborhood import CONNECTION_INTERFACE_BUDDY_INFO
+from jarabe.model.neighborhood import CONNECTION_INTERFACE_REQUESTS
+from jarabe.model.neighborhood import \
+    CONNECTION_INTERFACE_ACTIVITY_PROPERTIES
+
+CONNECTION = TelepathyGLib.IFACE_CONNECTION
+CHANNEL = TelepathyGLib.IFACE_CHANNEL
+CHANNEL_TYPE_TEXT = TelepathyGLib.IFACE_CHANNEL_TYPE_TEXT
+HANDLE_TYPE_ROOM = TelepathyGLib.HandleType.ROOM
+HANDLE_TYPE_CONTACT = int(TelepathyGLib.HandleType.CONTACT)
+# A stock Chat window only renders NORMAL messages. Its
+# TextChannelWrapper._received_cb drops anything else before it
+# reaches the screen ("if type_ != 0: return" in sugarlabs/chat's
+# activity.py), but it stays in the channel for
+# whoever else is reading. That's why the whole protocol rides
+# NOTICE.
+MESSAGE_TYPE_PROTOCOL = int(TelepathyGLib.ChannelTextMessageType.NOTICE)
+
+PROTOCOL = 1
+KIND_FETCH = 'fetch'
+KIND_ENTRY = 'entry'
+KIND_ASK = 'ask'
+KINDS = (KIND_FETCH, KIND_ENTRY, KIND_ASK)
+
+# Longest question we'll take, in characters.
+ASK_LIMIT = 500
+# Ceiling on the encoded line, in bytes. A message goes whole or it
+# doesn't go, so an entry whose preview would push it over the top
+# gets sent without the preview.
+PAYLOAD_LIMIT = 90000
+
+# The entry keys a peer may see; build_entry_payload adds the uid,
+# color, comments and preview on top of these. The child's talk with
+# Jo, their moments and their next steps are deliberately not here,
+# so they stay on this laptop.
+_PAYLOAD_KEYS = ('title', 'description', 'tags', 'activity')
+
+_RETRY_SECONDS = 10
+
+_instance = None
+
+
+def entry_activity_id(uid):
+    return hashlib.sha1(uid.encode('utf-8')).hexdigest()
+
+
+def without_activity(activities, activity_id):
+    """The buddy's activity list with one entry filtered out.
+
+    SetActivities replaces the whole list, so a retraction has to
+    start from what GetActivities gave us. Sending only our own
+    entries would drop everything else the child is sharing.
+    """
+    return [(aid, room_handle) for aid, room_handle in activities
+            if aid != activity_id]
+
+
+def entry_properties(metadata, color=None):
+    if color is None:
+        color = profile.get_color().to_string()
+    # The connection manager rejects any key outside the stock
+    # property set, so the uid, source bundle id and mime type all
+    # ride space-separated in 'tags'. Only the mime type has a '/' in
+    # it, which is how the reader tells the tokens apart when some of
+    # them are missing.
+    uid = metadata.get('uid', '')
+    bundle_id = metadata.get('activity', '')
+    mime_type = metadata.get('mime_type', '')
+    tokens = [uid]
+    if bundle_id:
+        tokens.append(bundle_id)
+    if mime_type and '/' in mime_type:
+        tokens.append(mime_type)
+    tags = ' '.join(tokens)
+    return {
+        'type': neighborhood.JOURNAL_ENTRY_TYPE,
+        'name': metadata.get('title', '') or '',
+        'color': color,
+        'private': False,
+        'tags': tags,
+    }
+
+
+def _preview_bytes(preview):
+    if isinstance(preview, str):
+        return preview.encode('utf-8')
+    try:
+        return bytes(preview)
+    except TypeError:
+        return b''
+
+
+def build_entry_payload(metadata, color=None):
+    """The page a friend gets to look at.
+
+    Built up key by key. If it were built by stripping the metadata
+    instead, a private key added to entries later would start
+    travelling on its own.
+    """
+    payload = {'peershare': PROTOCOL, 'kind': KIND_ENTRY,
+               'uid': str(metadata.get('uid', '') or '')}
+    for key in _PAYLOAD_KEYS:
+        payload[key] = str(metadata.get(key, '') or '')
+    entry_color = metadata.get('icon-color')
+    if not entry_color:
+        entry_color = color if color is not None \
+            else profile.get_color().to_string()
+    payload['color'] = str(entry_color)
+    payload['comments'] = reflection.parse_comments(
+        metadata.get('comments', ''))
+    preview = _preview_bytes(metadata.get('preview', ''))
+    if preview:
+        payload['preview'] = base64.b64encode(preview).decode('ascii')
+    return payload
+
+
+def encode_payload(payload):
+    line = json.dumps(payload)
+    if len(line.encode('utf-8')) <= PAYLOAD_LIMIT:
+        return line
+    payload = dict(payload)
+    payload.pop('preview', None)
+    return json.dumps(payload)
+
+
+TAG_LIMIT = 8
+TAG_CHARS = 32
+
+_UID_SHAPE = re.compile(r'[A-Za-z0-9_-]{1,128}')
+
+_BUNDLE_KINDS = (ActivityBundle.MIME_TYPE, ContentBundle.MIME_TYPE,
+                 JournalEntryBundle.MIME_TYPE)
+
+
+def safe_uid(uid):
+    """The uid if it's a plain id, otherwise ''.
+
+    The machinery this page gets handed to reads a uid that looks
+    like a real path as a file to open, so nothing arriving off the
+    wire is allowed to name a path on this laptop.
+    """
+    if not isinstance(uid, str) or _UID_SHAPE.fullmatch(uid) is None:
+        return ''
+    return uid
+
+
+def safe_mime(mime_type):
+    """Refuse the activity, content and Journal-entry bundle types,
+    which would send the Journal looking for a file on disk.
+    """
+    if not isinstance(mime_type, str) or mime_type in _BUNDLE_KINDS:
+        return ''
+    return mime_type
+
+
+def safe_tags(tags):
+    """Trim the tag string down to what the page can draw."""
+    if not isinstance(tags, str):
+        return ''
+    words = []
+    for word in tags.split():
+        word = ''.join(ch for ch in word
+                       if unicodedata.category(ch)
+                       not in ('Cc', 'Cf', 'Zl', 'Zp'))
+        if word:
+            words.append(word[:TAG_CHARS])
+        if len(words) == TAG_LIMIT:
+            break
+    return ' '.join(words)
+
+
+def parse_message(line):
+    """Parse a line as this protocol's envelope, or return None.
+
+    These are plain text channels, so most of what arrives on one is
+    somebody else's traffic and gets ignored. The channel only tells
+    us which friend we're talking to, so a fetch or an ask has to
+    carry the uid itself or there's nothing to answer.
+    """
+    try:
+        message = json.loads(line)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(message, dict):
+        return None
+    version = message.get('peershare')
+    if isinstance(version, bool) or version != PROTOCOL:
+        return None
+    kind = message.get('kind')
+    if kind not in KINDS:
+        return None
+    if kind in (KIND_FETCH, KIND_ASK):
+        uid = message.get('uid')
+        if not isinstance(uid, str) or not uid:
+            return None
+    return message
+
+
+_stray_chat_cb = None
+
+
+def set_stray_chat_cb(callback):
+    """Register the listener for real chat on a protocol line.
+
+    The invites model quietens the knock for channels that only carry
+    protocol, so it needs telling when a friend starts actually
+    talking on one.
+    """
+    global _stray_chat_cb
+    _stray_chat_cb = callback
+
+
+def sender_nick(nick):
+    """A peer's nick for a comment's 'from', or '' for anonymous.
+
+    Anything longer than a real name, or carrying control or
+    direction-changing characters, comes back as ''.
+    """
+    nick = nick.strip() if isinstance(nick, str) else ''
+    if len(nick) > reflection.PEER_NAME_LIMIT:
+        return ''
+    if any(unicodedata.category(ch) in ('Cc', 'Cf', 'Zl', 'Zp')
+           for ch in nick):
+        return ''
+    return nick
+
+
+def has_asked(comments, nick):
+    """Whether this visitor's question already stands on the entry.
+
+    The answer comes out of the entry's own comments, so closing the
+    page and opening it again doesn't hand out a second turn.
+    Visitors with no usable name all share the anonymous slot.
+    """
+    if not isinstance(comments, list):
+        return False
+    who = sender_nick(nick)
+    return any(isinstance(comment, dict) and comment.get('from') == who
+               for comment in comments)
+
+
+def append_comment(comments_raw, nick, text, color=''):
+    """The entry's comments with one friend's question appended, or
+    None if the ask can't be taken.
+
+    This is where one-question-per-friend is actually enforced. The
+    visitor's window checks too, but that check runs on their machine
+    and can't be relied on here. A record already at MAX_COMMENTS
+    takes no more, which keeps a peer from growing it without bound.
+    """
+    if not isinstance(text, str):
+        return None
+    text = text.strip()
+    if not text or len(text) > ASK_LIMIT:
+        return None
+    # Zero-width joiners are allowed through because that's how
+    # multi-part emoji hold together. Every other format character is
+    # a lever on how the record displays. A question made of nothing
+    # but joiners has nothing to show, so it goes too.
+    bare = text.replace('\u200d', '')
+    if not bare or any(unicodedata.category(ch) in ('Cc', 'Cf', 'Zl', 'Zp')
+                       for ch in bare):
+        return None
+    who = sender_nick(nick)
+    comments = reflection.parse_comments(comments_raw)
+    if len(comments) >= reflectguard.MAX_COMMENTS:
+        return None
+    for comment in comments:
+        if comment.get('from') == who:
+            return None
+    entry = {'from': who, 'message': text}
+    if color:
+        entry['icon-color'] = color
+    comments.append(entry)
+    return json.dumps(comments)
+
+
+class PeerShare(object):
+
+    def __init__(self):
+        self._shares = {}
+        self._pending = set()
+        self._retractions = set()
+        self._retract_inflight = False
+        self._peers = {}
+        self._watches = []
+        self._bus_name = None
+        self._wait_source = None
+        self._buddy_info_absent = False
+        model.updated.connect(self.__entry_updated_cb)
+        model.deleted.connect(self.__entry_deleted_cb)
+        neighborhood.get_model().connect(
+            'link-local-connection-changed', self.__connection_changed_cb)
+        GLib.idle_add(self.__rescan_cb)
+
+    def _connection(self):
+        return neighborhood.get_model().get_link_local_connection()
+
+    def __rescan_cb(self):
+        # The datastore's filter on 'shared' isn't reliable, so
+        # re-read every hit before letting it advertise.
+        try:
+            bus = dbus.SessionBus()
+            data_store = dbus.Interface(
+                bus.get_object('org.laptop.sugar.DataStore',
+                               '/org/laptop/sugar/DataStore'),
+                'org.laptop.sugar.DataStore')
+            entries, _count = data_store.find(
+                {'shared': '1'}, ['uid'], byte_arrays=True)
+        except Exception:
+            logging.exception('peershare: could not scan for shared entries')
+            return False
+        for entry in entries:
+            uid = str(entry['uid'])
+            try:
+                metadata = model.get(uid)
+            except Exception:
+                continue
+            if metadata.get('shared', '0') == '1':
+                reflectguard.get_guard().note_shared(uid, '1')
+                self._queue(uid)
+        return False
+
+    def _queue(self, uid):
+        self._retractions.discard(uid)
+        if uid in self._shares or uid in self._pending:
+            return
+        self._pending.add(uid)
+        self._flush()
+
+    def _flush(self):
+        conn = self._connection()
+        if conn is None:
+            self._arm_wait()
+            return
+        self._ensure_watch(conn)
+        if not self._buddy_info_ready(conn):
+            return
+        for uid in list(self._pending):
+            self._pending.discard(uid)
+            self._advertise(uid, conn)
+
+    def _buddy_info_ready(self, conn):
+        if CONNECTION_INTERFACE_BUDDY_INFO in conn:
+            return True
+        # If it's missing it stays missing for the life of this
+        # connection, so retrying every few seconds just opens and
+        # closes rooms for nothing. The next connection gets a fresh
+        # try.
+        if not self._buddy_info_absent:
+            self._buddy_info_absent = True
+            logging.warning('peershare: connection has no BuddyInfo '
+                            'interface; entries stay unadvertised')
+        return False
+
+    def _arm_wait(self):
+        """Make sure the retry timer is running.
+
+        Two things end up waiting on this: entries queued while there
+        was no connection at all, and entries parked after a call came
+        back an error. Both want the same thing a few seconds later,
+        so one timer covers the whole queue. __wait_cb lets it die
+        once the queues are empty, which keeps an idle shell from
+        waking up every ten seconds forever. Calling this while the
+        timer is already armed does nothing.
+        """
+        if self._wait_source is not None:
+            return
+        self._wait_source = GLib.timeout_add_seconds(
+            _RETRY_SECONDS, self.__wait_cb)
+
+    def __wait_cb(self):
+        if not self._pending and not self._retractions:
+            self._wait_source = None
+            return False
+        if self._connection() is None:
+            return True
+        self._wait_source = None
+        self._flush()
+        self._flush_retractions()
+        return False
+
+    def __connection_changed_cb(self, neighbors):
+        conn = self._connection()
+        if conn is None:
+            self._drop_shares()
+            self._drop_peers()
+            return
+        # What the dead connection was missing tells us nothing about
+        # this one, so look for BuddyInfo again.
+        self._buddy_info_absent = False
+        # A read still out against the dead bus will never come back.
+        # Leaving the flag set would jam retractions for the rest of
+        # the session.
+        self._retract_inflight = False
+        self._flush()
+        self._flush_retractions()
+
+    def _drop_shares(self):
+        """The channels and handles went with the dead connection, so
+        there is nothing left to close and the rooms are just
+        forgotten. Each entry goes back on the pending queue for
+        whatever connection turns up next.
+        """
+        for uid in list(self._shares):
+            self._pending.add(uid)
+        self._shares.clear()
+        self._retract_inflight = False
+        if self._pending:
+            self._arm_wait()
+
+    def _advertise(self, uid, conn):
+        activity_id = entry_activity_id(uid)
+        self._shares[uid] = {'activity_id': activity_id,
+                             'room_handle': None, 'channel': None,
+                             'advertised': False,
+                             'bus_name': conn[CONNECTION].bus_name}
+        logging.debug('peershare: advertising %r as %r', uid, activity_id)
+        try:
+            conn[CONNECTION].RequestHandles(
+                HANDLE_TYPE_ROOM, [activity_id],
+                reply_handler=partial(self.__got_room_cb, uid),
+                error_handler=partial(self.__share_error_cb, uid,
+                                      'RequestHandles'))
+        except Exception as error:
+            # A dead proxy raises straight away and never calls back.
+            self.__share_error_cb(uid, 'RequestHandles', error)
+
+    def _park(self, uid):
+        share = self._shares.pop(uid, None)
+        if share is None and uid not in self._pending:
+            # A late error for a share that has already been
+            # retracted. Parking it would put an unshared entry back
+            # on the neighborhood.
+            return
+        if share is not None:
+            self._close_channel(share)
+        self._pending.add(uid)
+        self._arm_wait()
+
+    def _close_channel(self, share):
+        channel_path = share.get('channel')
+        if channel_path is None:
+            return
+        try:
+            bus = dbus.SessionBus()
+            channel = bus.get_object(share['bus_name'], channel_path)
+            channel.Close(dbus_interface=CHANNEL,
+                          reply_handler=lambda: None,
+                          error_handler=partial(self.__close_error_cb,
+                                                channel_path))
+        except Exception:
+            logging.exception('peershare: could not close the room')
+
+    def __close_error_cb(self, channel_path, error):
+        logging.error('peershare: Close failed for %r: %s',
+                      channel_path, error)
+
+    def __got_room_cb(self, uid, handles):
+        share = self._shares.get(uid)
+        if share is None:
+            return
+        conn = self._connection()
+        if conn is None:
+            self._park(uid)
+            return
+        share['room_handle'] = handles[0]
+        try:
+            conn[CONNECTION].RequestChannel(
+                CHANNEL_TYPE_TEXT, HANDLE_TYPE_ROOM, handles[0], True,
+                reply_handler=partial(self.__got_channel_cb, uid),
+                error_handler=partial(self.__share_error_cb, uid,
+                                      'RequestChannel'))
+        except Exception as error:
+            self.__share_error_cb(uid, 'RequestChannel', error)
+
+    def __got_channel_cb(self, uid, channel_path):
+        share = self._shares.get(uid)
+        if share is None:
+            return
+        conn = self._connection()
+        if conn is None:
+            self._park(uid)
+            return
+        share['channel'] = channel_path
+        if not self._buddy_info_ready(conn):
+            self._park(uid)
+            return
+        try:
+            conn[CONNECTION_INTERFACE_BUDDY_INFO].AddActivity(
+                share['activity_id'], share['room_handle'],
+                reply_handler=partial(self.__advertised_cb, uid),
+                error_handler=partial(self.__share_error_cb, uid,
+                                      'AddActivity'))
+        except Exception as error:
+            self.__share_error_cb(uid, 'AddActivity', error)
+
+    def __advertised_cb(self, uid):
+        logging.debug('peershare: %r is on the neighborhood', uid)
+        share = self._shares.get(uid)
+        if share is not None:
+            share['advertised'] = True
+        self._publish_properties(uid)
+
+    def _publish_properties(self, uid):
+        share = self._shares.get(uid)
+        conn = self._connection()
+        if share is None or conn is None or share['room_handle'] is None:
+            return
+        try:
+            metadata = model.get(uid)
+        except Exception:
+            logging.exception('peershare: could not read %r', uid)
+            return
+        try:
+            conn[CONNECTION_INTERFACE_ACTIVITY_PROPERTIES].SetProperties(
+                share['room_handle'], entry_properties(metadata),
+                reply_handler=lambda: None,
+                error_handler=partial(self.__share_error_cb, uid,
+                                      'SetProperties'))
+        except Exception as error:
+            self.__share_error_cb(uid, 'SetProperties', error)
+
+    def _ensure_watch(self, conn):
+        """Watch the connection for the channels peers talk on.
+
+        A fetch turns up on a one-to-one text channel no matter who
+        opened it, so this has to catch channels our own window asked
+        for as well as ones a friend opened: if we're looking at their
+        entry while they look at ours, both sides are talking down the
+        same channel. Which signal announces it depends on the
+        connection manager, so the old Connection.NewChannel and the
+        Requests.NewChannels are both hooked up and _attach ignores a
+        path it has seen before. That still leaves channels that were
+        open before any of this ran, because salut keeps going on the
+        user bus across a shell restart, so the Get(Channels) call at
+        the end sweeps those up.
+        """
+        if self._bus_name is not None:
+            return
+        self._bus_name = conn[CONNECTION].bus_name
+        watches = ((CONNECTION, 'NewChannel', self.__new_channel_cb),
+                   (CONNECTION_INTERFACE_REQUESTS, 'NewChannels',
+                    self.__new_channels_cb))
+        for interface, signal, callback in watches:
+            try:
+                self._watches.append(
+                    conn[interface].connect_to_signal(signal, callback))
+            except Exception:
+                logging.exception('peershare: could not watch %s', signal)
+        # Sweep up the channels that were already open.
+        try:
+            bus = dbus.SessionBus()
+            proxy = bus.get_object(self._bus_name,
+                                   conn[CONNECTION].object_path)
+            proxy.Get(CONNECTION_INTERFACE_REQUESTS, 'Channels',
+                      dbus_interface=dbus.PROPERTIES_IFACE,
+                      reply_handler=self.__new_channels_cb,
+                      error_handler=partial(self.__log_error_cb,
+                                            'watch', 'Get(Channels)'))
+        except Exception:
+            logging.exception('peershare: could not sweep open channels')
+
+    def __new_channel_cb(self, channel_path, channel_type, handle_type,
+                         handle, suppress_handler):
+        if channel_type == CHANNEL_TYPE_TEXT and \
+                handle_type == HANDLE_TYPE_CONTACT:
+            self._attach(channel_path)
+
+    def __new_channels_cb(self, channels):
+        for channel_path, properties in channels:
+            if properties.get(CHANNEL + '.ChannelType') == \
+                    CHANNEL_TYPE_TEXT and \
+                    properties.get(CHANNEL + '.TargetHandleType') == \
+                    HANDLE_TYPE_CONTACT:
+                self._attach(channel_path)
+
+    def _attach(self, channel_path):
+        if channel_path in self._peers or self._bus_name is None:
+            return
+        try:
+            bus = dbus.SessionBus()
+            proxy = bus.get_object(self._bus_name, channel_path)
+        except Exception:
+            logging.exception('peershare: could not open a visitor channel')
+            return
+        peer = {'proxy': proxy, 'match': None}
+        self._peers[channel_path] = peer
+        peer['match'] = proxy.connect_to_signal(
+            'Received', partial(self.__peer_received_cb, channel_path),
+            dbus_interface=CHANNEL_TYPE_TEXT)
+        # A fetch that landed before the signal handler was connected
+        # is still in the pending queue. Reading with clear=False
+        # leaves it there for anyone else on the channel.
+        proxy.ListPendingMessages(
+            False, dbus_interface=CHANNEL_TYPE_TEXT,
+            reply_handler=partial(self.__peer_pending_cb, channel_path),
+            error_handler=partial(self.__log_error_cb, channel_path,
+                                  'ListPendingMessages'))
+
+    def __peer_pending_cb(self, channel_path, messages):
+        for message in messages:
+            self.__peer_received_cb(channel_path, *message)
+
+    def __peer_received_cb(self, channel_path, message_id, timestamp,
+                           sender, message_type, flags, text):
+        message = parse_message(text)
+        if message is None:
+            # A friend's chat rides these channels too. Leave it in
+            # the queue unread and unacknowledged so its own reader
+            # finds it, but tell whoever quietened this line that
+            # someone is actually talking on it.
+            if _stray_chat_cb is not None:
+                try:
+                    _stray_chat_cb(channel_path, sender)
+                except Exception:
+                    logging.exception('peershare: stray chat listener')
+            return
+        kind = message['kind']
+        if kind not in (KIND_FETCH, KIND_ASK):
+            # An entry payload is an answer; the window that asked
+            # deals with it.
+            return
+        self._acknowledge(channel_path, message_id)
+        uid = message['uid']
+        if uid not in self._shares:
+            return
+        if kind == KIND_FETCH:
+            self._send_entry(channel_path, uid)
+        else:
+            self._take_ask(uid, sender, message.get('message'))
+
+    def _drop_peers(self):
+        for peer in list(self._peers.values()):
+            self._remove_match(peer['match'])
+        self._peers.clear()
+        for match in self._watches:
+            self._remove_match(match)
+        self._watches = []
+        self._bus_name = None
+
+    def _remove_match(self, match):
+        if match is None:
+            return
+        try:
+            match.remove()
+        except Exception:
+            logging.exception('peershare: could not drop a listener')
+
+    def _acknowledge(self, channel_path, message_id):
+        peer = self._peers.get(channel_path)
+        if peer is None:
+            return
+        peer['proxy'].AcknowledgePendingMessages(
+            [message_id], dbus_interface=CHANNEL_TYPE_TEXT,
+            reply_handler=lambda: None,
+            error_handler=partial(self.__log_error_cb, channel_path,
+                                  'AcknowledgePendingMessages'))
+
+    def _send_entry(self, channel_path, uid):
+        peer = self._peers.get(channel_path)
+        if peer is None:
+            return
+        try:
+            metadata = model.get(uid)
+        except Exception:
+            logging.exception('peershare: could not read %r', uid)
+            return
+        peer['proxy'].Send(
+            MESSAGE_TYPE_PROTOCOL,
+            encode_payload(build_entry_payload(metadata)),
+            dbus_interface=CHANNEL_TYPE_TEXT,
+            reply_handler=lambda: None,
+            error_handler=partial(self.__log_error_cb, uid, 'Send'))
+
+    def _take_ask(self, uid, sender, text):
+        # Read fresh. The datastore replaces the whole record on
+        # write, so writing back an older copy would roll back
+        # anything the child changed in the meantime.
+        try:
+            metadata = model.get(uid)
+        except Exception:
+            logging.exception('peershare: could not read %r', uid)
+            return False
+        who, color = self._sender(sender)
+        comments = append_comment(metadata.get('comments', ''),
+                                  who, text, color=color)
+        if comments is None:
+            return False
+        metadata['comments'] = comments
+        model.write(metadata, update_mtime=False)
+        # An activity that resumes with the metadata it loaded
+        # earlier would wipe the question we just wrote. The guard
+        # puts it back.
+        delivered = reflection.parse_comments(comments)
+        if delivered:
+            reflectguard.get_guard().note_delivered_comment(
+                uid, delivered[-1])
+        return True
+
+    def _sender(self, handle):
+        """Look up the sender's nick and color.
+
+        Both come from the channel's sender handle and our own
+        presence record. A nick or color carried inside the message
+        would just be whatever the sender typed there.
+        """
+        try:
+            neighbors = neighborhood.get_model()
+            if handle == neighbors.get_link_local_self_handle():
+                return (profile.get_nick_name(),
+                        profile.get_color().to_string())
+            buddy = neighbors.get_buddy_by_handle(handle)
+        except Exception:
+            logging.exception('peershare: could not name the sender')
+            return '', ''
+        if buddy is None:
+            return '', ''
+        color = buddy.get_color()
+        return (buddy.get_nick() or '',
+                color.to_string() if color is not None else '')
+
+    def __share_error_cb(self, uid, call, error):
+        logging.error('peershare: %s failed for %r: %s', call, uid, error)
+        self._park(uid)
+
+    def _retract(self, uid):
+        self._pending.discard(uid)
+        share = self._shares.pop(uid, None)
+        if share is None:
+            return
+        logging.debug('peershare: retracting %r', uid)
+        self._close_channel(share)
+        self._retractions.add(uid)
+        self._flush_retractions()
+
+    def _flush_retractions(self):
+        """Push the queued retractions out over BuddyInfo.
+
+        This needs a live connection, so without one the retraction
+        stays queued and the timer brings us back to it. The whole
+        queue goes out in a single read-modify-write round, because
+        two overlapping rounds would each write back what the other
+        had just removed.
+        """
+        if not self._retractions or self._retract_inflight:
+            return
+        conn = self._connection()
+        if conn is None or not self._buddy_info_ready(conn):
+            self._arm_wait()
+            return
+        self_handle = neighborhood.get_model().get_link_local_self_handle()
+        if self_handle is None:
+            self._arm_wait()
+            return
+        self._retract_inflight = True
+        try:
+            conn[CONNECTION_INTERFACE_BUDDY_INFO].GetActivities(
+                self_handle,
+                reply_handler=self.__got_own_activities_cb,
+                error_handler=self.__retract_read_error_cb)
+        except Exception:
+            # A call that never went out won't reach either handler,
+            # and a flag left set here would stop retractions for the
+            # rest of the session.
+            self._retract_inflight = False
+            logging.exception('peershare: could not read own activities')
+            self._arm_wait()
+
+    def __got_own_activities_cb(self, activities):
+        self._retract_inflight = False
+        conn = self._connection()
+        if conn is None:
+            return
+        batch = []
+        remaining = list(activities)
+        for uid in list(self._retractions):
+            self._retractions.discard(uid)
+            if uid in self._shares or uid in self._pending:
+                # The child shared it again while we were asking, so
+                # leave the new advert alone.
+                continue
+            batch.append(uid)
+            remaining = without_activity(remaining, entry_activity_id(uid))
+        if not batch:
+            return
+        # An advert that landed after the read would be lost if we
+        # wrote back the list from before it, so put those back in.
+        # Only shares whose AddActivity already went through count.
+        # Naming the room any earlier shows peers an advert with no
+        # properties on it yet.
+        present = set(activity_id for activity_id, _ in remaining)
+        for share in self._shares.values():
+            if share.get('advertised') and \
+                    share['activity_id'] not in present:
+                remaining.append((share['activity_id'],
+                                  share['room_handle']))
+        try:
+            conn[CONNECTION_INTERFACE_BUDDY_INFO].SetActivities(
+                remaining,
+                reply_handler=lambda: None,
+                error_handler=partial(self.__retract_error_cb, batch))
+        except Exception as error:
+            self.__retract_error_cb(batch, error)
+
+    def __retract_read_error_cb(self, error):
+        self._retract_inflight = False
+        logging.error('peershare: GetActivities failed: %s', error)
+        self._arm_wait()
+
+    def __retract_error_cb(self, batch, error):
+        logging.error('peershare: SetActivities failed for %r: %s',
+                      batch, error)
+        for uid in batch:
+            if uid not in self._shares:
+                self._retractions.add(uid)
+        self._arm_wait()
+
+    def __log_error_cb(self, uid, call, error):
+        logging.error('peershare: %s failed for %r: %s', call, uid, error)
+
+    def __entry_updated_cb(self, sender, object_id=None, **kwargs):
+        if not object_id:
+            return
+        try:
+            metadata = model.get(object_id)
+        except Exception:
+            return
+        shared = metadata.get('shared', '0') == '1'
+        if shared and object_id not in self._shares:
+            self._queue(object_id)
+        elif not shared:
+            self._retract(object_id)
+        else:
+            # The title may have changed under the advert.
+            self._publish_properties(object_id)
+
+    def __entry_deleted_cb(self, sender, object_id=None, **kwargs):
+        if object_id:
+            self._retract(object_id)
+
+
+def is_ours(uid):
+    return _instance is not None and uid in _instance._shares
+
+
+def start():
+    global _instance
+    if _instance is None:
+        _instance = PeerShare()

--- a/src/jarabe/journal/reflectguard.py
+++ b/src/jarabe/journal/reflectguard.py
@@ -17,14 +17,15 @@
 
 The datastore's update() prunes any metadata key a writer does not
 send, and a running activity saves with the metadata it loaded at
-resume - erasing a moment, snapshot or session written here
-mid-session. The last written state is held in shell memory and put
-back the instant an update wipes it from the entry.
+resume - erasing a moment, snapshot, session, delivered comment or
+share flag written here mid-session. The last written state is held
+and put back the instant an update wipes it from the entry.
 
 The guard retires if the datastore ever merges updates instead of
 deleting omitted keys.
 """
 
+import json
 import logging
 import time
 
@@ -39,6 +40,17 @@ SNAP_KEY = reflection.SNAP_KEY_PREFIX + '%d'
 # Past a couple dozen, the oldest moment is dropped with its snapshot key.
 MAX_MOMENTS = 24
 
+MAX_COMMENTS = 24
+
+
+def comment_identity(comment):
+    """Compare comments by this (from, message) pair rather than the
+    whole dict. A writer that only adds a ctime or an icon to a
+    comment hasn't actually written a different comment.
+    """
+    return (comment.get('from'), comment.get('message'))
+
+
 # How long a write's expected model.updated echo stays credited.
 # Past this, a stale echo could swallow the next real clobber.
 ECHO_TTL = 30
@@ -49,6 +61,7 @@ class ReflectionsGuard(object):
         self._entries = {}
         self._warned_sidless = False
         model.updated.connect(self.__updated_cb)
+        model.deleted.connect(self.__deleted_cb)
 
     def note_moments(self, uid, moments, snaps):
         """The canonical post-write state for an entry's moments and
@@ -63,10 +76,39 @@ class ReflectionsGuard(object):
         """
         self.__replace(uid, sessions=sessions)
 
-    def __replace(self, uid, moments=None, snaps=None, sessions=None):
+    def note_delivered_comment(self, uid, comment):
+        held = self._entries.get(uid)
+        comments = list(held['comments']) if held is not None else []
+        identity = comment_identity(comment)
+        if identity not in comments:
+            comments.append(identity)
+        del comments[:-MAX_COMMENTS]
+        self.__replace(uid, comments=comments)
+
+    def note_comments_pruned(self, uid, comments_raw):
+        """The child's own comment list wins here. If they deleted a
+        comment, it drops out of the hold too, instead of getting
+        written back in.
+        """
+        if uid not in self._entries:
+            return
+        current = {comment_identity(c)
+                   for c in reflection.parse_comments(comments_raw)}
+        kept = [c for c in self._entries[uid]['comments'] if c in current]
+        self.__replace(uid, comments=kept)
+
+    def note_shared(self, uid, value):
+        """The canonical share flag, either '1' or '0'. Only the
+        share toggle writes this key, so whatever we're holding
+        always overrides a write from anything else.
+        """
+        self.__replace(uid, shared=value)
+
+    def __replace(self, uid, moments=None, snaps=None, sessions=None,
+                  comments=None, shared=None):
         held = self._entries.setdefault(uid, {
-            'moments': [], 'snaps': {}, 'sessions': [],
-            'echoes': 0, 'echo_born': 0.0, 'pending': False,
+            'moments': [], 'snaps': {}, 'sessions': [], 'comments': [],
+            'shared': None, 'echoes': 0, 'echo_born': 0.0, 'pending': False,
         })
         if moments is not None:
             held['moments'] = list(moments)
@@ -74,6 +116,10 @@ class ReflectionsGuard(object):
             held['snaps'] = dict(snaps)
         if sessions is not None:
             held['sessions'] = self.__hold_sessions(sessions)
+        if comments is not None:
+            held['comments'] = list(comments)
+        if shared is not None:
+            held['shared'] = shared
         held['echoes'] += 1
         held['echo_born'] = time.monotonic()
 
@@ -92,6 +138,9 @@ class ReflectionsGuard(object):
                 copy['turns'] = list(copy['turns'])
             held.append(copy)
         return held
+
+    def __deleted_cb(self, sender, object_id=None, **kwargs):
+        self._entries.pop(object_id, None)
 
     def __updated_cb(self, sender, object_id=None, **kwargs):
         held = self._entries.get(object_id)
@@ -124,7 +173,14 @@ class ReflectionsGuard(object):
         lost_sessions = [
             s for s in held['sessions']
             if reflection.find_session(data, s.get('sid')) is None]
-        if not lost and not lost_snaps and not lost_sessions:
+        comments = reflection.parse_comments(metadata.get('comments', ''))
+        present = {comment_identity(c) for c in comments}
+        lost_comments = [c for c in held['comments'] if c not in present]
+        held_shared = held['shared']
+        shared_now = metadata.get('shared', '0')
+        lost_shared = held_shared is not None and shared_now != held_shared
+        if not lost and not lost_snaps and not lost_sessions \
+                and not lost_comments and not lost_shared:
             return False
 
         merged = sorted(current + lost, key=lambda m: m.get('ts', 0))
@@ -141,12 +197,19 @@ class ReflectionsGuard(object):
             data['sessions'] = sorted(
                 data.get('sessions', []), key=lambda s: s.get('ts', 0))
 
+        if lost_comments:
+            comments += [{'from': who, 'message': said}
+                         for who, said in lost_comments]
+            metadata['comments'] = json.dumps(comments)
+
         metadata['reflections'] = reflection.dumps(data)
         for key in lost_snaps:
             metadata[key] = held['snaps'][key]
         for seq in evicted:
             if seq is not None:
                 metadata.pop(SNAP_KEY % seq, None)
+        if lost_shared:
+            metadata['shared'] = held['shared']
         try:
             model.write(metadata, update_mtime=False)
         except Exception:
@@ -166,7 +229,7 @@ class ReflectionsGuard(object):
         kept_sessions = [s for s in written['sessions']
                          if s.get('sid') in held_sids]
         self.__replace(uid, moments=written['moments'], snaps=kept_snaps,
-                       sessions=kept_sessions)
+                       sessions=kept_sessions, comments=held['comments'])
         return False
 
 

--- a/src/jarabe/model/invites.py
+++ b/src/jarabe/model/invites.py
@@ -37,6 +37,7 @@ from jarabe.model import telepathyclient
 from jarabe.model import bundleregistry
 from jarabe.model import neighborhood
 from jarabe.journal import misc
+from jarabe.journal import peershare
 
 
 CONNECTION_INTERFACE_ACTIVITY_PROPERTIES = \
@@ -152,6 +153,14 @@ class PrivateInvite(BaseInvite):
                     uri=self._private_channel)
 
 
+class _StrayChatInvite(PrivateInvite):
+    """Invitation on a channel we already claimed for peer-share, which
+    Chat takes from the invite as there's no dispatch operation left."""
+
+    def _call_handle_with(self):
+        pass
+
+
 class Invites(GObject.GObject):
     __gsignals__ = {
         'invite-added': (GObject.SignalFlags.RUN_FIRST, None,
@@ -164,10 +173,12 @@ class Invites(GObject.GObject):
         GObject.GObject.__init__(self)
 
         self._dispatch_operations = {}
+        self._claimed_lines = {}
 
         client_handler = telepathyclient.get_instance()
         client_handler.got_dispatch_operation.connect(
             self.__got_dispatch_operation_cb)
+        peershare.set_stray_chat_cb(self.__stray_chat_cb)
 
     def __got_dispatch_operation_cb(self, **kwargs):
         logging.debug('__got_dispatch_operation_cb')
@@ -233,9 +244,11 @@ class Invites(GObject.GObject):
         if channel_type == CHANNEL_TYPE_CONTACT_LIST:
             self._handle_with(dispatch_operation_path, CLIENT + '.Sugar')
         elif channel_type == CHANNEL_TYPE_TEXT:
-            handler = CLIENT + '.org.laptop.Chat'
-            self._add_private_invite(dispatch_operation_path, handle, handler,
-                                     channel_path, properties)
+            # A window fetching a shared Journal entry uses a channel
+            # that looks just like a chat. the pending messages are the
+            # only way to tell them apart, so peek at those first.
+            self._sort_text_invitation(dispatch_operation_path, handle,
+                                       channel_path, properties)
             return
         else:
             self._call_handle_with(dispatch_operation_path, '')
@@ -243,6 +256,65 @@ class Invites(GObject.GObject):
         if handler is not None:
             logging.debug('Adding an invite from a non-Sugar client')
             self._add_invite(dispatch_operation_path, handle, handler)
+
+    def _sort_text_invitation(self, dispatch_operation_path, handle,
+                              channel_path, properties):
+        connection_path = properties[CHANNEL_DISPATCH_OPERATION +
+                                     '.Connection']
+        connection_name = connection_path.replace('/', '.')[1:]
+        bus = dbus.Bus()
+        channel = bus.get_object(connection_name, channel_path)
+        surface = partial(self._add_private_invite, dispatch_operation_path,
+                          handle, CLIENT + '.org.laptop.Chat', channel_path,
+                          properties)
+        channel.ListPendingMessages(
+            False, dbus_interface=CHANNEL_TYPE_TEXT,
+            reply_handler=partial(self.__pending_peeked_cb,
+                                  dispatch_operation_path, surface,
+                                  connection_name, connection_path,
+                                  channel_path, handle),
+            error_handler=lambda error: surface())
+
+    def __pending_peeked_cb(self, dispatch_operation_path, surface,
+                            connection_name, connection_path, channel_path,
+                            handle, messages):
+        lines = [message[5] for message in messages]
+        if not lines or \
+                any(peershare.parse_message(line) is None for line in lines):
+            surface()
+            return
+        # Everything waiting is protocol, so nobody is knocking. it's a
+        # window fetching and peershare is already serving it. claiming
+        # the operation keeps Chat out of the way without launching it.
+        logging.debug('invites: claiming a peer-share line quietly')
+        bus = dbus.Bus()
+        obj = bus.get_object(CHANNEL_DISPATCHER, dispatch_operation_path)
+        dispatch_operation = dbus.Interface(obj, CHANNEL_DISPATCH_OPERATION)
+        dispatch_operation.Claim(
+            reply_handler=partial(self.__claimed_cb, connection_name,
+                                  connection_path, channel_path, handle),
+            error_handler=self.__claim_error_cb)
+
+    def __claimed_cb(self, connection_name, connection_path, channel_path,
+                     handle):
+        self._claimed_lines[channel_path] = (connection_name,
+                                             connection_path, handle)
+
+    def __claim_error_cb(self, error):
+        logging.error('invites: could not claim a peer-share line: %s', error)
+
+    def __stray_chat_cb(self, channel_path, sender):
+        line = self._claimed_lines.pop(channel_path, None)
+        if line is None:
+            return
+        connection_name, connection_path, handle = line
+        private_channel = json.dumps([connection_name, connection_path,
+                                      channel_path])
+        invite = _StrayChatInvite(channel_path, handle,
+                                  CLIENT + '.org.laptop.Chat',
+                                  private_channel)
+        self._dispatch_operations[channel_path] = invite
+        self.emit('invite-added', invite)
 
     def _call_handle_with(self, dispatch_operation_path, handler):
         logging.debug('_handle_with %r %r', dispatch_operation_path, handler)

--- a/src/jarabe/model/neighborhood.py
+++ b/src/jarabe/model/neighborhood.py
@@ -544,6 +544,17 @@ class _Account(GObject.GObject):
     def _update_buddy_activities(self, buddy_handle, activities):
         logging.debug('_Account._update_buddy_activities')
 
+        if buddy_handle != self._self_handle and \
+                buddy_handle not in self._buddy_handles:
+            # ActivitiesChanged can arrive before the contact round
+            # trip is done. half processing it records the pairing and
+            # then trips over the missing name, and the buddy stays
+            # wedged out of their activities for good. the contact
+            # turning up re-queries GetActivities anyway, so drop it.
+            logging.debug('_update_buddy_activities before contact %r',
+                          buddy_handle)
+            return
+
         if buddy_handle not in self._activities_per_buddy:
             self._activities_per_buddy[buddy_handle] = set()
 

--- a/src/jarabe/model/neighborhood.py
+++ b/src/jarabe/model/neighborhood.py
@@ -65,6 +65,28 @@ CONNECTION_INTERFACE_BUDDY_INFO = 'org.laptop.Telepathy.BuddyInfo'
 CONNECTION_INTERFACE_ACTIVITY_PROPERTIES = \
     'org.laptop.Telepathy.ActivityProperties'
 
+# Shared Journal entries go over the activity wire with this type. an
+# older shell doesn't know it, and drops the advert as an unknown
+# bundle.
+JOURNAL_ENTRY_TYPE = 'org.sugarlabs.JournalEntry'
+
+
+def parse_entry_tags(tags):
+    """Split a shared entry's 'tags' property into uid, bundle_id and
+    mime_type. The last two come back empty if the entry has no such tag.
+    """
+    parts = str(tags or '').split()
+    uid = parts[0] if parts else ''
+    bundle_id = ''
+    mime_type = ''
+    for token in parts[1:]:
+        if '/' in token:
+            mime_type = mime_type or token
+        else:
+            bundle_id = bundle_id or token
+    return uid, bundle_id, mime_type
+
+
 _QUERY_DBUS_TIMEOUT = 200
 """
 Time in seconds to wait when querying contact properties. Some jabber servers
@@ -91,6 +113,10 @@ class ActivityModel(GObject.GObject):
 
         self.activity_id = activity_id
         self.room_handle = room_handle
+        self.entry_uid = None
+        self.entry_mime = ''
+        self._owner = None
+        self._owner_known = False
         self._bundle = None
         self._color = None
         self._private = True
@@ -135,13 +161,28 @@ class ActivityModel(GObject.GObject):
     def get_buddies(self):
         return self._buddies
 
+    def get_owner(self):
+        return self._owner
+
+    owner = GObject.Property(type=object, getter=get_owner)
+
     def add_buddy(self, buddy):
+        # We hear about the room from somebody's activity list, so that
+        # buddy gets here first and anyone later is only a visitor.
+        # claim the slot once and never reuse it.
+        if not self._owner_known:
+            self._owner_known = True
+            self._owner = buddy
+            self.notify('owner')
         self._buddies.append(buddy)
         self.notify('buddies')
         self.emit('buddy-added', buddy)
 
     def remove_buddy(self, buddy):
         self._buddies.remove(buddy)
+        if buddy is self._owner:
+            self._owner = None
+            self.notify('owner')
         self.notify('buddies')
         self.emit('buddy-removed', buddy)
 
@@ -1064,10 +1105,23 @@ class Neighborhood(GObject.GObject):
         self._activities[activity_id] = activity
 
     def __activity_updated_cb(self, account, activity_id, properties):
-        logging.debug('__activity_updated_cb %r %r', activity_id, properties)
+        # Key names only. the values would put every peer's entry
+        # titles in the log.
+        logging.debug('__activity_updated_cb %r %r', activity_id,
+                      sorted(properties.keys()))
         if activity_id not in self._activities:
             logging.debug('__activity_updated_cb Unknown activity with '
                           'activity_id %r', activity_id)
+            return
+
+        if properties.get('type') == JOURNAL_ENTRY_TYPE:
+            self._update_shared_entry(activity_id, properties)
+            return
+
+        if 'type' not in properties:
+            # A half published room has no type yet. we'll get the
+            # properties signal again once it does.
+            logging.debug('__activity_updated_cb typeless %r', activity_id)
             return
 
         registry = bundleregistry.get_registry()
@@ -1091,6 +1145,27 @@ class Neighborhood(GObject.GObject):
                                                   activity.props.color)
             self.emit('activity-added', activity)
 
+    def _update_shared_entry(self, activity_id, properties):
+        # A shared entry never goes into the shell model, there's
+        # nothing to launch, just a page to look at.
+        activity = self._activities[activity_id]
+        is_new = activity.props.name is None
+        tags_uid, bundle_id, mime_type = \
+            parse_entry_tags(properties.get('tags', ''))
+        activity.entry_uid = str(properties.get('uid', '') or tags_uid)
+        if mime_type:
+            activity.entry_mime = mime_type
+        if bundle_id:
+            registry = bundleregistry.get_registry()
+            activity.props.bundle = registry.get_bundle(bundle_id)
+        color = properties.get('color')
+        if color:
+            activity.props.color = XoColor(str(color))
+        activity.props.name = str(properties.get('name', '') or '')
+        activity.props.private = bool(properties.get('private', False))
+        if is_new:
+            self.emit('activity-added', activity)
+
     def __activity_removed_cb(self, account, activity_id):
         logging.debug('__activity_removed_cb %r', activity_id)
         if activity_id not in self._activities:
@@ -1099,6 +1174,9 @@ class Neighborhood(GObject.GObject):
             return
         activity = self._activities[activity_id]
         del self._activities[activity_id]
+        if activity.entry_uid is not None:
+            self.emit('activity-removed', activity)
+            return
         self._shell_model.remove_shared_activity(activity_id)
 
         if activity.props.bundle is not None:
@@ -1114,6 +1192,11 @@ class Neighborhood(GObject.GObject):
         if activity_id and activity_id not in self._activities:
             logging.debug('__current_activity_updated_cb Unknown activity with'
                           ' id %s', activity_id)
+            activity_id = ''
+        elif activity_id and \
+                self._activities[activity_id].entry_uid is not None:
+            # Nobody is ever "in" a shared entry, whatever the peer
+            # announces.
             activity_id = ''
 
         buddy = self._buddies[contact_id]

--- a/src/jarabe/model/neighborhood.py
+++ b/src/jarabe/model/neighborhood.py
@@ -185,6 +185,7 @@ class _Account(GObject.GObject):
                                      None, ([object, object])),
         'connected': (GObject.SignalFlags.RUN_FIRST, None, ([])),
         'disconnected': (GObject.SignalFlags.RUN_FIRST, None, ([])),
+        'connection-changed': (GObject.SignalFlags.RUN_FIRST, None, ([])),
     }
 
     def __init__(self, account_path):
@@ -193,6 +194,8 @@ class _Account(GObject.GObject):
         self.object_path = account_path
 
         self._connection = None
+        self.conn_ready = False
+        self._interfaces_ready = False
         self._buddy_handles = {}
         self._activity_handles = {}
         self._self_handle = None
@@ -204,8 +207,17 @@ class _Account(GObject.GObject):
 
         self._start_listening()
 
+    def _set_conn_ready(self, ready):
+        if ready == self.conn_ready:
+            return
+        self.conn_ready = ready
+        self.emit('connection-changed')
+
     def _close_connection(self):
         self._connection = None
+        self._interfaces_ready = False
+        self._self_handle = None
+        self._set_conn_ready(False)
         if self._home_changed_hid is not None:
             model = shell.get_model()
             model.disconnect(self._home_changed_hid)
@@ -271,7 +283,9 @@ class _Account(GObject.GObject):
 
         self._connection = {}
         self._object_path = connection_path
-        self.conn_ready = False
+        self._interfaces_ready = False
+        self._self_handle = None
+        self._set_conn_ready(False)
         self.conn_proxy = dbus.Bus().get_object(
             connection_name, connection_path)
         self._connection[PROPERTIES_IFACE] = dbus.Interface(
@@ -300,11 +314,11 @@ class _Account(GObject.GObject):
         for interface in interfaces:
             self._connection[interface] = dbus.Interface(
                 self.conn_proxy, interface)
-        self.conn_ready = True
+        self._interfaces_ready = True
         self.__connection_ready_cb(self._connection)
 
     def __connection_ready_cb(self, connection):
-        if not self.conn_ready:
+        if not self._interfaces_ready:
             return
 
         logging.debug('_Account.__connection_ready_cb %r',
@@ -339,6 +353,8 @@ class _Account(GObject.GObject):
                     'Connection.GetSelfHandle'))
             self.emit('connected')
         else:
+            self._self_handle = None
+            self._set_conn_ready(False)
             for contact_handle, contact_id in list(
                     self._buddy_handles.items()):
                 if contact_id is not None:
@@ -360,6 +376,10 @@ class _Account(GObject.GObject):
 
     def __get_self_handle_cb(self, self_handle):
         self._self_handle = self_handle
+        # We have the interfaces and our own handle now, which is all a
+        # caller needs off this connection, so say ready here. the
+        # channel setup below can raise.
+        self._set_conn_ready(True)
 
         if CONNECTION_INTERFACE_CONTACT_CAPABILITIES in self._connection:
             interface = CONNECTION_INTERFACE_CONTACT_CAPABILITIES
@@ -751,6 +771,8 @@ class Neighborhood(GObject.GObject):
                         ([object])),
         'buddy-removed': (GObject.SignalFlags.RUN_FIRST, None,
                           ([object])),
+        'link-local-connection-changed': (GObject.SignalFlags.RUN_FIRST,
+                                          None, ([])),
     }
 
     def __init__(self):
@@ -803,6 +825,12 @@ class Neighborhood(GObject.GObject):
                         self.__current_activity_updated_cb)
         account.connect('connected', self.__account_connected_cb)
         account.connect('disconnected', self.__account_disconnected_cb)
+        account.connect('connection-changed',
+                        self.__account_connection_changed_cb)
+
+    def __account_connection_changed_cb(self, account):
+        if account == self._link_local_account:
+            self.emit('link-local-connection-changed')
 
     def __account_connected_cb(self, account):
         logging.debug('__account_connected_cb %s', account.object_path)
@@ -1142,6 +1170,40 @@ class Neighborhood(GObject.GObject):
 
     def get_activities(self):
         return list(self._activities.values())
+
+    def get_link_local_connection(self):
+        """The salut connection's interface proxies, used to advertise
+        shared entries. None until the account connects and
+        GetInterfaces has replied, since BuddyInfo only turns up then.
+        """
+        account = self._link_local_account
+        if account is None or not account.conn_ready:
+            return None
+        return account._connection
+
+    def get_link_local_handle(self, buddy):
+        """A buddy's contact handle on the salut connection, or None.
+
+        A handle from the jabber account names somebody else over
+        here, so only salut's own buddies get one.
+        """
+        account = self._link_local_account
+        if buddy is None or account is None or not account.conn_ready:
+            return None
+        if buddy.is_owner() or buddy.props.account != account.object_path:
+            return None
+        return buddy.props.handle
+
+    def get_link_local_self_handle(self):
+        """The salut account's own contact handle, once known.
+
+        Same readiness check as the connection, since a handle from a
+        connection that has gone away names nobody.
+        """
+        account = self._link_local_account
+        if account is None or not account.conn_ready:
+            return None
+        return account._self_handle
 
 
 def get_model():

--- a/tests/journal/test_model_privacy.py
+++ b/tests/journal/test_model_privacy.py
@@ -17,6 +17,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 # gi is an apt-installed system package, not something `uvx pytest`'s
 # own managed interpreter has -- skip rather than error when it isn't
@@ -92,6 +93,23 @@ class TestRewritesEntryInPlace(unittest.TestCase):
         # already indexed 'mountpoint', but 'uid' may legitimately be
         # absent, and testing it first is what keeps that safe.
         self.assertFalse(model._rewrites_entry_in_place({}))
+
+
+class TestCopyLeavesTheAudienceBehind(unittest.TestCase):
+
+    def test_a_copy_of_a_shared_entry_is_not_shared(self):
+        written = {}
+
+        def _capture(metadata, file_path='', **kwargs):
+            written.update(metadata)
+
+        with mock.patch.object(model, 'get', return_value={
+                'uid': 'u1', 'title': 't', 'shared': '1'}), \
+                mock.patch.object(model, 'get_file', return_value=None), \
+                mock.patch.object(model, 'write', side_effect=_capture):
+            model.copy({'uid': 'u1'}, '/media/stick')
+        self.assertNotIn('shared', written)
+        self.assertEqual(written['mountpoint'], '/media/stick')
 
 
 def _rmtree(path):

--- a/tests/journal/test_peershare.py
+++ b/tests/journal/test_peershare.py
@@ -1,0 +1,1368 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import base64
+import json
+import logging
+import unittest
+from functools import partial
+from unittest.mock import Mock, patch
+
+from jarabe.journal import model
+from jarabe.journal import peershare
+from jarabe.journal import reflectguard
+from jarabe.model import neighborhood
+
+CONNECTION = peershare.CONNECTION
+REQUESTS = neighborhood.CONNECTION_INTERFACE_REQUESTS
+BUDDY_INFO = neighborhood.CONNECTION_INTERFACE_BUDDY_INFO
+ACTIVITY_PROPERTIES = \
+    neighborhood.CONNECTION_INTERFACE_ACTIVITY_PROPERTIES
+
+
+class TestParseEntryTags(unittest.TestCase):
+
+    def test_all_three_tokens(self):
+        self.assertEqual(
+            neighborhood.parse_entry_tags(
+                'abc org.laptop.RocketActivity image/png'),
+            ('abc', 'org.laptop.RocketActivity', 'image/png'))
+
+    def test_a_mime_without_a_bundle_is_told_apart(self):
+        self.assertEqual(neighborhood.parse_entry_tags('abc image/png'),
+                         ('abc', '', 'image/png'))
+
+    def test_empty(self):
+        self.assertEqual(neighborhood.parse_entry_tags(''), ('', '', ''))
+        self.assertEqual(neighborhood.parse_entry_tags(None), ('', '', ''))
+
+
+class TestEntryAdvert(unittest.TestCase):
+
+    def test_activity_id_is_stable_and_room_shaped(self):
+        uid = '1b4c282a-f20a-41ec-9805-2ea9b7124948'
+        first = peershare.entry_activity_id(uid)
+        self.assertEqual(first, peershare.entry_activity_id(uid))
+        self.assertEqual(len(first), 40)
+        int(first, 16)
+        self.assertNotEqual(first, peershare.entry_activity_id('other'))
+
+    def test_properties_carry_the_entry_not_the_talk(self):
+        metadata = {'uid': 'abc', 'title': 'my rockit',
+                    'reflections': '{"sessions": []}',
+                    'description': 'private words'}
+        properties = peershare.entry_properties(metadata,
+                                                color='#FF2B34,#005FE4')
+        self.assertEqual(properties['type'],
+                         neighborhood.JOURNAL_ENTRY_TYPE)
+        self.assertEqual(properties['name'], 'my rockit')
+        self.assertEqual(properties['tags'], 'abc')
+        self.assertFalse(properties['private'])
+        # The connection manager rejects keys outside the stock set.
+        self.assertEqual(sorted(properties),
+                         ['color', 'name', 'private', 'tags', 'type'])
+        for value in properties.values():
+            self.assertNotIn('sessions', str(value))
+            self.assertNotIn('private words', str(value))
+
+    def test_properties_carry_uid_and_bundle_when_activity_present(self):
+        metadata = {'uid': 'abc', 'title': 'my rockit',
+                    'activity': 'org.laptop.RocketActivity'}
+        properties = peershare.entry_properties(metadata,
+                                                color='#FF2B34,#005FE4')
+        self.assertEqual(properties['tags'], 'abc org.laptop.RocketActivity')
+
+    def test_properties_carry_the_mime_type_too(self):
+        metadata = {'uid': 'abc', 'title': 'my rockit',
+                    'activity': 'org.laptop.RocketActivity',
+                    'mime_type': 'image/png'}
+        properties = peershare.entry_properties(metadata,
+                                                color='#FF2B34,#005FE4')
+        self.assertEqual(properties['tags'],
+                         'abc org.laptop.RocketActivity image/png')
+
+    def test_a_slashless_mime_type_stays_home(self):
+        # Without its '/' the reader could not tell it from a bundle.
+        metadata = {'uid': 'abc', 'mime_type': 'weird'}
+        properties = peershare.entry_properties(metadata,
+                                                color='#FF2B34,#005FE4')
+        self.assertEqual(properties['tags'], 'abc')
+
+    def test_properties_survive_a_bare_record(self):
+        properties = peershare.entry_properties({}, color='#000,#FFF')
+        self.assertEqual(properties['name'], '')
+        self.assertEqual(properties['tags'], '')
+
+
+class TestWithoutActivity(unittest.TestCase):
+
+    def test_filters_only_the_named_activity(self):
+        activities = [('write-1', 5), ('entry-1', 9), ('paint-1', 11)]
+        remaining = peershare.without_activity(activities, 'entry-1')
+        self.assertEqual(remaining, [('write-1', 5), ('paint-1', 11)])
+
+    def test_absent_activity_id_leaves_list_untouched(self):
+        activities = [('write-1', 5)]
+        self.assertEqual(peershare.without_activity(activities, 'nope'),
+                         activities)
+
+
+class _FakeNeighborhood(object):
+
+    def __init__(self, activity):
+        self._activities = {'a1': activity}
+        self.emitted = []
+
+    def emit(self, signal, *args):
+        self.emitted.append((signal, args))
+
+
+class TestActivitiesBeforeContact(unittest.TestCase):
+    """ActivitiesChanged racing ahead of the contact round trip."""
+
+    def _bare_account(self):
+        account = neighborhood._Account.__new__(neighborhood._Account)
+        account._self_handle = 1
+        account._buddy_handles = {}
+        account._activity_handles = {}
+        account._activities_per_buddy = {}
+        account._buddies_per_activity = {}
+        account._connection = _fake_conn()
+        account._connection[ACTIVITY_PROPERTIES].replies['GetProperties'] = \
+            ({},)
+        account._connection[BUDDY_INFO].replies['GetCurrentActivity'] = \
+            ('', 0)
+        emitted = []
+        account.emit = lambda *args: emitted.append(args)
+        return account, emitted
+
+    def test_a_signal_ahead_of_the_contact_is_dropped_whole(self):
+        # partial processing would record the pairing, then crash on
+        # the missing name, leaving nothing for the retry to do
+        account, emitted = self._bare_account()
+        account._update_buddy_activities(2, [('act-1', 7)])
+        self.assertEqual(emitted, [])
+        self.assertNotIn(2, account._activities_per_buddy)
+
+    def test_the_requery_after_the_contact_lands_attaches(self):
+        account, emitted = self._bare_account()
+        account._update_buddy_activities(2, [('act-1', 7)])
+        account._buddy_handles[2] = 'contact-2'
+        account._update_buddy_activities(2, [('act-1', 7)])
+        self.assertIn(('buddy-joined-activity', 'contact-2', 'act-1'),
+                      emitted)
+
+
+class TestUpdateSharedEntry(unittest.TestCase):
+
+    def test_missing_color_does_not_crash(self):
+        activity = neighborhood.ActivityModel('a1', 7)
+        fake = _FakeNeighborhood(activity)
+        neighborhood.Neighborhood._update_shared_entry(
+            fake, 'a1', {'type': neighborhood.JOURNAL_ENTRY_TYPE,
+                         'name': 'no color here'})
+        self.assertEqual(activity.get_name(), 'no color here')
+        self.assertIsNone(activity.get_color())
+
+    def test_missing_name_defaults_to_empty(self):
+        activity = neighborhood.ActivityModel('a1', 7)
+        fake = _FakeNeighborhood(activity)
+        neighborhood.Neighborhood._update_shared_entry(
+            fake, 'a1', {'type': neighborhood.JOURNAL_ENTRY_TYPE,
+                         'color': '#FF2B34,#005FE4'})
+        self.assertEqual(activity.get_name(), '')
+
+    def test_a_full_record_still_updates_both(self):
+        activity = neighborhood.ActivityModel('a1', 7)
+        fake = _FakeNeighborhood(activity)
+        neighborhood.Neighborhood._update_shared_entry(
+            fake, 'a1', {'type': neighborhood.JOURNAL_ENTRY_TYPE,
+                         'name': 'my rockit',
+                         'color': '#FF2B34,#005FE4',
+                         'uid': 'abc'})
+        self.assertEqual(activity.get_name(), 'my rockit')
+        self.assertEqual(activity.get_color().to_string(),
+                         '#FF2B34,#005FE4')
+        self.assertEqual(activity.entry_uid, 'abc')
+        self.assertEqual(fake.emitted, [('activity-added', (activity,))])
+
+    def test_the_mime_type_lands_on_the_model(self):
+        activity = neighborhood.ActivityModel('a1', 7)
+        fake = _FakeNeighborhood(activity)
+        neighborhood.Neighborhood._update_shared_entry(
+            fake, 'a1', {'type': neighborhood.JOURNAL_ENTRY_TYPE,
+                         'name': 'my rockit',
+                         'tags': 'abc image/png'})
+        self.assertEqual(activity.entry_mime, 'image/png')
+
+    def test_a_signal_without_tags_keeps_the_mime_type(self):
+        activity = neighborhood.ActivityModel('a1', 7)
+        activity.entry_mime = 'image/png'
+        fake = _FakeNeighborhood(activity)
+        neighborhood.Neighborhood._update_shared_entry(
+            fake, 'a1', {'type': neighborhood.JOURNAL_ENTRY_TYPE,
+                         'name': 'renamed'})
+        self.assertEqual(activity.entry_mime, 'image/png')
+
+    def test_no_bundle_token_leaves_bundle_unset(self):
+        activity = neighborhood.ActivityModel('a1', 7)
+        fake = _FakeNeighborhood(activity)
+        neighborhood.Neighborhood._update_shared_entry(
+            fake, 'a1', {'type': neighborhood.JOURNAL_ENTRY_TYPE,
+                         'name': 'my rockit', 'tags': 'abc'})
+        self.assertIsNone(activity.get_bundle())
+
+    def test_bundle_token_resolves_through_the_registry(self):
+        activity = neighborhood.ActivityModel('a1', 7)
+        fake = _FakeNeighborhood(activity)
+        bundle = object()
+        registry = Mock()
+        registry.get_bundle.return_value = bundle
+        with patch('jarabe.model.neighborhood.bundleregistry.get_registry',
+                   return_value=registry):
+            neighborhood.Neighborhood._update_shared_entry(
+                fake, 'a1', {'type': neighborhood.JOURNAL_ENTRY_TYPE,
+                             'name': 'my rockit',
+                             'tags': 'abc org.laptop.RocketActivity'})
+        registry.get_bundle.assert_called_once_with(
+            'org.laptop.RocketActivity')
+        self.assertIs(activity.get_bundle(), bundle)
+
+    def test_a_partial_signal_does_not_take_the_bundle_away(self):
+        activity = neighborhood.ActivityModel('a1', 7)
+        fake = _FakeNeighborhood(activity)
+        bundle = object()
+        registry = Mock()
+        registry.get_bundle.return_value = bundle
+        with patch('jarabe.model.neighborhood.bundleregistry.get_registry',
+                   return_value=registry):
+            neighborhood.Neighborhood._update_shared_entry(
+                fake, 'a1', {'type': neighborhood.JOURNAL_ENTRY_TYPE,
+                             'name': 'my rockit',
+                             'tags': 'abc org.laptop.RocketActivity'})
+        neighborhood.Neighborhood._update_shared_entry(
+            fake, 'a1', {'type': neighborhood.JOURNAL_ENTRY_TYPE,
+                         'name': 'my rockit renamed'})
+        self.assertIs(activity.get_bundle(), bundle)
+
+    def test_unknown_bundle_id_falls_back_to_none(self):
+        activity = neighborhood.ActivityModel('a1', 7)
+        fake = _FakeNeighborhood(activity)
+        registry = Mock()
+        registry.get_bundle.return_value = None
+        with patch('jarabe.model.neighborhood.bundleregistry.get_registry',
+                   return_value=registry):
+            neighborhood.Neighborhood._update_shared_entry(
+                fake, 'a1', {'type': neighborhood.JOURNAL_ENTRY_TYPE,
+                             'name': 'my rockit',
+                             'tags': 'abc org.laptop.MissingActivity'})
+        self.assertIsNone(activity.get_bundle())
+
+
+class TestEntryOwner(unittest.TestCase):
+
+    def test_the_first_buddy_attached_stays_the_owner(self):
+        activity = neighborhood.ActivityModel('a1', 7)
+        self.assertIsNone(activity.get_owner())
+        author = Mock()
+        visitor = Mock()
+        activity.add_buddy(author)
+        activity.add_buddy(visitor)
+        self.assertIs(activity.get_owner(), author)
+
+    def test_a_visitor_leaving_does_not_change_the_owner(self):
+        activity = neighborhood.ActivityModel('a1', 7)
+        author = Mock()
+        visitor = Mock()
+        activity.add_buddy(author)
+        activity.add_buddy(visitor)
+        activity.remove_buddy(visitor)
+        self.assertIs(activity.get_owner(), author)
+
+    def test_the_owner_leaving_leaves_the_entry_unattributed(self):
+        activity = neighborhood.ActivityModel('a1', 7)
+        author = Mock()
+        visitor = Mock()
+        latecomer = Mock()
+        activity.add_buddy(author)
+        activity.add_buddy(visitor)
+        activity.remove_buddy(author)
+        self.assertIsNone(activity.get_owner())
+        # a later buddy joining does not fill the empty owner slot
+        activity.add_buddy(latecomer)
+        self.assertIsNone(activity.get_owner())
+
+
+class _FakeAccount(object):
+
+    def __init__(self, object_path='/salut', conn_ready=True):
+        self.object_path = object_path
+        self.conn_ready = conn_ready
+
+
+class _FakeLinkLocal(object):
+
+    def __init__(self, account):
+        self._link_local_account = account
+
+
+class TestLinkLocalHandle(unittest.TestCase):
+    """Only salut's own buddies have a handle salut answers to."""
+
+    def _handle(self, buddy, account=None):
+        if account is None:
+            account = _FakeAccount()
+        return neighborhood.Neighborhood.get_link_local_handle(
+            _FakeLinkLocal(account), buddy)
+
+    def _buddy(self, account='/salut', handle=9):
+        return neighborhood.BuddyModel(nick='Ana', account=account,
+                                       contact_id='ana@laptop',
+                                       handle=handle)
+
+    def test_a_friend_on_this_connection_is_known_by_handle(self):
+        self.assertEqual(self._handle(self._buddy()), 9)
+
+    def test_a_friend_from_the_jabber_account_is_not(self):
+        # this handle was assigned by a different connection and
+        # refers to someone else on this one
+        self.assertIsNone(self._handle(self._buddy(account='/jabber')))
+
+    def test_a_friend_without_a_handle_yet_is_not(self):
+        self.assertIsNone(self._handle(self._buddy(handle=None)))
+
+    def test_we_are_not_our_own_friend(self):
+        owner = Mock()
+        owner.is_owner.return_value = True
+        self.assertIsNone(self._handle(owner))
+
+    def test_a_connection_that_is_not_ready_names_nobody(self):
+        self.assertIsNone(
+            self._handle(self._buddy(),
+                         account=_FakeAccount(conn_ready=False)))
+
+    def test_no_account_and_no_friend_are_survivable(self):
+        no_account = neighborhood.Neighborhood.get_link_local_handle(
+            _FakeLinkLocal(None), self._buddy())
+        self.assertIsNone(no_account)
+        self.assertIsNone(self._handle(None))
+
+
+class TestBuildEntryPayload(unittest.TestCase):
+
+    def _payload(self, metadata):
+        return peershare.build_entry_payload(metadata,
+                                             color='#FF2B34,#005FE4')
+
+    def test_the_talk_never_travels(self):
+        payload = self._payload({
+            'uid': 'abc', 'title': 'my rockit',
+            'description': 'i made a rocket',
+            'reflections': '{"sessions": [{"turns": ["secret"]}]}',
+            'next_steps': 'paint the fins',
+            'moment-snap-1': 'AAAA',
+            'shared': '1'})
+        for key in ('reflections', 'next_steps', 'moment-snap-1', 'shared'):
+            self.assertNotIn(key, payload)
+        line = peershare.encode_payload(payload)
+        for word in ('secret', 'paint the fins', 'AAAA'):
+            self.assertNotIn(word, line)
+
+    def test_the_page_travels(self):
+        payload = self._payload({
+            'uid': 'abc', 'title': 'my rockit',
+            'description': 'i made a rocket', 'tags': 'space',
+            'activity': 'org.laptop.RocketActivity'})
+        self.assertEqual(payload['peershare'], peershare.PROTOCOL)
+        self.assertEqual(payload['kind'], peershare.KIND_ENTRY)
+        self.assertEqual(payload['uid'], 'abc')
+        self.assertEqual(payload['title'], 'my rockit')
+        self.assertEqual(payload['description'], 'i made a rocket')
+        self.assertEqual(payload['tags'], 'space')
+        self.assertEqual(payload['activity'], 'org.laptop.RocketActivity')
+
+    def test_comments_travel_as_a_list(self):
+        comments = [{'from': 'Ana', 'message': 'how did you do the fins?'}]
+        payload = self._payload({'uid': 'abc',
+                                 'comments': json.dumps(comments)})
+        self.assertEqual(payload['comments'], comments)
+
+    def test_broken_comments_travel_as_nothing(self):
+        payload = self._payload({'uid': 'abc', 'comments': 'not json'})
+        self.assertEqual(payload['comments'], [])
+
+    def test_the_entry_color_beats_the_owner_color(self):
+        payload = self._payload({'uid': 'abc',
+                                 'icon-color': '#00FF00,#0000FF'})
+        self.assertEqual(payload['color'], '#00FF00,#0000FF')
+
+    def test_a_colorless_entry_falls_back(self):
+        payload = self._payload({'uid': 'abc'})
+        self.assertEqual(payload['color'], '#FF2B34,#005FE4')
+
+    def test_preview_rides_base64(self):
+        payload = self._payload({'uid': 'abc', 'preview': b'\x89PNG\r\n'})
+        self.assertEqual(base64.b64decode(payload['preview']),
+                         b'\x89PNG\r\n')
+
+    def test_a_missing_preview_leaves_the_key_out(self):
+        self.assertNotIn('preview', self._payload({'uid': 'abc'}))
+        self.assertNotIn('preview',
+                         self._payload({'uid': 'abc', 'preview': ''}))
+
+    def test_a_bare_record_still_builds(self):
+        payload = self._payload({})
+        self.assertEqual(payload['uid'], '')
+        self.assertEqual(payload['title'], '')
+        self.assertEqual(payload['comments'], [])
+
+
+class TestEncodePayload(unittest.TestCase):
+
+    def test_a_small_page_keeps_its_preview(self):
+        payload = peershare.build_entry_payload(
+            {'uid': 'abc', 'preview': b'tiny'}, color='#000,#FFF')
+        line = peershare.encode_payload(payload)
+        self.assertIn('preview', json.loads(line))
+        self.assertNotIn('\n', line)
+
+    def test_an_oversized_preview_is_left_behind(self):
+        payload = peershare.build_entry_payload(
+            {'uid': 'abc', 'title': 'my rockit',
+             'preview': b'x' * peershare.PAYLOAD_LIMIT},
+            color='#000,#FFF')
+        message = json.loads(peershare.encode_payload(payload))
+        self.assertNotIn('preview', message)
+        self.assertEqual(message['title'], 'my rockit')
+
+    def test_an_oversized_page_without_a_preview_still_goes(self):
+        payload = peershare.build_entry_payload(
+            {'uid': 'abc', 'description': 'x' * peershare.PAYLOAD_LIMIT},
+            color='#000,#FFF')
+        message = json.loads(peershare.encode_payload(payload))
+        self.assertEqual(len(message['description']),
+                         peershare.PAYLOAD_LIMIT)
+
+
+class TestParseMessage(unittest.TestCase):
+
+    def test_a_fetch_parses(self):
+        message = peershare.parse_message(
+            '{"peershare": 1, "kind": "fetch", "uid": "abc"}')
+        self.assertEqual(message['kind'], 'fetch')
+        self.assertEqual(message['uid'], 'abc')
+
+    def test_an_ask_keeps_its_text(self):
+        message = peershare.parse_message(
+            json.dumps({'peershare': 1, 'kind': 'ask', 'uid': 'abc',
+                        'message': 'why?'}))
+        self.assertEqual(message['message'], 'why?')
+
+    def test_a_fetch_that_names_no_entry_is_nothing_to_answer(self):
+        for line in ('{"peershare": 1, "kind": "fetch"}',
+                     '{"peershare": 1, "kind": "fetch", "uid": ""}',
+                     '{"peershare": 1, "kind": "fetch", "uid": 5}',
+                     '{"peershare": 1, "kind": "fetch", "uid": null}',
+                     '{"peershare": 1, "kind": "fetch", "uid": ["abc"]}',
+                     '{"peershare": 1, "kind": "ask", "message": "why?"}',
+                     '{"peershare": 1, "kind": "ask", "uid": 5}'):
+            self.assertIsNone(peershare.parse_message(line), line)
+
+    def test_an_entry_reply_needs_no_uid_to_parse(self):
+        message = peershare.parse_message(
+            '{"peershare": 1, "kind": "entry"}')
+        self.assertEqual(message['kind'], 'entry')
+
+    def test_somebody_elses_chat_is_ignored(self):
+        for line in ('hello everyone', '', '[1, 2, 3]', '"peershare"',
+                     'null', '{"kind": "fetch", "uid": "abc"}',
+                     '{"peershare": 2, "kind": "fetch", "uid": "abc"}',
+                     '{"peershare": true, "kind": "fetch", "uid": "abc"}',
+                     '{"peershare": 1, "kind": "erase", "uid": "abc"}',
+                     '{"peershare": 1}'):
+            self.assertIsNone(peershare.parse_message(line), line)
+
+    def test_a_non_string_is_ignored(self):
+        self.assertIsNone(peershare.parse_message(None))
+
+    def test_a_round_trip_survives(self):
+        payload = peershare.build_entry_payload(
+            {'uid': 'abc', 'title': 'my rockit'}, color='#000,#FFF')
+        message = peershare.parse_message(peershare.encode_payload(payload))
+        self.assertEqual(message['kind'], peershare.KIND_ENTRY)
+        self.assertEqual(message['title'], 'my rockit')
+
+
+class TestSenderNick(unittest.TestCase):
+
+    def test_a_name_is_a_name(self):
+        self.assertEqual(peershare.sender_nick('  Ana '), 'Ana')
+
+    def test_a_name_nobody_has_is_anonymous(self):
+        self.assertEqual(peershare.sender_nick('a' * 500), '')
+
+    def test_control_and_direction_characters_are_anonymous(self):
+        for nick in ('An\ra', 'An\u202ea', 'An\u2028a'):
+            self.assertEqual(peershare.sender_nick(nick), '')
+
+    def test_a_missing_nick_is_anonymous(self):
+        self.assertEqual(peershare.sender_nick(None), '')
+        self.assertEqual(peershare.sender_nick(''), '')
+
+
+class TestHasAsked(unittest.TestCase):
+
+    def test_a_visitor_who_already_asked_is_recognised(self):
+        comments = [{'from': 'Bo', 'message': 'nice'},
+                    {'from': 'Ana', 'message': 'how?'}]
+        self.assertTrue(peershare.has_asked(comments, 'Ana'))
+
+    def test_a_visitor_who_has_not_asked_still_may(self):
+        comments = [{'from': 'Bo', 'message': 'nice'}]
+        self.assertFalse(peershare.has_asked(comments, 'Ana'))
+
+    def test_an_empty_page_lets_anyone_ask(self):
+        self.assertFalse(peershare.has_asked([], 'Ana'))
+
+    def test_the_question_survives_reopening_the_page(self):
+        # a window closed and reopened re-derives the answer from the
+        # comments already on the page, since that's the only record
+        raw = peershare.append_comment('', 'Ana', 'how?')
+        self.assertTrue(peershare.has_asked(json.loads(raw), 'Ana'))
+
+    def test_an_unusable_name_shares_the_anonymous_slot(self):
+        comments = [{'from': '', 'message': 'how?'}]
+        self.assertTrue(peershare.has_asked(comments, 'a' * 500))
+        self.assertFalse(peershare.has_asked(comments, 'Ana'))
+
+    def test_a_page_without_comments_lets_anyone_ask(self):
+        for comments in (None, '', {'from': 'Ana'}, 5):
+            self.assertFalse(peershare.has_asked(comments, 'Ana'))
+
+    def test_junk_in_the_list_is_not_a_question(self):
+        self.assertFalse(peershare.has_asked(['Ana', None], 'Ana'))
+
+
+class TestAppendComment(unittest.TestCase):
+
+    def test_a_question_lands_on_the_end(self):
+        comments = json.loads(peershare.append_comment(
+            '[{"from": "Bo", "message": "nice"}]', 'Ana', 'how?'))
+        self.assertEqual(comments[-1], {'from': 'Ana', 'message': 'how?'})
+        self.assertEqual(len(comments), 2)
+
+    def test_the_first_question_starts_the_list(self):
+        comments = json.loads(
+            peershare.append_comment('', 'Ana', 'how?'))
+        self.assertEqual(comments, [{'from': 'Ana', 'message': 'how?'}])
+
+    def test_a_redelivered_question_lands_once(self):
+        first = peershare.append_comment('', 'Ana', 'how?')
+        self.assertIsNone(peershare.append_comment(first, 'Ana', 'how?'))
+
+    def test_a_second_question_from_the_same_friend_is_dropped(self):
+        # the has-asked check in the window only runs on the visitor's
+        # own machine, so the record has to enforce the rule too
+        first = peershare.append_comment('', 'Ana', 'how?')
+        self.assertIsNone(
+            peershare.append_comment(first, 'Ana', 'and the fins?'))
+
+    def test_a_different_friend_still_gets_their_turn(self):
+        first = peershare.append_comment('', 'Ana', 'how?')
+        second = peershare.append_comment(first, 'Ben', 'and the fins?')
+        self.assertEqual(
+            [comment['from'] for comment in json.loads(second)],
+            ['Ana', 'Ben'])
+
+    def test_a_full_record_takes_no_more(self):
+        comments = json.dumps(
+            [{'from': 'kid-%d' % index, 'message': 'hi'}
+             for index in range(reflectguard.MAX_COMMENTS)])
+        self.assertIsNone(peershare.append_comment(comments, 'Ana', 'how?'))
+
+    def test_an_empty_question_is_no_question(self):
+        for text in ('', '   ', '\t\n ', None, 5, ['how?']):
+            self.assertIsNone(peershare.append_comment('', 'Ana', text))
+
+    def test_an_essay_is_not_a_question(self):
+        self.assertIsNone(peershare.append_comment(
+            '', 'Ana', 'x' * (peershare.ASK_LIMIT + 1)))
+        self.assertIsNotNone(peershare.append_comment(
+            '', 'Ana', 'x' * peershare.ASK_LIMIT))
+
+    def test_control_characters_never_reach_the_record(self):
+        self.assertIsNone(
+            peershare.append_comment('', 'Ana', 'how\u202edid you'))
+
+    def test_an_unusable_name_leaves_the_question_anonymous(self):
+        comments = json.loads(
+            peershare.append_comment('', 'a' * 500, 'how?'))
+        self.assertEqual(comments, [{'from': '', 'message': 'how?'}])
+
+    def test_a_broken_record_is_not_a_reason_to_drop_the_question(self):
+        comments = json.loads(
+            peershare.append_comment('not json', 'Ana', 'how?'))
+        self.assertEqual(comments, [{'from': 'Ana', 'message': 'how?'}])
+
+    def test_an_emoji_held_together_still_asks(self):
+        self.assertIsNotNone(peershare.append_comment(
+            '', 'Ana', 'I love \U0001F469\u200d\U0001F680 rockets!'))
+
+    def test_a_question_of_nothing_but_joiners_is_no_question(self):
+        self.assertIsNone(
+            peershare.append_comment('', 'Ana', '\u200d\u200d'))
+
+    def test_the_senders_color_rides_along_when_known(self):
+        comments = json.loads(peershare.append_comment(
+            '', 'Ana', 'how?', color='#FF2B34,#005FE4'))
+        self.assertEqual(comments[0]['icon-color'], '#FF2B34,#005FE4')
+
+    def test_an_unknown_color_leaves_the_record_plain(self):
+        comments = json.loads(
+            peershare.append_comment('', 'Ana', 'how?'))
+        self.assertNotIn('icon-color', comments[0])
+
+
+class _Call(object):
+    """One D-Bus method call the fake connection took."""
+
+    def __init__(self, name, args, reply_handler, error_handler):
+        self.name = name
+        self.args = args
+        self.reply_handler = reply_handler
+        self.error_handler = error_handler
+
+    def reply(self, *values):
+        self.reply_handler(*values)
+
+    def fail(self, error='boom'):
+        self.error_handler(error)
+
+
+class _FakeInterface(object):
+    """One interface proxy off the fake connection.
+
+    Every method call lands in `calls`; by default the reply handler
+    fires straight away with whatever `replies` holds for that method.
+    A name in `holds` is recorded and left hanging, so a test can drive
+    the ordering by firing the reply itself.
+    """
+
+    def __init__(self, bus_name='org.fake.Salut'):
+        self.bus_name = bus_name
+        self.object_path = '/org/fake/conn'
+        self.calls = []
+        self.replies = {}
+        self.errors = {}
+        self.holds = set()
+        self.raises = set()
+        self.signals = {}
+
+    def __getattr__(self, name):
+        return partial(self._invoke, name)
+
+    def connect_to_signal(self, name, handler, **kwargs):
+        self.signals[name] = handler
+        return Mock()
+
+    def _invoke(self, name, *args, **kwargs):
+        if name in self.raises:
+            raise RuntimeError('synchronous boom')
+        call = _Call(name, args, kwargs.get('reply_handler'),
+                     kwargs.get('error_handler'))
+        self.calls.append(call)
+        if name in self.holds:
+            return
+        if name in self.errors:
+            call.fail(self.errors[name])
+            return
+        if call.reply_handler is not None:
+            call.reply(*self.replies.get(name, ()))
+
+    def names(self):
+        return [call.name for call in self.calls]
+
+    def find(self, name):
+        return [call for call in self.calls if call.name == name]
+
+
+def _fake_conn(buddy_info=True):
+    conn = {CONNECTION: _FakeInterface(),
+            REQUESTS: _FakeInterface(),
+            ACTIVITY_PROPERTIES: _FakeInterface()}
+    conn[CONNECTION].replies['RequestHandles'] = ([7],)
+    conn[CONNECTION].replies['RequestChannel'] = ('/org/fake/room',)
+    if buddy_info:
+        conn[BUDDY_INFO] = _FakeInterface()
+        conn[BUDDY_INFO].replies['GetActivities'] = ([],)
+    return conn
+
+
+class _FakeNeighborhoodModel(object):
+
+    def __init__(self, conn):
+        self.conn = conn
+        self.self_handle = 1
+        self._callbacks = []
+
+    def connect(self, signal, callback):
+        self._callbacks.append((signal, callback))
+        return len(self._callbacks)
+
+    def get_link_local_connection(self):
+        return self.conn
+
+    def get_link_local_self_handle(self):
+        if self.conn is None:
+            return None
+        return self.self_handle
+
+    def get_buddy_by_handle(self, handle):
+        return None
+
+    def connection_changed(self):
+        for signal, callback in self._callbacks:
+            if signal == 'link-local-connection-changed':
+                callback(self)
+
+
+class _FakeChannel(object):
+
+    def __init__(self):
+        self.sent = []
+        self.sent_types = []
+        self.closes = 0
+        self.acknowledged = []
+        self.pending = []
+        self.handlers = []
+        self.matches = []
+
+    def connect_to_signal(self, name, handler, **kwargs):
+        match = Mock()
+        if name == 'Received':
+            self.handlers.append(handler)
+            match.remove.side_effect = \
+                lambda: self.handlers.remove(handler)
+        self.matches.append(match)
+        return match
+
+    def ListPendingMessages(self, clear, **kwargs):
+        kwargs['reply_handler'](list(self.pending))
+
+    def AcknowledgePendingMessages(self, message_ids, **kwargs):
+        self.acknowledged.extend(message_ids)
+
+    def Send(self, message_type, text, **kwargs):
+        self.sent.append(text)
+        self.sent_types.append(message_type)
+
+    def Close(self, **kwargs):
+        self.closes += 1
+
+    def receive(self, text, message_id=1, sender=42):
+        for handler in list(self.handlers):
+            handler(message_id, 0, sender, 0, 0, text)
+
+
+class _FakeConnProxy(object):
+    """Stands in for the connection object the sweep calls
+    Properties.Get on to list channels that existed before the
+    watch started."""
+
+    def __init__(self):
+        self.existing = []
+        self.gets = []
+
+    def Get(self, interface, name, **kwargs):
+        self.gets.append((interface, name))
+        kwargs['reply_handler'](list(self.existing))
+
+
+class _FakeBus(object):
+
+    def __init__(self, channel, conn_proxy=None):
+        self._channel = channel
+        self._conn_proxy = conn_proxy or _FakeConnProxy()
+
+    def get_object(self, bus_name, path):
+        if path == '/org/fake/conn':
+            return self._conn_proxy
+        return self._channel
+
+
+class _TransportCase(unittest.TestCase):
+    """Drives the advert's D-Bus chain without a bus or a main loop."""
+
+    def setUp(self):
+        self.timers = []
+        self.channel = _FakeChannel()
+        self.conn_proxy = _FakeConnProxy()
+        self.model = _FakeNeighborhoodModel(_fake_conn())
+        self.written = []
+        self._patch(peershare.GLib, 'idle_add', lambda cb, *a: 0)
+        self._patch(peershare.GLib, 'timeout_add_seconds', self._add_timer)
+        self._patch(peershare.neighborhood, 'get_model', lambda: self.model)
+        self._patch(peershare.dbus, 'SessionBus',
+                    lambda: _FakeBus(self.channel, self.conn_proxy))
+        self._patch(model, 'get',
+                    lambda uid: {'uid': uid, 'title': 'my rockit',
+                                 'shared': '1'})
+        self._patch(model, 'write',
+                    lambda metadata, **kwargs:
+                    self.written.append(dict(metadata)))
+
+    def _patch(self, target, attribute, value):
+        patcher = patch.object(target, attribute, value)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _add_timer(self, delay, callback, *args):
+        self.timers.append((delay, callback, args))
+        return len(self.timers)
+
+    def _peershare(self):
+        share = peershare.PeerShare()
+        self.addCleanup(model.updated.disconnect,
+                        share._PeerShare__entry_updated_cb)
+        self.addCleanup(model.deleted.disconnect,
+                        share._PeerShare__entry_deleted_cb)
+        return share
+
+
+class TestAdvertiseChain(_TransportCase):
+
+    def test_properties_only_go_out_once_the_advert_landed(self):
+        conn = self.model.conn
+        conn[BUDDY_INFO].holds.add('AddActivity')
+        share = self._peershare()
+        share._queue('uid-1')
+
+        names = conn[CONNECTION].names()
+        self.assertLess(names.index('RequestHandles'),
+                        names.index('RequestChannel'))
+        self.assertEqual(conn[BUDDY_INFO].names(), ['AddActivity'])
+        self.assertEqual(conn[ACTIVITY_PROPERTIES].names(), [])
+
+        conn[BUDDY_INFO].find('AddActivity')[0].reply()
+        self.assertEqual(conn[ACTIVITY_PROPERTIES].names(),
+                         ['SetProperties'])
+        self.assertIn('uid-1', share._shares)
+
+    def test_the_room_is_named_after_the_entry(self):
+        share = self._peershare()
+        share._queue('uid-1')
+        call = self.model.conn[CONNECTION].find('RequestHandles')[0]
+        self.assertEqual(call.args[1],
+                         [peershare.entry_activity_id('uid-1')])
+
+
+class TestFailedAdvert(_TransportCase):
+
+    def test_a_failed_advert_comes_round_again_on_the_wait(self):
+        conn = self.model.conn
+        conn[CONNECTION].errors['RequestHandles'] = 'no bus'
+        share = self._peershare()
+        with self.assertLogs(level=logging.ERROR):
+            share._queue('uid-1')
+
+        self.assertIn('uid-1', share._pending)
+        self.assertEqual(self.timers[-1][0], peershare._RETRY_SECONDS)
+
+        del conn[CONNECTION].errors['RequestHandles']
+        _delay, callback, args = self.timers[-1]
+        callback(*args)
+        self.assertIn('uid-1', share._shares)
+        self.assertEqual(conn[BUDDY_INFO].names(), ['AddActivity'])
+
+
+class TestConnectionComesAndGoes(_TransportCase):
+
+    def test_a_dropped_connection_re_advertises_when_it_returns(self):
+        share = self._peershare()
+        share._queue('uid-1')
+        self.assertIn('uid-1', share._shares)
+
+        self.model.conn = None
+        self.model.connection_changed()
+        self.assertEqual(share._shares, {})
+        self.assertIn('uid-1', share._pending)
+        # nothing is closed over a connection that is already gone
+        self.assertEqual(self.channel.closes, 0)
+
+        self.model.conn = _fake_conn()
+        self.model.connection_changed()
+        self.assertIn('uid-1', share._shares)
+        self.assertEqual(self.model.conn[BUDDY_INFO].names(),
+                         ['AddActivity'])
+
+
+class TestRetraction(_TransportCase):
+
+    def test_a_retraction_waits_for_a_connection_it_can_use(self):
+        share = self._peershare()
+        share._queue('uid-1')
+        buddy_info = self.model.conn[BUDDY_INFO]
+        buddy_info.replies['GetActivities'] = (
+            [('other-activity', 3),
+             (peershare.entry_activity_id('uid-1'), 7)],)
+
+        self.model.self_handle = None
+        share._retract('uid-1')
+        self.assertEqual(share._retractions, {'uid-1'})
+        self.assertEqual(buddy_info.names(), ['AddActivity'])
+
+        self.model.self_handle = 5
+        self.model.connection_changed()
+        self.assertEqual(buddy_info.names(),
+                         ['AddActivity', 'GetActivities', 'SetActivities'])
+        self.assertEqual(buddy_info.find('SetActivities')[0].args[0],
+                         [('other-activity', 3)])
+        self.assertEqual(share._retractions, set())
+
+    def test_two_retractions_ride_one_round_and_both_land(self):
+        # if each retraction did its own read, the second write would
+        # undo the first one's removal
+        share = self._peershare()
+        share._queue('uid-1')
+        share._queue('uid-2')
+        buddy_info = self.model.conn[BUDDY_INFO]
+        buddy_info.holds.add('GetActivities')
+
+        share._retract('uid-1')
+        share._retract('uid-2')
+        self.assertEqual(len(buddy_info.find('GetActivities')), 1)
+
+        buddy_info.find('GetActivities')[0].reply(
+            [('other-activity', 3),
+             (peershare.entry_activity_id('uid-1'), 7),
+             (peershare.entry_activity_id('uid-2'), 8)])
+        sets = buddy_info.find('SetActivities')
+        self.assertEqual(len(sets), 1)
+        self.assertEqual(sets[0].args[0], [('other-activity', 3)])
+        self.assertEqual(share._retractions, set())
+
+    def test_a_retraction_does_not_write_over_a_fresh_advert(self):
+        share = self._peershare()
+        share._queue('uid-1')
+        buddy_info = self.model.conn[BUDDY_INFO]
+        buddy_info.holds.add('GetActivities')
+
+        share._retract('uid-1')
+        share._queue('uid-2')
+        buddy_info.find('GetActivities')[0].reply(
+            [(peershare.entry_activity_id('uid-1'), 7)])
+
+        sets = buddy_info.find('SetActivities')
+        self.assertEqual(len(sets), 1)
+        self.assertEqual(sets[0].args[0],
+                         [(peershare.entry_activity_id('uid-2'), 7)])
+
+    def test_a_half_advertised_entry_is_not_named_early(self):
+        # its AddActivity call is still in flight, so listing it now
+        # would show peers a room with no name or colour yet
+        share = self._peershare()
+        share._queue('uid-1')
+        buddy_info = self.model.conn[BUDDY_INFO]
+        buddy_info.holds.add('GetActivities')
+        share._retract('uid-1')
+        buddy_info.holds.add('AddActivity')
+        share._queue('uid-2')
+
+        buddy_info.find('GetActivities')[0].reply(
+            [(peershare.entry_activity_id('uid-1'), 7)])
+        sets = buddy_info.find('SetActivities')
+        self.assertEqual(len(sets), 1)
+        self.assertEqual(sets[0].args[0], [])
+
+    def test_a_read_that_blows_up_does_not_jam_retractions(self):
+        share = self._peershare()
+        share._queue('uid-1')
+        buddy_info = self.model.conn[BUDDY_INFO]
+        buddy_info.raises.add('GetActivities')
+        with self.assertLogs(level=logging.ERROR):
+            share._retract('uid-1')
+        self.assertEqual(share._retractions, {'uid-1'})
+
+        buddy_info.raises.discard('GetActivities')
+        share._flush_retractions()
+        self.assertEqual(len(buddy_info.find('SetActivities')), 1)
+        self.assertEqual(share._retractions, set())
+
+    def test_a_reads_jam_ends_with_its_connection(self):
+        share = self._peershare()
+        share._queue('uid-1')
+        buddy_info = self.model.conn[BUDDY_INFO]
+        buddy_info.holds.add('GetActivities')
+        share._retract('uid-1')
+        self.assertEqual(share._retractions, {'uid-1'})
+
+        # the connection drops while the read is still outstanding,
+        # so no reply is ever going to arrive for it
+        old_conn = self.model.conn
+        self.model.conn = None
+        self.model.connection_changed()
+        self.model.conn = old_conn
+        buddy_info.holds.discard('GetActivities')
+        self.model.connection_changed()
+        self.assertEqual(len(buddy_info.find('SetActivities')), 1)
+        self.assertEqual(share._retractions, set())
+
+    def test_an_entry_shared_again_is_not_written_out_of_the_list(self):
+        # a failed write puts its entries back in the queue, and by
+        # the next round the child may have shared one of them again;
+        # that entry must be left alone this time
+        share = self._peershare()
+        share._queue('uid-1')
+        share._queue('uid-2')
+        buddy_info = self.model.conn[BUDDY_INFO]
+        buddy_info.replies['GetActivities'] = (
+            [(peershare.entry_activity_id('uid-1'), 7),
+             (peershare.entry_activity_id('uid-2'), 8)],)
+        buddy_info.holds.add('SetActivities')
+        share._retract('uid-1')
+
+        self.model.conn[CONNECTION].errors['RequestHandles'] = 'no bus'
+        with self.assertLogs(level=logging.ERROR):
+            share._queue('uid-1')
+            buddy_info.find('SetActivities')[0].fail('boom')
+        self.assertIn('uid-1', share._pending)
+        self.assertIn('uid-1', share._retractions)
+
+        buddy_info.holds.discard('SetActivities')
+        share._retract('uid-2')
+        sets = buddy_info.find('SetActivities')
+        self.assertEqual(len(sets), 2)
+        self.assertEqual(sets[-1].args[0],
+                         [(peershare.entry_activity_id('uid-1'), 7)])
+
+
+# a friend's page gets drawn, so its fields are validated first
+
+
+class TestTheIdAFriendSends(unittest.TestCase):
+
+    def test_an_ordinary_id_is_carried(self):
+        self.assertEqual(peershare.safe_uid('4f9a-22bc_1'), '4f9a-22bc_1')
+
+    def test_an_id_that_names_a_path_is_refused(self):
+        # the page's own machinery opens an id that names a real file,
+        # so a friend cannot use it to point at our disk
+        self.assertEqual(peershare.safe_uid('/etc/shadow'), '')
+        self.assertEqual(peershare.safe_uid('../../home/kid/notes'), '')
+
+    def test_an_id_that_is_not_a_string_is_refused(self):
+        self.assertEqual(peershare.safe_uid(None), '')
+        self.assertEqual(peershare.safe_uid({'uid': 'x'}), '')
+
+    def test_an_endless_id_is_refused(self):
+        self.assertEqual(peershare.safe_uid('a' * 400), '')
+
+
+class TestTheKindAFriendClaims(unittest.TestCase):
+
+    def test_an_ordinary_kind_is_carried(self):
+        self.assertEqual(peershare.safe_mime('image/png'), 'image/png')
+
+    def test_a_bundle_kind_is_refused(self):
+        # a page claiming to be a bundle would send the Journal
+        # looking for a file to install; a shared page is not a bundle
+        for kind in peershare._BUNDLE_KINDS:
+            self.assertEqual(peershare.safe_mime(kind), '')
+
+    def test_a_kind_that_is_not_a_string_is_refused(self):
+        self.assertEqual(peershare.safe_mime(None), '')
+
+
+class TestTheTagsAFriendSends(unittest.TestCase):
+
+    def test_ordinary_tags_are_carried(self):
+        self.assertEqual(peershare.safe_tags('rockets moon'),
+                         'rockets moon')
+
+    def test_a_flood_of_tags_stops_at_a_page_full(self):
+        # each tag becomes a widget on screen, and the wire limit
+        # alone would still leave room for thousands of them
+        tags = ' '.join('t%d' % number for number in range(4000))
+        self.assertEqual(len(peershare.safe_tags(tags).split()),
+                         peershare.TAG_LIMIT)
+
+    def test_an_endless_tag_is_cut_to_a_tag(self):
+        self.assertEqual(len(peershare.safe_tags('x' * 5000)),
+                         peershare.TAG_CHARS)
+
+    def test_control_marks_still_come_out(self):
+        self.assertEqual(peershare.safe_tags('one\u202etwo'), 'onetwo')
+
+
+class TestSynchronousFailures(_TransportCase):
+
+    def test_an_advertise_that_blows_up_waits_its_turn_again(self):
+        self.model.conn[CONNECTION].raises.add('RequestHandles')
+        share = self._peershare()
+        with self.assertLogs(level=logging.ERROR):
+            share._queue('uid-1')
+
+        self.assertNotIn('uid-1', share._shares)
+        self.assertIn('uid-1', share._pending)
+        self.assertTrue(self.timers)
+
+    def test_a_late_error_after_a_retract_stays_retracted(self):
+        buddy_info = self.model.conn[BUDDY_INFO]
+        buddy_info.holds.add('AddActivity')
+        buddy_info.holds.add('GetActivities')
+        share = self._peershare()
+        share._queue('uid-1')
+        share._retract('uid-1')
+
+        with self.assertLogs(level=logging.ERROR):
+            buddy_info.find('AddActivity')[0].fail('connection reset')
+
+        self.assertNotIn('uid-1', share._pending)
+        self.assertNotIn('uid-1', share._shares)
+        self.assertEqual(self.timers, [])
+
+    def test_a_write_that_blows_up_keeps_the_retractions(self):
+        buddy_info = self.model.conn[BUDDY_INFO]
+        share = self._peershare()
+        share._queue('uid-1')
+        buddy_info.holds.add('GetActivities')
+        share._retract('uid-1')
+
+        buddy_info.raises.add('SetActivities')
+        with self.assertLogs(level=logging.ERROR):
+            buddy_info.find('GetActivities')[0].reply(
+                [(peershare.entry_activity_id('uid-1'), 7)])
+
+        self.assertEqual(share._retractions, {'uid-1'})
+        self.assertFalse(share._retract_inflight)
+
+
+class TestMissingBuddyInfo(_TransportCase):
+
+    def test_a_connection_without_buddy_info_opens_no_room(self):
+        self.model.conn = _fake_conn(buddy_info=False)
+        share = self._peershare()
+        with self.assertLogs(level=logging.WARNING) as caught:
+            share._queue('uid-1')
+            share._flush()
+
+        self.assertEqual(self.model.conn[CONNECTION].names(), [])
+        self.assertIn('uid-1', share._pending)
+        self.assertEqual(share._shares, {})
+        said = [record for record in caught.records
+                if 'BuddyInfo' in record.getMessage()]
+        self.assertEqual(len(said), 1)
+
+    def test_the_next_connection_gets_a_fresh_try(self):
+        self.model.conn = _fake_conn(buddy_info=False)
+        share = self._peershare()
+        with self.assertLogs(level=logging.WARNING):
+            share._queue('uid-1')
+
+        self.model.conn = _fake_conn()
+        self.model.connection_changed()
+        self.assertIn('uid-1', share._shares)
+
+
+class TestServingVisitors(_TransportCase):
+    """The line back is a one-to-one channel a visitor opens."""
+
+    _PATH = '/org/fake/contact/1'
+
+    def _share(self, uid='uid-1'):
+        share = self._peershare()
+        share._queue(uid)
+        return share
+
+    def _visitor_arrives(self, share, path=None):
+        signals = self.model.conn[CONNECTION].signals
+        signals['NewChannel'](path or self._PATH,
+                              peershare.CHANNEL_TYPE_TEXT,
+                              peershare.HANDLE_TYPE_CONTACT, 9, False)
+
+    def _fetch(self, uid):
+        return json.dumps({'peershare': peershare.PROTOCOL,
+                           'kind': peershare.KIND_FETCH, 'uid': uid})
+
+    def _ask(self, uid, text):
+        return json.dumps({'peershare': peershare.PROTOCOL,
+                           'kind': peershare.KIND_ASK, 'uid': uid,
+                           'message': text})
+
+    def test_both_signals_lead_to_one_channel(self):
+        share = self._share()
+        self._visitor_arrives(share)
+        self.model.conn[REQUESTS].signals['NewChannels']([
+            (self._PATH, {peershare.CHANNEL + '.ChannelType':
+                          peershare.CHANNEL_TYPE_TEXT,
+                          peershare.CHANNEL + '.TargetHandleType':
+                          peershare.HANDLE_TYPE_CONTACT})])
+        self.assertEqual(list(share._peers), [self._PATH])
+        self.assertEqual(len(self.channel.handlers), 1)
+
+    def test_a_channel_open_before_the_watch_is_swept_in(self):
+        # salut outlives the shell, so a visitor's channel can already
+        # be open before the watch starts and no NewChannel signal
+        # will fire for it -- the sweep is what picks it up
+        self.conn_proxy.existing = [
+            (self._PATH, {peershare.CHANNEL + '.ChannelType':
+                          peershare.CHANNEL_TYPE_TEXT,
+                          peershare.CHANNEL + '.TargetHandleType':
+                          peershare.HANDLE_TYPE_CONTACT})]
+        share = self._share()
+
+        self.assertIn((REQUESTS, 'Channels'), self.conn_proxy.gets)
+        self.assertEqual(list(share._peers), [self._PATH])
+        self.channel.receive(self._fetch('uid-1'))
+        self.assertEqual(len(self.channel.sent), 1)
+
+    def test_a_channel_we_opened_ourselves_is_served_too(self):
+        # two children viewing each other's entries share one
+        # channel, so the one our window requested is also where
+        # their fetch arrives
+        self._share()
+        self.model.conn[CONNECTION].signals['NewChannel'](
+            self._PATH, peershare.CHANNEL_TYPE_TEXT,
+            peershare.HANDLE_TYPE_CONTACT, 9, True)
+        self.channel.receive(self._fetch('uid-1'))
+        self.assertEqual(len(self.channel.sent), 1)
+
+    def test_a_room_channel_is_not_a_line_to_anybody(self):
+        share = self._share()
+        self.model.conn[CONNECTION].signals['NewChannel'](
+            '/org/fake/room', peershare.CHANNEL_TYPE_TEXT,
+            peershare.HANDLE_TYPE_ROOM, 7, False)
+        self.assertEqual(share._peers, {})
+
+    def test_an_answer_is_left_to_the_window_that_asked(self):
+        share = self._share()
+        self._visitor_arrives(share)
+        self.channel.receive(json.dumps(peershare.build_entry_payload(
+            {'uid': 'uid-1'}, color='#000,#FFF')), message_id=3)
+        self.assertEqual(self.channel.acknowledged, [])
+        self.assertEqual(self.channel.sent, [])
+
+    def test_a_fetch_is_answered_on_the_same_channel(self):
+        share = self._share()
+        self._visitor_arrives(share)
+        self.channel.receive(self._fetch('uid-1'))
+
+        self.assertEqual(len(self.channel.sent), 1)
+        page = json.loads(self.channel.sent[0])
+        self.assertEqual(page['kind'], peershare.KIND_ENTRY)
+        self.assertEqual(page['uid'], 'uid-1')
+        self.assertEqual(page['title'], 'my rockit')
+        self.assertEqual(self.channel.acknowledged, [1])
+        self.assertEqual(self.channel.sent_types,
+                         [peershare.MESSAGE_TYPE_PROTOCOL])
+        # Telepathy spec values: NORMAL=0, ACTION=1, NOTICE=2.
+        self.assertEqual(peershare.MESSAGE_TYPE_PROTOCOL, 2)
+
+    def test_a_fetch_for_an_unshared_entry_is_not_answered(self):
+        share = self._share()
+        self._visitor_arrives(share)
+        self.channel.receive(self._fetch('uid-nobody-shared'))
+        self.assertEqual(self.channel.sent, [])
+        self.assertEqual(self.channel.acknowledged, [1])
+
+    def test_a_fetch_waiting_in_the_queue_is_answered_too(self):
+        share = self._share()
+        self.channel.pending = [(4, 0, 42, 0, 0, self._fetch('uid-1'))]
+        self._visitor_arrives(share)
+        self.assertEqual(len(self.channel.sent), 1)
+        self.assertEqual(self.channel.acknowledged, [4])
+
+    def test_a_friends_chat_is_left_where_they_will_find_it(self):
+        share = self._share()
+        self._visitor_arrives(share)
+        for line in ('hello!', '{"not": "ours"}', ''):
+            self.channel.receive(line, message_id=7)
+        self.assertEqual(self.channel.acknowledged, [])
+        self.assertEqual(self.channel.sent, [])
+
+    def test_a_friends_chat_is_reported_to_the_stray_listener(self):
+        heard = []
+        peershare.set_stray_chat_cb(
+            lambda channel_path, sender: heard.append((channel_path, sender)))
+        self.addCleanup(peershare.set_stray_chat_cb, None)
+        share = self._share()
+        self._visitor_arrives(share)
+        self.channel.receive('hello!', message_id=7, sender=42)
+        self.assertEqual(heard, [(self._PATH, 42)])
+        self.assertEqual(self.channel.acknowledged, [])
+
+    def test_an_ask_lands_on_the_entry_it_names(self):
+        share = self._share()
+        self._visitor_arrives(share)
+        self.channel.receive(self._ask('uid-1', 'how did you do the fins?'))
+
+        self.assertEqual(len(self.written), 1)
+        self.assertEqual(self.written[0]['uid'], 'uid-1')
+        self.assertEqual(
+            json.loads(self.written[0]['comments']),
+            [{'from': '', 'message': 'how did you do the fins?'}])
+
+    def test_an_ask_for_an_unshared_entry_is_dropped(self):
+        share = self._share()
+        self._visitor_arrives(share)
+        self.channel.receive(self._ask('uid-nobody-shared', 'how?'))
+        self.assertEqual(self.written, [])
+
+    def test_a_lost_connection_takes_the_listeners_with_it(self):
+        share = self._share()
+        self._visitor_arrives(share)
+        matches = list(self.channel.matches)
+
+        self.model.conn = None
+        self.model.connection_changed()
+
+        self.assertEqual(share._peers, {})
+        self.assertIsNone(share._bus_name)
+        for match in matches:
+            match.remove.assert_called_once_with()
+
+    def test_the_next_connection_listens_again(self):
+        share = self._share()
+        self._visitor_arrives(share)
+        self.model.conn = None
+        self.model.connection_changed()
+
+        self.model.conn = _fake_conn()
+        self.model.connection_changed()
+        self._visitor_arrives(share)
+        self.channel.receive(self._fetch('uid-1'))
+        self.assertEqual(len(self.channel.sent), 1)
+
+
+class TestAskLeg(_TransportCase):
+
+    def test_a_delivered_question_is_handed_to_the_guard(self):
+        share = self._peershare()
+        share._queue('uid-1')
+        guard = Mock()
+        self._patch(peershare.reflectguard, 'get_guard', lambda: guard)
+
+        share._take_ask('uid-1', 42, 'how did you do the fins?')
+
+        self.assertEqual(len(self.written), 1)
+        self.assertEqual(
+            json.loads(self.written[0]['comments']),
+            [{'from': '', 'message': 'how did you do the fins?'}])
+        guard.note_delivered_comment.assert_called_once_with(
+            'uid-1', {'from': '', 'message': 'how did you do the fins?'})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/journal/test_reflectguard.py
+++ b/tests/journal/test_reflectguard.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import json
 import logging
 import os
 import sys
@@ -175,8 +176,7 @@ class TestRemergeRestoresClobberedWrite(unittest.TestCase):
         guard.note_moments(uid, [moment], {reflectguard.SNAP_KEY % 0: 'AAA'})
         model.updated.send(None, object_id=uid)  # swallow our own echo
 
-        def boom(*args, **kwargs):
-            raise AssertionError('write touched when nothing was lost')
+        written = []
         intact = {
             'reflections': reflection.dumps({'moments': [moment]}),
             reflectguard.SNAP_KEY % 0: 'AAA',
@@ -184,7 +184,9 @@ class TestRemergeRestoresClobberedWrite(unittest.TestCase):
         patcher = mock.patch.object(model, 'get', lambda object_id: intact)
         patcher.start()
         self.addCleanup(patcher.stop)
-        patcher = mock.patch.object(model, 'write', boom)
+        patcher = mock.patch.object(
+            model, 'write',
+            lambda metadata, **kwargs: written.append(dict(metadata)))
         patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -192,6 +194,7 @@ class TestRemergeRestoresClobberedWrite(unittest.TestCase):
         # its snapshot is actually missing from the datastore's copy
         model.updated.send(None, object_id=uid)
 
+        self.assertEqual(written, [])
         self.assertIs(guard._entries[uid]['pending'], False)
 
     def test_remerge_evicts_oldest_moments_past_the_cap(self):
@@ -230,38 +233,6 @@ class TestRemergeRestoresClobberedWrite(unittest.TestCase):
             [m['snap_seq'] for m in data['moments']], list(range(1, cap + 1)))
         self.assertNotIn(reflectguard.SNAP_KEY % 0, written[0])
         self.assertIn(reflectguard.SNAP_KEY % 1, written[0])
-
-
-# --- the echo counter also guards the re-merge's own follow-up write ---
-
-class TestRemergeOwnWriteEchoSwallowed(unittest.TestCase):
-
-    def test_remerges_own_write_echo_is_swallowed_next_time(self):
-        _run_idle(self)
-        uid = 'uid-loop-guard'
-        moment = {'caption': 'x', 'mark': 'wonder', 'ts': 1, 'snap_seq': 0}
-        guard = reflectguard.ReflectionsGuard()
-        guard.note_moments(uid, [moment], {})
-        model.updated.send(None, object_id=uid)  # swallow our own echo
-
-        written = []
-        patcher = mock.patch.object(model, 'get', lambda object_id: {})
-        patcher.start()
-        self.addCleanup(patcher.stop)
-        patcher = mock.patch.object(
-            model, 'write',
-            lambda md, **kwargs: written.append(dict(md)))
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
-        model.updated.send(None, object_id=uid)  # the real clobber -> remerge
-        self.assertEqual(len(written), 1)
-
-        # the Updated signal the remerge's own model.write() just emitted is
-        # the next one in -- it must be swallowed, not chased as another
-        # clobber, or every remerge would retrigger itself forever.
-        model.updated.send(None, object_id=uid)
-        self.assertEqual(len(written), 1)
 
 
 # --- the pending flag: only one re-merge in flight per entry ---
@@ -466,6 +437,208 @@ class TestMixedMomentsAndSessionsEchoSuppression(unittest.TestCase):
         model.updated.send(None, object_id=uid)  # the write's own echo
         self.assertEqual(guard._entries[uid]['echoes'], 0)
         self.assertEqual(len(written), 1)
+
+
+# delivered comments
+
+class TestDeliveredComments(unittest.TestCase):
+
+    def _clobber(self, on_disk):
+        written = []
+        patcher = mock.patch.object(
+            model, 'get', lambda object_id: dict(on_disk))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch.object(
+            model, 'write',
+            lambda metadata, **kwargs: written.append(dict(metadata)))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return written
+
+    def test_a_comment_the_disk_still_holds_keeps_its_place(self):
+        _run_idle(self)
+        uid = 'uid-comment-order'
+        theirs = {'from': 'Bo', 'message': 'nice rocket'}
+        ours = {'from': 'Ana', 'message': 'how?'}
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_delivered_comment(uid, ours)
+        model.updated.send(None, object_id=uid)
+
+        written = self._clobber({'comments': json.dumps([theirs])})
+        model.updated.send(None, object_id=uid)
+
+        self.assertEqual(json.loads(written[0]['comments']),
+                         [theirs, ours])
+
+    def test_a_writer_adding_keys_does_not_duplicate_the_comment(self):
+        _run_idle(self)
+        uid = 'uid-comment-keys'
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_delivered_comment(
+            uid, {'from': 'Ana', 'message': 'how?'})
+        model.updated.send(None, object_id=uid)
+
+        written = []
+        on_disk = [{'from': 'Ana', 'message': 'how?', 'ctime': '2026',
+                    'icon': 'computer-xo'}]
+        patcher = mock.patch.object(
+            model, 'get',
+            lambda object_id: {'comments': json.dumps(on_disk)})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch.object(
+            model, 'write',
+            lambda metadata, **kwargs: written.append(dict(metadata)))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        model.updated.send(None, object_id=uid)
+
+        self.assertEqual(written, [])
+
+    def test_the_childs_erase_wins_and_stays_won(self):
+        _run_idle(self)
+        uid = 'uid-comment-erase'
+        erased = {'from': 'Ana', 'message': 'how?'}
+        kept = {'from': 'Bo', 'message': 'nice rocket'}
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_delivered_comment(uid, erased)
+        guard.note_delivered_comment(uid, kept)
+        model.updated.send(None, object_id=uid)
+        model.updated.send(None, object_id=uid)
+
+        guard.note_comments_pruned(uid, json.dumps([kept]))
+        self.assertEqual(guard._entries[uid]['comments'],
+                         [('Bo', 'nice rocket')])
+        model.updated.send(None, object_id=uid)  # the erase write's echo
+
+        # a full clobber afterwards should still bring back only 'kept'
+        written = self._clobber({})
+        model.updated.send(None, object_id=uid)
+        self.assertEqual(json.loads(written[0]['comments']), [kept])
+
+    def test_the_hold_stops_at_the_cap(self):
+        uid = 'uid-comment-cap'
+        guard = reflectguard.ReflectionsGuard()
+        for index in range(reflectguard.MAX_COMMENTS + 5):
+            guard.note_delivered_comment(
+                uid, {'from': 'Ana', 'message': 'q%d' % index})
+
+        held = guard._entries[uid]['comments']
+        self.assertEqual(len(held), reflectguard.MAX_COMMENTS)
+        # check by identity, not by the internal tuple shape
+        self.assertEqual(
+            held[0], reflectguard.comment_identity(
+                {'from': 'Ana', 'message': 'q5'}))
+        self.assertEqual(
+            held[-1], reflectguard.comment_identity(
+                {'from': 'Ana', 'message': 'q28'}))
+
+    def test_pruning_an_entry_nobody_guards_does_nothing(self):
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_comments_pruned('never-held', '[]')
+        self.assertEqual(guard._entries, {})
+
+
+# note_shared vs. a foreign clobber
+
+class TestNoteSharedOutranksForeignWrite(unittest.TestCase):
+
+    def test_remerge_restores_shared_dropped_by_a_clobbering_write(self):
+        _run_idle(self)
+        uid = 'uid-shared-restore'
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_shared(uid, '1')
+        model.updated.send(None, object_id=uid)  # swallow our own echo
+
+        written = []
+        patcher = mock.patch.object(
+            model, 'get', lambda object_id: {'title': 'my rockit'})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch.object(
+            model, 'write',
+            lambda metadata, **kwargs: written.append(dict(metadata)))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        model.updated.send(None, object_id=uid)
+
+        self.assertEqual(len(written), 1)
+        self.assertEqual(written[0]['shared'], '1')
+        self.assertEqual(written[0]['title'], 'my rockit')
+
+    def test_held_zero_does_not_spuriously_reshare(self):
+        _run_idle(self)
+        uid = 'uid-shared-zero'
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_shared(uid, '0')
+        model.updated.send(None, object_id=uid)  # swallow our own echo
+
+        written = []
+        patcher = mock.patch.object(model, 'get', lambda object_id: {})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch.object(
+            model, 'write',
+            lambda metadata, **kwargs: written.append(dict(metadata)))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        model.updated.send(None, object_id=uid)
+
+        self.assertEqual(written, [])
+
+    def test_the_toggles_own_write_is_swallowed_not_fought(self):
+        _forbid_model_access(self)
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_shared('uid-shared-echo', '1')
+
+        model.updated.send(None, object_id='uid-shared-echo')
+
+        self.assertEqual(guard._entries['uid-shared-echo']['echoes'], 0)
+
+    def test_a_lossless_write_after_noting_an_unheld_uid_does_not_restore(
+            self):
+        _run_idle(self)
+        uid = 'uid-shared-lossless'
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_shared(uid, '1')
+        model.updated.send(None, object_id=uid)  # swallow our own echo
+
+        written = []
+        patcher = mock.patch.object(
+            model, 'get', lambda object_id: {'shared': '1'})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch.object(
+            model, 'write',
+            lambda metadata, **kwargs: written.append(dict(metadata)))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        model.updated.send(None, object_id=uid)
+
+        self.assertEqual(written, [])
+
+
+# delete drops the hold
+
+class TestDeletedEntryDropsHold(unittest.TestCase):
+
+    def test_a_deleted_entrys_hold_goes_with_it(self):
+        guard = reflectguard.ReflectionsGuard()
+        guard.note_shared('uid-gone', '1')
+        self.assertIn('uid-gone', guard._entries)
+
+        model.deleted.send(None, object_id='uid-gone')
+        self.assertNotIn('uid-gone', guard._entries)
+
+    def test_a_delete_of_something_never_held_is_nothing(self):
+        guard = reflectguard.ReflectionsGuard()
+        model.deleted.send(None, object_id='never-held')
+        self.assertEqual(guard._entries, {})
 
 
 # --- guarding against a naming drift between the two modules under test ---


### PR DESCRIPTION
## Summary
Plumbing half of peer sharing. A shared entry is advertised over salut like a shared activity, a friend fetches it over a text channel and can send one question back into the comments. No UI yet, that's the next PR.

Builds on #1123.

- First two commits fix the neighborhood model: conn_ready waits for the self handle, and an ActivitiesChanged that arrives before the contact is dropped instead of half processed (this was wedging buddies after a shell restart).
- invites.py checks the pending queue before treating a text channel as a chat.
- Messages go as NOTICE, stock Chat ignores that type.
- nick, uid, mime, tags, question length and comment count are all bounded before they hit the datastore.
- Nothing calls peershare.start() yet, so this does nothing on its own. No translatable strings.

## Tests
- test_peershare.py (118)
- test_reflectguard.py (25)
- one privacy test

- VM Test: two VMs over real salut, share/unshare/fetch/ask/reconnect.

## Note: 
Debian 13 and Ubuntu 24.04 don't ship telepathy-salut, and OpenSSH 10 broke the DSA keygen (#1004), so a bare install has no Neighborhood.

Series notes in #1111.