### PR TITLE
the pages for a shared journal entry

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -88,6 +88,7 @@ src/jarabe/journal/iconview.py
 src/jarabe/journal/projectview.py
 src/jarabe/journal/gridview.py
 src/jarabe/journal/timeline.py
+src/jarabe/journal/peerview.py
 src/jarabe/model/desktop.py
 src/jarabe/model/network.py
 src/jarabe/model/screenshot.py

--- a/src/jarabe/desktop/meshbox.py
+++ b/src/jarabe/desktop/meshbox.py
@@ -20,9 +20,13 @@ from gettext import gettext as _
 import logging
 
 import dbus
+from gi.repository import Gdk
+from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gio
+from gi.repository import Gtk
 
+from sugar3 import mime
 from sugar3.graphics.icon import Icon
 from sugar3.graphics.icon import CanvasIcon
 from sugar3.graphics import style
@@ -44,10 +48,16 @@ from jarabe.model import network
 from jarabe.model.network import AccessPoint
 from jarabe.model.olpcmesh import OlpcMeshManager
 from jarabe.model.adhoc import get_adhoc_manager_instance
+from jarabe.journal import journalactivity
 from jarabe.journal import misc
+from jarabe.journal import peershare
+from jarabe.journal import peerview
 
 
 _FILTERED_ALPHA = 0.33
+
+_BADGE_SCALE = 0.4
+_BADGE_INSET = style.zoom(2)
 
 
 class _ActivityIcon(CanvasIcon):
@@ -103,6 +113,246 @@ class _ActivityIcon(CanvasIcon):
         bundle = self._model.get_bundle()
         misc.launch(bundle, activity_id=self._model.activity_id,
                     color=self._model.get_color())
+
+
+class _SharedEntryIcon(CanvasIcon):
+
+    def __init__(self, model):
+        CanvasIcon.__init__(self, icon_name='activity-journal',
+                            xo_color=model.get_color(),
+                            pixel_size=style.STANDARD_ICON_SIZE)
+        self._model = model
+        self._filtered = False
+        self._badge = None
+        self._badge_size = 0
+        self._load_icon()
+        # Icons get remade every time entries group and ungroup, but
+        # the model sticks around. drop the handlers with the widget or
+        # the model keeps the dead icons alive for the whole session.
+        self._model_handlers = [
+            self._model.connect('notify::name', self.__model_notify_cb),
+            self._model.connect('notify::color', self.__model_notify_cb),
+            self._model.connect('notify::bundle', self.__bundle_notify_cb),
+            self._model.connect('buddy-added', self.__buddy_added_cb),
+        ]
+        self.connect('destroy', self.__destroy_cb)
+        self.palette_invoker.props.toggle_palette = True
+        self.palette_invoker.cache_palette = False
+        self.connect('activate', self.__activate_cb)
+
+    def get_model(self):
+        return self._model
+
+    def __destroy_cb(self, icon):
+        for handler in self._model_handlers:
+            self._model.disconnect(handler)
+        self._model_handlers = []
+
+    def _face(self):
+        """(file_name, icon_name) for the entry: the source activity's
+        own icon if we have it, else one for the mime type, else the
+        Journal's.
+        """
+        bundle = self._model.get_bundle()
+        if bundle is not None:
+            return bundle.get_icon(), None
+        mime_type = self._model.entry_mime
+        if mime_type:
+            name = mime.get_mime_icon(mime_type)
+            if name and Gtk.IconTheme.get_default().has_icon(name):
+                return None, name
+        return None, 'activity-journal'
+
+    def _load_icon(self):
+        # File_name wins over icon_name in the toolkit's buffer, so
+        # clear it when we're using a themed icon. keep the face
+        # around, do_draw wants it on every repaint.
+        self._face_now = self._face()
+        file_name, icon_name = self._face_now
+        if file_name is not None:
+            self.props.file_name = file_name
+        else:
+            self.props.file_name = None
+            self.props.icon_name = icon_name
+
+    def __activate_cb(self, icon):
+        palette = self.get_palette()
+        if palette is not None and palette.is_up():
+            palette.popdown(immediate=True)
+        if peershare.is_ours(self._model.entry_uid):
+            # Our own entry, so go to the real page where the sharing
+            # switch is
+            journal = journalactivity.get_journal()
+            journal.reveal()
+            journal.show_object(self._model.entry_uid)
+            return
+        peerview.open_entry(self._model)
+
+    def _secondary_text(self):
+        owner = self._model.get_owner()
+        nick = owner.get_nick() if owner is not None else ''
+        if nick:
+            # Isolated so a right to left nick can't reorder the
+            # sentence around it
+            # TRANS: %s is the name of the friend the entry came from
+            return _("From %s's Journal") % ('\u2068%s\u2069' % nick)
+        return _('A shared Journal entry')
+
+    def _badge_pixbuf(self):
+        """The Journal mark for the corner, at this icon's size.
+
+        The toolkit's badge code hangs badges off theme attach points,
+        which a bundle's svg doesn't have, so the badge ends up
+        clipped outside the icon. Draw it ourselves instead.
+        """
+        # Keep the mark even when the face is already the Journal icon,
+        # it's the only thing that tells a shared entry from an activity
+        size = max(1, int(self.props.pixel_size * _BADGE_SCALE))
+        if size != self._badge_size:
+            self._badge_size = size
+            theme = Gtk.IconTheme.get_default()
+            try:
+                self._badge = theme.load_icon('activity-journal', size, 0)
+            except GLib.Error:
+                self._badge = None
+        return self._badge
+
+    def do_draw(self, cr):
+        CanvasIcon.do_draw(self, cr)
+        badge = self._badge_pixbuf()
+        if badge is None:
+            return
+        allocation = self.get_allocation()
+        Gdk.cairo_set_source_pixbuf(
+            cr, badge,
+            allocation.width - badge.get_width() - _BADGE_INSET,
+            allocation.height - badge.get_height() - _BADGE_INSET)
+        cr.paint()
+
+    def create_palette(self):
+        file_name, icon_name = self._face()
+        if file_name is not None:
+            palette_icon = Icon(file=file_name,
+                                pixel_size=style.STANDARD_ICON_SIZE,
+                                xo_color=self._model.get_color())
+        else:
+            palette_icon = Icon(icon_name=icon_name,
+                                pixel_size=style.STANDARD_ICON_SIZE,
+                                xo_color=self._model.get_color())
+        palette = Palette(None,
+                          primary_text=self._model.get_name(),
+                          secondary_text=self._secondary_text(),
+                          icon=palette_icon)
+        self.connect_to_palette_pop_events(palette)
+        return palette
+
+    def __model_notify_cb(self, model, pspec):
+        self._update()
+
+    def __bundle_notify_cb(self, model, pspec):
+        # The advert can arrive in pieces, and the source activity is
+        # often only named on a later properties signal
+        self._load_icon()
+        self.queue_draw()
+
+    def __buddy_added_cb(self, model, buddy):
+        palette = self.get_palette()
+        if palette is not None:
+            palette.props.secondary_text = self._secondary_text()
+
+    def _update(self):
+        # The advert can arrive in pieces, and a later signal may bring
+        # the tags that name a better face
+        self._load_icon()
+        self.props.xo_color = self._model.get_color()
+        if self._filtered:
+            self.alpha = _FILTERED_ALPHA
+        else:
+            self.alpha = 1.0
+        palette = self.get_palette()
+        if palette is not None:
+            palette.props.primary_text = self._model.get_name()
+            palette.props.icon.props.xo_color = self._model.get_color()
+
+    def set_filter(self, query):
+        name = normalize_string(self._model.get_name() or '')
+        self._filtered = name.find(query) == -1
+        self._update()
+
+
+class _SharedEntriesGroup(SnowflakeLayout):
+
+    def __init__(self, owner_model, center_icon):
+        SnowflakeLayout.__init__(self)
+        self._owner_model = owner_model
+        self._center = center_icon
+        self._entries = {}
+        self.add_icon(center_icon, center=True)
+        center_icon.show()
+
+    def get_owner_model(self):
+        return self._owner_model
+
+    def do_forall(self, include_internals, callback):
+        # GTK walks the children once more during teardown, after the
+        # Python side has gone, and by then the wrapper we get has no
+        # attributes left. raising here doesn't just fail once. the
+        # traceback machinery keeps the dead wrapper alive, then drops
+        # it, and the drop runs teardown again, and round it goes. any
+        # SnowflakeLayout vfunc that reaches into self._children can
+        # hit this, so guard them all and not only the one we saw fire.
+        for child in list(getattr(self, '_children', {}).keys()):
+            callback(child)
+
+    def do_realize(self):
+        self.set_realized(True)
+        self.set_window(self.get_parent_window())
+        for child in list(getattr(self, '_children', {}).keys()):
+            child.set_parent_window(self.get_parent_window())
+        self.queue_resize()
+
+    def do_size_allocate(self, allocation):
+        if not hasattr(self, '_children'):
+            self.set_allocation(allocation)
+            return
+        SnowflakeLayout.do_size_allocate(self, allocation)
+
+    def _get_radius(self):
+        if not hasattr(self, '_children'):
+            return 0
+        return SnowflakeLayout._get_radius(self)
+
+    def _calculate_size(self):
+        if not hasattr(self, '_children'):
+            return 0
+        return SnowflakeLayout._calculate_size(self)
+
+    def add_entry(self, activity_id, icon):
+        self._entries[activity_id] = icon
+        self.add_icon(icon)
+        icon.show()
+
+    def has_entry(self, activity_id):
+        return activity_id in self._entries
+
+    def remove_entry(self, activity_id):
+        icon = self._entries.pop(activity_id)
+        self.remove(icon)
+        icon.destroy()
+
+    def entry_ids(self):
+        return list(self._entries.keys())
+
+    def is_empty(self):
+        return not self._entries
+
+    def set_filter(self, query):
+        self._center.set_filter(query)
+        for icon in self._entries.values():
+            icon.set_filter(query)
+
+    def get_positioning_data(self):
+        return 'entries-of-%s' % (self._owner_model.props.key or '')
 
 
 class ActivityView(SnowflakeLayout):
@@ -378,6 +628,7 @@ class MeshBox(ViewContainer):
         self._model = neighborhood.get_model()
         self._buddies = {}
         self._activities = {}
+        self._entry_groups = {}
         self._mesh = []
         self._buddy_to_activity = {}
         self._suspended = True
@@ -429,12 +680,17 @@ class MeshBox(ViewContainer):
             icon.set_filter(self._query)
 
         self._buddies[buddy_model.props.key] = icon
+        self._adopt_entries(buddy_model)
 
     def _remove_buddy(self, buddy_model):
         logging.debug('MeshBox._remove_buddy')
-        icon = self._buddies[buddy_model.props.key]
+        key = buddy_model.props.key
+        if key in self._entry_groups:
+            self._dissolve_group(key, keep_buddy=False)
+            return
+        icon = self._buddies[key]
         self.remove(icon)
-        del self._buddies[buddy_model.props.key]
+        del self._buddies[key]
 
     def __buddy_notify_current_activity_cb(self, buddy_model, pspec):
         logging.debug('MeshBox.__buddy_notify_current_activity_cb %s',
@@ -446,6 +702,19 @@ class MeshBox(ViewContainer):
             self._remove_buddy(buddy_model)
 
     def _add_activity(self, activity_model):
+        if activity_model.entry_uid is not None:
+            activity_model.connect('notify::owner',
+                                   self.__entry_owner_notify_cb)
+            icon = _SharedEntryIcon(activity_model)
+            group = self._group_for(activity_model)
+            if group is not None:
+                group.add_entry(activity_model.activity_id, icon)
+            else:
+                self.add(icon)
+                icon.show()
+            icon.set_filter(self._query)
+            self._activities[activity_model.activity_id] = icon
+            return
         icon = ActivityView(activity_model)
         self.add(icon)
         icon.show()
@@ -456,9 +725,90 @@ class MeshBox(ViewContainer):
         self._activities[activity_model.activity_id] = icon
 
     def _remove_activity(self, activity_model):
-        icon = self._activities[activity_model.activity_id]
+        activity_id = activity_model.activity_id
+        icon = self._activities.pop(activity_id)
+        for key, group in list(self._entry_groups.items()):
+            if group.has_entry(activity_id):
+                group.remove_entry(activity_id)
+                if group.is_empty():
+                    self._dissolve_group(key, keep_buddy=True)
+                return
         self.remove(icon)
-        del self._activities[activity_model.activity_id]
+        if isinstance(icon, _SharedEntryIcon):
+            # Its model handlers only come off on destroy
+            icon.destroy()
+
+    def _group_for(self, activity_model):
+        """The snowflake around this entry's owner, made if it isn't
+        there yet. None if the owner has no icon of their own to
+        gather around.
+        """
+        owner = activity_model.get_owner()
+        if owner is None or owner.is_owner():
+            return None
+        key = owner.props.key
+        group = self._entry_groups.get(key)
+        if group is not None:
+            return group
+        if key not in self._buddies:
+            return None
+        old = self._buddies.pop(key)
+        self.remove(old)
+        old.destroy()
+        group = _SharedEntriesGroup(owner, BuddyIcon(owner))
+        self.add(group)
+        group.show()
+        group.set_filter(self._query)
+        self._entry_groups[key] = group
+        self._buddies[key] = group
+        return group
+
+    def _dissolve_group(self, key, keep_buddy):
+        group = self._entry_groups.pop(key)
+        owner_model = group.get_owner_model()
+        leftovers = [(activity_id,
+                      self._activities[activity_id].get_model())
+                     for activity_id in group.entry_ids()
+                     if activity_id in self._activities]
+        self.remove(group)
+        group.destroy()
+        del self._buddies[key]
+        if keep_buddy:
+            icon = BuddyIcon(owner_model)
+            self.add(icon)
+            icon.show()
+            icon.set_filter(self._query)
+            self._buddies[key] = icon
+        for activity_id, model in leftovers:
+            icon = _SharedEntryIcon(model)
+            self.add(icon)
+            icon.show()
+            icon.set_filter(self._query)
+            self._activities[activity_id] = icon
+
+    def _adopt_entries(self, buddy_model):
+        for activity_model in self._model.get_activities():
+            if activity_model.entry_uid is not None and \
+                    activity_model.get_owner() is buddy_model:
+                self.__entry_owner_notify_cb(activity_model, None)
+
+    def __entry_owner_notify_cb(self, activity_model, pspec):
+        activity_id = activity_model.activity_id
+        icon = self._activities.get(activity_id)
+        if icon is None:
+            return
+        if any(group.has_entry(activity_id)
+               for group in self._entry_groups.values()):
+            return
+        group = self._group_for(activity_model)
+        if group is None:
+            return
+        self.remove(icon)
+        icon.destroy()
+        fresh = _SharedEntryIcon(activity_model)
+        group.add_entry(activity_id, fresh)
+        fresh.set_filter(self._query)
+        self._activities[activity_id] = fresh
 
     # add AP to its corresponding network icon on the desktop,
     # creating one if it doesn't already exist

--- a/src/jarabe/frame/friendstray.py
+++ b/src/jarabe/frame/friendstray.py
@@ -82,7 +82,13 @@ class FriendsTray(VTray):
     def __neighborhood_activity_added_cb(self, neighborhood_model,
                                          shared_activity):
         logging.debug('FriendsTray.__neighborhood_activity_added_cb')
+        if shared_activity.entry_uid is not None:
+            # A shared Journal entry isn't a session, so there's
+            # nothing here for the tray to follow.
+            return
         active_activity = shell.get_model().get_active_activity()
+        if active_activity is None:
+            return
         if active_activity.get_activity_id() != shared_activity.activity_id:
             return
 

--- a/src/jarabe/journal/Makefile.am
+++ b/src/jarabe/journal/Makefile.am
@@ -25,6 +25,7 @@ sugar_PYTHON =				\
 	joglyph.py			\
 	momentcard.py			\
 	peershare.py			\
+	peerview.py			\
 	reflectguard.py			\
 	reflection.py			\
 	reflectiontrigger.py		\

--- a/src/jarabe/journal/expandedentry.py
+++ b/src/jarabe/journal/expandedentry.py
@@ -44,6 +44,7 @@ from jarabe.journal.palettes import ObjectPalette, BuddyPalette
 from jarabe.journal import misc
 from jarabe.journal import model
 from jarabe.journal import journalwindow
+from jarabe.journal import reflectguard
 from jarabe.journal import reflection
 from jarabe.journal.momentcard import SNAP_KEY, draw_mark, \
     draw_star, FoldGlyph
@@ -129,6 +130,15 @@ def _ensure_css():
         .journal-when {
             font-family: %(font_clear)s;
             font-size: %(z15)dpx; color: %(ink_soft)s;
+        }
+        .journal-shared-chip {
+            font-family: %(font_clear)s;
+            font-weight: 700; font-size: %(z13)dpx;
+            color: %(stroke)s;
+            background-color: %(card)s;
+            border: %(z2)dpx solid %(stroke)s;
+            border-radius: %(z999)dpx;
+            padding: %(z3)dpx %(z12)dpx;
         }
         .journal-lead-label {
             font-family: %(font_clear)s;
@@ -616,6 +626,10 @@ class _MountFace(Gtk.DrawingArea):
         self.connect('button-release-event',
                      lambda w, e: self.emit('tapped'))
         self.connect('draw', self.__draw_cb)
+
+    def set_corner_color(self, stroke):
+        self._corner = _blend_to_white(stroke, 0.30)
+        self.queue_draw()
 
     def set_pixbuf(self, pixbuf):
         self._pixbuf = pixbuf
@@ -1267,6 +1281,13 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
             'toggled', self._keep_icon_toggled_cb)
         row.pack_start(self._keep_icon, False, False, 0)
 
+        # TRANS: small badge on an entry that is shared with friends
+        self._shared_chip = Gtk.Label(label=_('Friends can look'))
+        self._shared_chip.get_style_context().add_class(
+            'journal-shared-chip')
+        self._shared_chip.set_no_show_all(True)
+        row.pack_start(self._shared_chip, False, False, 0)
+
         self._date = Gtk.Label()
         self._date.get_style_context().add_class('journal-when')
         self._date.set_margin_end(style.zoom(12))
@@ -1365,6 +1386,8 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
         self._keep_icon.set_active(int(metadata.get('keep', 0)) == 1)
         self._keep_icon.handler_unblock(self._keep_sid)
 
+        self._shared_chip.set_visible(metadata.get('shared', '0') == '1')
+
         self._icon = self._create_icon()
         _replace_child(self._icon_box, self._icon)
 
@@ -1373,7 +1396,7 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
         # under the child's cursor.
         if first_look or not self.in_focus:
             self._title.set_text(metadata.get('title', _('Untitled')))
-        self._title.set_editable(model.is_editable(metadata))
+        self._title.set_editable(self._entry_editable())
 
         self._refresh_page()
 
@@ -1382,15 +1405,25 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
         _replace_child(self._buddy_list, self._create_buddy_list(),
                        style.DEFAULT_SPACING)
 
+        self._attach_reflection(metadata)
+
+    def _attach_reflection(self, metadata):
         self._reflection.set_metadata(metadata)
         GLib.idle_add(self._reflection.focus_entry)
+
+    def _none_kept(self):
+        none = Gtk.Label(label=_('nothing kept here yet'))
+        none.get_style_context().add_class('journal-none')
+        return none
+
+    def _entry_editable(self):
+        return model.is_editable(self._metadata)
 
     def _refresh_page(self):
         """Everything below the title that follows the metadata:
         mount, staging, description zones, tags, moments, comments.
         """
-        metadata = self._metadata
-        editable = model.is_editable(metadata)
+        editable = self._entry_editable()
         moments = self._moments()
         if self._staged_seq is not None and \
                 not any(m.get('snap_seq') == self._staged_seq
@@ -1477,9 +1510,9 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
             self._metadata.get('reflections', ''),
             self._metadata.get('description', ''), limit=2)
         if not kepts:
-            none = Gtk.Label(label=_('nothing kept here yet'))
-            none.get_style_context().add_class('journal-none')
-            self._words_face.pack_start(none, False, False, 0)
+            none = self._none_kept()
+            if none is not None:
+                self._words_face.pack_start(none, False, False, 0)
         for position, line in enumerate(kepts):
             quote = Gtk.Label(label='“%s”' % line)
             quote.set_line_wrap(True)
@@ -1694,7 +1727,7 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
             tags.remove(tag)
             self._metadata['tags'] = ' '.join(tags)
             self._write_entry()
-        self._refresh_tags(model.is_editable(self._metadata))
+        self._refresh_tags(self._entry_editable())
 
     def _tag_add_cb(self, button):
         entry = Gtk.Entry()
@@ -1736,7 +1769,7 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
                         self._write_entry()
                     else:
                         already_here = value
-            self._refresh_tags(model.is_editable(self._metadata))
+            self._refresh_tags(self._entry_editable())
             if already_here is not None:
                 sticker = self._tag_stickers.get(already_here)
                 if sticker is not None:
@@ -2012,6 +2045,12 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
 
     def _comments_changed_cb(self, event, comments):
         self._metadata['comments'] = comments
+        # The child may have deleted a comment. Tell the guard so it
+        # stops holding anything no longer on this list, instead of
+        # writing it back in later.
+        uid = self._metadata.get('uid')
+        if uid:
+            reflectguard.get_guard().note_comments_pruned(uid, comments)
         self._write_entry()
 
     def _reflections_changed_cb(self, view, reflections, next_steps):
@@ -2034,7 +2073,7 @@ class ExpandedEntry(Gtk.EventBox, BaseExpandedEntry):
 
     def _update_entry(self, needs_update=False):
         self.in_focus = False
-        if not model.is_editable(self._metadata):
+        if not self._entry_editable():
             return
 
         old_title = self._metadata.get('title', None)

--- a/src/jarabe/journal/expandedentry.py
+++ b/src/jarabe/journal/expandedentry.py
@@ -385,6 +385,11 @@ def _trim_letterbox(pixbuf):
 
         def bar(x, y):
             offset = y * stride + x * channels
+            # Treat a fully transparent margin as letterbox too -
+            # previews saved with alpha pad the short sides with
+            # nothing instead of a solid color.
+            if channels == 4 and pixels[offset + 3] == 0:
+                return True
             return all(abs(pixels[offset + i] - target[i]) <= 8
                        for i in range(3))
 
@@ -411,6 +416,11 @@ def _trim_letterbox(pixbuf):
         while right > width * 2 // 3 and col_is_bar(right - 1):
             right -= 1
         if top == 0 and left == 0 and bottom == height and right == width:
+            return pixbuf
+        if right - left <= 0 or bottom - top <= 0:
+            # Nothing left to frame, so return the pixbuf whole. A
+            # zero-size cut fails below the Python level, past what
+            # the except around this call could catch.
             return pixbuf
         return pixbuf.new_subpixbuf(left, top, right - left, bottom - top)
     except Exception:

--- a/src/jarabe/journal/journaltoolbox.py
+++ b/src/jarabe/journal/journaltoolbox.py
@@ -51,6 +51,7 @@ from jarabe.journal import model
 from jarabe.journal.palettes import CopyMenuBuilder
 from jarabe.journal.palettes import BatchOperator
 from jarabe.journal import journalwindow
+from jarabe.journal import reflectguard
 from jarabe.journal.reflectionview import ReflectionView
 from jarabe.webservice import accountsmanager
 
@@ -601,6 +602,13 @@ class DetailToolbox(ToolbarBox):
         self.toolbar.insert(stretch, -1)
         stretch.show()
 
+        self._share_toggle = ToggleToolButton('zoom-neighborhood')
+        # TRANS: tooltip of the toggle that shares an entry with friends
+        self._share_toggle.set_tooltip(_('Share with the neighborhood'))
+        self._share_toggle.connect('toggled', self.__share_toggled_cb)
+        self.toolbar.insert(self._share_toggle, -1)
+        self._share_toggle.show()
+
         self._rail_toggle = ToggleToolButton('reflectjo')
         self._rail_toggle.set_active(True)
         self._rail_toggle.set_tooltip(_('Show or hide the talk'))
@@ -610,6 +618,38 @@ class DetailToolbox(ToolbarBox):
 
     def __rail_toggled_cb(self, button):
         self.emit('rail-toggled', button.get_active())
+
+    def __share_toggled_cb(self, button):
+        if self._metadata is None:
+            return
+        # Our dict is from when the entry was opened, and the datastore
+        # overwrites every key we hand it, so writing this one back
+        # would roll the entry to how it looked then. re-read first.
+        try:
+            metadata = model.get(self._metadata['uid'])
+        except Exception:
+            logging.exception('could not re-read the entry to share it')
+            button.handler_block_by_func(self.__share_toggled_cb)
+            button.set_active(not button.get_active())
+            button.handler_unblock_by_func(self.__share_toggled_cb)
+            return
+        value = '1' if button.get_active() else '0'
+        metadata['shared'] = value
+        model.write(metadata, update_mtime=False)
+        # An activity that's already running will save back the metadata
+        # it loaded and wipe this flag. the guard puts it back.
+        reflectguard.get_guard().note_shared(metadata['uid'], value)
+
+    def sync_share_toggle(self, metadata):
+        editable = metadata.get('mountpoint', '/') == '/'
+        self._share_toggle.set_sensitive(editable)
+        shared = editable and metadata.get('shared', '0') == '1'
+        if self._share_toggle.get_active() != shared:
+            self._share_toggle.handler_block_by_func(
+                self.__share_toggled_cb)
+            self._share_toggle.set_active(shared)
+            self._share_toggle.handler_unblock_by_func(
+                self.__share_toggled_cb)
 
     def sync_rail_toggle(self, shown):
         if self._rail_toggle.get_active() != shown:
@@ -621,6 +661,7 @@ class DetailToolbox(ToolbarBox):
     def set_metadata(self, metadata):
         self._metadata = metadata
         self.sync_rail_toggle(not ReflectionView.rail_shut())
+        self.sync_share_toggle(metadata)
         self._refresh_copy_palette()
         self._refresh_duplicate_palette()
         self._refresh_refresh_palette()

--- a/src/jarabe/journal/peerview.py
+++ b/src/jarabe/journal/peerview.py
@@ -1,0 +1,763 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""A window onto a friend's shared Journal entry.
+
+Everything shown here arrives over a one-to-one text channel with
+the friend who shared it: the window asks them for the page and
+draws whatever comes back. It never reads the datastore and never
+writes to it, so it behaves the same whether the entry lives on the
+laptop across the table or on this one.
+
+The page is the Journal's own detail page, reused so a shared entry
+looks the way it does on the owner's desk. The writing paths are
+turned into dead ends and the parts that don't travel - the talk
+with Jo, the moments, the star - are hidden. A visitor can leave one
+question, which goes back to the owner and shows up in the entry's
+comments.
+"""
+
+import base64
+import json
+import logging
+import unicodedata
+from functools import partial
+from gettext import gettext as _
+
+import dbus
+from gi.repository import Gdk
+from gi.repository import GLib
+from gi.repository import Gtk
+from gi.repository import Pango
+
+from sugar3 import profile
+from sugar3.graphics import style
+from sugar3.graphics.icon import CanvasIcon
+from sugar3.graphics.icon import Icon
+from sugar3.graphics.toolbutton import ToolButton
+from sugar3.graphics.xocolor import XoColor
+
+from jarabe.journal import misc
+from jarabe.journal import peershare
+from jarabe.journal import reflectguard
+from jarabe.journal import reflectstyle
+from jarabe.journal.expandedentry import ExpandedEntry
+from jarabe.model import neighborhood
+
+_FETCH_SECONDS = 30
+_DEFAULT_COLOR = '#FFFFFF,#000000'
+
+_css_registered = False
+
+_open_views = {}
+
+
+def _ensure_css():
+    global _css_registered
+    if _css_registered:
+        return
+    _css_registered = True
+
+    px = reflectstyle.px
+
+    css = ("""
+        .pv-page { background-color: %(paper)s; }
+        .pv-title {
+            font-family: %(font_hand)s;
+            font-size: %(z28)dpx;
+            color: %(paper)s;
+        }
+        .pv-owner {
+            font-family: %(font_hand)s;
+            font-size: %(z17)dpx;
+            color: %(ink_soft)s;
+        }
+        .pv-status {
+            font-family: %(font_hand)s;
+            font-size: %(z18)dpx;
+            color: %(ink_soft)s;
+        }
+        .pv-card {
+            background-color: %(card)s;
+            border-radius: %(z12)dpx;
+            border: %(z1)dpx solid %(rim)s;
+        }
+        .pv-who {
+            font-family: %(font_clear)s;
+            font-size: %(z13)dpx;
+            color: %(ink_soft)s;
+        }
+        .pv-said {
+            font-family: %(font_clear)s;
+            font-size: %(z17)dpx;
+            color: %(ink)s;
+        }
+        .pv-lead {
+            font-family: %(font_hand)s;
+            font-size: %(z19)dpx;
+            color: %(ink)s;
+        }
+        .pv-entry {
+            font-family: %(font_clear)s;
+            font-size: %(z17)dpx;
+            color: %(ink)s;
+            background-color: %(card)s;
+            border: %(z1)dpx solid %(rim)s;
+            border-radius: %(z999)dpx;
+            padding: %(z8)dpx %(z16)dpx;
+        }
+        .pv-send {
+            font-family: %(font_clear)s;
+            font-size: %(z16)dpx;
+            color: %(ink)s;
+            background-color: %(card)s;
+            border: %(z1)dpx solid %(rim)s;
+            border-radius: %(z999)dpx;
+            padding: %(z8)dpx %(z22)dpx;
+        }
+        .pv-send:active { background-color: %(ember)s; }
+    """) % {
+        'paper': reflectstyle.PAPER_PAGE,
+        'card': reflectstyle.CARD,
+        'rim': reflectstyle.RIM_PAGE,
+        'ink': reflectstyle.INK_PAGE,
+        'ink_soft': reflectstyle.INK_SOFT_PAGE,
+        'ember': reflectstyle.EMBER,
+        'font_hand': reflectstyle.FONT_HAND,
+        'font_clear': reflectstyle.FONT_CLEAR,
+        'z1': px(1), 'z8': px(8), 'z12': px(12),
+        'z13': px(13), 'z16': px(16), 'z17': px(17), 'z18': px(18),
+        'z19': px(19), 'z22': px(22), 'z28': px(28),
+        'z999': px(999),
+    }
+
+    provider = Gtk.CssProvider()
+    provider.load_from_data(css.encode('utf-8'))
+    Gtk.StyleContext.add_provider_for_screen(
+        Gdk.Screen.get_default(), provider,
+        Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+
+
+def _class(widget, name):
+    widget.get_style_context().add_class(name)
+    return widget
+
+
+def _preview_bytes(encoded):
+    """Unwrap the base64 the preview arrived in.
+
+    Only a PNG gets through. The toolkit's preview loader takes
+    anything else for base64 text and decodes it outside its own
+    try, so junk bytes from a peer would blow up halfway through
+    drawing the page.
+    """
+    if not encoded:
+        return None
+    if not isinstance(encoded, str) or \
+            len(encoded) > peershare.PAYLOAD_LIMIT:
+        # A whole page fits under the limit already, so there is no
+        # reason to spend the decode on something bigger.
+        return None
+    try:
+        raw = base64.b64decode(encoded)
+    except Exception:
+        logging.exception('peerview: preview was not base64')
+        return None
+    if not raw.startswith(b'\x89PNG\r\n\x1a\n'):
+        return None
+    return raw
+
+
+def _owner_nick(activity):
+    owner = activity.get_owner()
+    if owner is None:
+        return ''
+    return owner.get_nick() or ''
+
+
+def _clean_text(text, multiline=False):
+    """Take the control and direction-changing characters out of a
+    peer's text before it reaches a label.
+
+    The page draws whatever the wire hands it, and a title or comment
+    carrying a direction override can rearrange the window around it.
+    Newlines survive only in the fields meant to have them.
+    """
+    if not isinstance(text, str):
+        return ''
+    kept = []
+    for ch in text:
+        if multiline and ch == '\n':
+            kept.append(ch)
+        elif unicodedata.category(ch) not in ('Cc', 'Cf', 'Zl', 'Zp'):
+            kept.append(ch)
+    return ''.join(kept)
+
+
+class _BorrowedPage(ExpandedEntry):
+    """A read-only version of the owner's detail page.
+
+    Everything the page can write goes through _write_entry and the
+    editable checks, and both are stubbed out here. The layout is
+    left alone: the parts that don't come over the wire - the talk
+    with Jo, the moments, the star, the date - are just absent, and
+    the visitor's question sits where the talk would have been.
+    """
+
+    def __init__(self, color):
+        ExpandedEntry.__init__(self, None)
+        self._reflection.hide()
+        # The tape takes the owner's colour, same as on their page.
+        self._mount.set_corner_color(color.get_stroke_color())
+
+    def set_ask(self, widget):
+        self._ask_widget = widget
+        self._sidecol.pack_start(widget, False, False, 0)
+        widget.show_all()
+
+    def _refresh_sidecol(self, moments, editable):
+        ExpandedEntry._refresh_sidecol(self, moments, editable)
+        widget = getattr(self, '_ask_widget', None)
+        if widget is not None:
+            self._sidecol.pack_start(widget, False, False, 0)
+            widget.show_all()
+
+    def put_away(self):
+        self._mount.set_corner_color(style.COLOR_INACTIVE_STROKE.get_html())
+
+    def _none_kept(self):
+        # Kept words aren't in the payload, so there is nothing to
+        # say either way.
+        return None
+
+    def _entry_editable(self):
+        return False
+
+    def _write_entry(self):
+        pass
+
+    def set_rail_shown(self, shown):
+        pass
+
+    def _attach_reflection(self, metadata):
+        pass
+
+    def set_metadata(self, metadata):
+        ExpandedEntry.set_metadata(self, metadata)
+        # hide() on its own doesn't hold. The window runs show_all()
+        # over itself once the page is packed, and that walks the
+        # whole tree and shows every child again, including the two
+        # we just hid, so they need no_show_all set as well.
+        for widget in (self._keep_icon, self._date):
+            widget.set_no_show_all(True)
+            widget.hide()
+
+    def _create_icon(self):
+        icon = CanvasIcon(file_name=misc.get_icon_name(self._metadata))
+        icon.props.xo_color = misc.get_icon_color(self._metadata)
+        return icon
+
+    def _create_technical(self):
+        # Size and date come off the owner's disk.
+        return Gtk.VBox()
+
+    def _artwork_pixbuf(self):
+        # Only the preview came over, so there is no file here to
+        # load a pixbuf from.
+        return None
+
+
+class PeerEntryView(Gtk.Window):
+
+    __gtype_name__ = 'SugarPeerEntryView'
+
+    def __init__(self, activity):
+        Gtk.Window.__init__(self)
+        self.set_type_hint(Gdk.WindowTypeHint.DIALOG)
+        self.set_decorated(False)
+        self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
+        self.set_border_width(style.LINE_WIDTH)
+        self.set_has_resize_grip(False)
+        self.set_size_request(
+            Gdk.Screen.width() - style.GRID_CELL_SIZE * 2,
+            Gdk.Screen.height() - style.GRID_CELL_SIZE * 2)
+
+        _ensure_css()
+
+        self._activity = activity
+        self._owner = _owner_nick(activity)
+        owner = activity.get_owner()
+        self._owner_key = owner.props.key if owner is not None else None
+        self._uid = activity.entry_uid
+        self._proxy = None
+        self._match = None
+        self._bus_name = None
+        self._timeout_id = None
+        self._answered = False
+        self._asked = False
+        self._closed = False
+        self._ask_row = None
+
+        self._page = None
+        self._put_away_done = False
+        model = neighborhood.get_model()
+        self._gone_id = model.connect(
+            'activity-removed', self.__activity_removed_cb)
+        # activity-removed fires when the share itself ends. A friend
+        # who drops off the network leaves the activity sitting in the
+        # model, so watch the buddy as well.
+        self._buddy_gone_id = model.connect(
+            'buddy-removed', self.__buddy_removed_cb)
+
+        self.set_title(_clean_text(activity.get_name() or ''))
+        self.connect('key-press-event', self.__key_press_cb)
+        self.connect('destroy', self.__destroy_cb)
+
+        ground = _class(Gtk.EventBox(), 'pv-page')
+        self.add(ground)
+        page = Gtk.VBox()
+        ground.add(page)
+        page.pack_start(self.__build_header(), False, False, 0)
+        page.pack_start(Gtk.HSeparator(), False, False, 0)
+
+        strip = Gtk.VBox()
+        strip.set_spacing(style.zoom(4))
+        strip.set_margin_top(style.zoom(16))
+        strip.set_margin_start(style.zoom(44))
+        page.pack_start(strip, False, False, 0)
+
+        owner_line = _class(Gtk.Label(), 'pv-owner')
+        owner_line.set_xalign(0.0)
+        if self._owner:
+            # Isolate the nick so a right-to-left name can't reorder
+            # the sentence around it.
+            # TRANS: %s is the name of the friend the entry came from
+            owner_line.set_label(_("From %s's Journal")
+                                 % ('\u2068%s\u2069' % self._owner))
+        else:
+            owner_line.set_label(_('A shared Journal entry'))
+        strip.pack_start(owner_line, False, False, 0)
+
+        self._status = _class(
+            Gtk.Label(label=_('Getting the page from your friend…')),
+            'pv-status')
+        self._status.set_xalign(0.0)
+        strip.pack_start(self._status, False, False, 0)
+
+        self._body = Gtk.VBox()
+        page.pack_start(self._body, True, True, 0)
+
+        self.show_all()
+        self._open_line()
+
+    def __build_header(self):
+        bar = Gtk.Toolbar()
+        bar.set_size_request(-1, style.GRID_CELL_SIZE)
+        self._title = _class(
+            Gtk.Label(label=_clean_text(self._activity.get_name() or '')),
+            'pv-title')
+        self._title.set_xalign(0.0)
+        self._title.set_margin_start(style.zoom(24))
+        self._title.set_ellipsize(Pango.EllipsizeMode.END)
+        item = Gtk.ToolItem()
+        item.set_expand(True)
+        item.add(self._title)
+        bar.insert(item, -1)
+        close = ToolButton(icon_name='dialog-cancel')
+        # TRANS: tooltip of the button that closes a friend's page
+        close.set_tooltip(_('Close'))
+        close.connect('clicked', lambda button: self.destroy())
+        bar.insert(close, -1)
+        return bar
+
+    def _open_line(self):
+        neighbors = neighborhood.get_model()
+        conn = neighbors.get_link_local_connection()
+        owner = self._activity.get_owner()
+        if conn is None or owner is None or not self._uid:
+            self._give_up()
+            return
+        self._bus_name = conn[peershare.CONNECTION].bus_name
+        self._timeout_id = GLib.timeout_add_seconds(
+            _FETCH_SECONDS, self.__fetch_timeout_cb)
+        # The neighborhood already knows the friend by handle.
+        handle = neighbors.get_link_local_handle(owner)
+        if handle:
+            self._request_channel(conn, handle)
+            return
+        contact_id = None if owner.is_owner() else owner.props.contact_id
+        if not contact_id:
+            self._give_up()
+            return
+        conn[peershare.CONNECTION].RequestHandles(
+            peershare.HANDLE_TYPE_CONTACT, [contact_id],
+            reply_handler=partial(self.__got_handle_cb, conn),
+            error_handler=partial(self.__wire_error_cb, 'RequestHandles'))
+
+    def __got_handle_cb(self, conn, handles):
+        self._request_channel(conn, handles[0])
+
+    def _request_channel(self, conn, handle):
+        conn[peershare.CONNECTION].RequestChannel(
+            peershare.CHANNEL_TYPE_TEXT, peershare.HANDLE_TYPE_CONTACT,
+            handle, True,
+            reply_handler=self.__got_channel_cb,
+            error_handler=partial(self.__wire_error_cb, 'RequestChannel'))
+
+    def __got_channel_cb(self, channel_path):
+        # The reply can land after the child closed the window.
+        if self._closed:
+            return
+        try:
+            bus = dbus.SessionBus()
+            self._proxy = bus.get_object(self._bus_name, channel_path)
+        except Exception:
+            logging.exception('peerview: could not open the line')
+            self._give_up()
+            return
+        self._match = self._proxy.connect_to_signal(
+            'Received', self.__received_cb,
+            dbus_interface=peershare.CHANNEL_TYPE_TEXT)
+        # An answer that beat the handler is in the pending queue.
+        self._proxy.ListPendingMessages(
+            False, dbus_interface=peershare.CHANNEL_TYPE_TEXT,
+            reply_handler=self.__pending_cb,
+            error_handler=partial(self.__log_error_cb,
+                                  'ListPendingMessages'))
+        self._send({'peershare': peershare.PROTOCOL,
+                    'kind': peershare.KIND_FETCH, 'uid': self._uid},
+                   partial(self.__wire_error_cb, 'Send'))
+
+    def __pending_cb(self, messages):
+        if self._closed:
+            return
+        for message in messages:
+            self.__received_cb(*message)
+
+    def _send(self, message, error_handler, reply_handler=None):
+        if self._proxy is None:
+            return
+        self._proxy.Send(
+            peershare.MESSAGE_TYPE_PROTOCOL, json.dumps(message),
+            dbus_interface=peershare.CHANNEL_TYPE_TEXT,
+            reply_handler=reply_handler or (lambda: None),
+            error_handler=error_handler)
+
+    def __received_cb(self, message_id, timestamp, sender, message_type,
+                      flags, text):
+        if self._closed:
+            return
+        message = peershare.parse_message(text)
+        if message is None or message['kind'] != peershare.KIND_ENTRY:
+            return
+        if self._answered or message.get('uid') != self._uid:
+            # Two pages open on the same friend share this line, so
+            # each one takes only the entry it asked for.
+            return
+        self._answered = True
+        self._acknowledge(message_id)
+        self._cancel_timeout()
+        self._show_entry(message)
+
+    def _acknowledge(self, message_id):
+        if self._proxy is None:
+            return
+        self._proxy.AcknowledgePendingMessages(
+            [message_id], dbus_interface=peershare.CHANNEL_TYPE_TEXT,
+            reply_handler=lambda: None,
+            error_handler=partial(self.__log_error_cb,
+                                  'AcknowledgePendingMessages'))
+
+    def __fetch_timeout_cb(self):
+        self._timeout_id = None
+        self._give_up()
+        return False
+
+    def _cancel_timeout(self):
+        if self._timeout_id is not None:
+            GLib.source_remove(self._timeout_id)
+            self._timeout_id = None
+
+    def _give_up(self):
+        self._cancel_timeout()
+        self._status.set_label(
+            _('Your friend did not answer. You can look again later.'))
+        self._status.show()
+
+    def __wire_error_cb(self, call, error):
+        logging.error('peerview: %s failed: %s', call, error)
+        self._give_up()
+
+    def __log_error_cb(self, call, error):
+        logging.error('peerview: %s failed: %s', call, error)
+
+    def _show_entry(self, payload):
+        if self._put_away_done:
+            # The owner pulled the entry while the page was still on
+            # its way; don't wake it up now.
+            return
+        title = _clean_text(
+            payload.get('title') or self._activity.get_name() or '')
+        title = title or _('Untitled')
+        self.set_title(title)
+        self._title.set_label(title)
+        self._color = self._payload_color(payload)
+        self._status.hide()
+
+        comments = payload.get('comments')
+        if not isinstance(comments, list):
+            comments = []
+        # The cap is applied where the owner writes a comment, but a
+        # hand-made reply can carry as many as it likes and each one
+        # becomes a widget here.
+        comments = [self._clean_comment(comment)
+                    for comment in comments[:reflectguard.MAX_COMMENTS]
+                    if isinstance(comment, dict)]
+
+        bundle = self._activity.get_bundle()
+        metadata = {
+            'uid': peershare.safe_uid(self._uid),
+            'title': title,
+            'description': _clean_text(payload.get('description') or '',
+                                       multiline=True),
+            'tags': peershare.safe_tags(payload.get('tags')),
+            'activity':
+                bundle.get_bundle_id() if bundle is not None else '',
+            'mime_type': peershare.safe_mime(self._activity.entry_mime),
+            'icon-color': self._color.to_string(),
+            'comments': json.dumps(comments),
+        }
+        preview = _preview_bytes(payload.get('preview'))
+        if preview is not None:
+            metadata['preview'] = preview
+
+        borrowed = _BorrowedPage(self._color)
+        borrowed.set_metadata(metadata)
+        self._body.pack_start(borrowed, True, True, 0)
+        self._body.show_all()
+        borrowed.set_ask(self.__build_ask(comments))
+        self._page = borrowed
+
+    def __activity_removed_cb(self, model, activity):
+        if activity.activity_id != self._activity.activity_id:
+            return
+        self._put_away()
+
+    def __buddy_removed_cb(self, model, buddy):
+        if self._owner_key is None or buddy.props.key != self._owner_key:
+            return
+        self._put_away()
+
+    def _put_away(self):
+        """Handle the share going away.
+
+        The friend can unshare, close the activity or drop off the
+        network, and all three land here. Whatever already arrived
+        stays on screen, since the child may be in the middle of
+        reading it, but the tape loses its colour, the ask box is
+        taken out if it is still up, no further question can be sent
+        and the status line says what happened. If the page never
+        arrived there is nothing to grey out, so only the status line
+        changes.
+        """
+        if self._put_away_done:
+            return
+        self._put_away_done = True
+        self._cancel_timeout()
+        if self._page is None:
+            # TRANS: %s is the name of the friend who owns the entry
+            self._status.set_label(_('%s put this away.') % self._owner
+                                   if self._owner
+                                   else _('This was put away.'))
+            self._status.show()
+            return
+        self._page.put_away()
+        if self._ask_row is not None:
+            self._ask_column.remove(self._ask_row)
+            self._ask_column.remove(self._ask_lead)
+            self._ask_row = None
+        self._asked = True
+        self._ask_status.set_label(
+            # TRANS: %s is the name of the friend who owns the entry
+            _('%s put this away for now. You can look again when '
+              'they share it.') % self._owner if self._owner
+            else _('This was put away for now.'))
+        self._ask_status.show()
+
+    def _clean_comment(self, comment):
+        clean = {'from': _clean_text(str(comment.get('from') or '')),
+                 'message': _clean_text(str(comment.get('message') or ''))}
+        color = comment.get('icon-color')
+        if isinstance(color, str):
+            try:
+                XoColor(color)
+            except Exception:
+                pass
+            else:
+                clean['icon-color'] = color
+        return clean
+
+    def _payload_color(self, payload):
+        try:
+            return XoColor(str(payload.get('color') or _DEFAULT_COLOR))
+        except Exception:
+            return XoColor(_DEFAULT_COLOR)
+
+    def _comment_card(self, comment):
+        card = _class(Gtk.EventBox(), 'pv-card')
+        card.set_halign(Gtk.Align.START)
+        row = Gtk.HBox()
+        row.set_spacing(style.DEFAULT_PADDING)
+        row.set_border_width(style.zoom(9))
+
+        icon = Icon(icon_name='computer-xo',
+                    pixel_size=style.SMALL_ICON_SIZE)
+        icon.props.xo_color = profile.get_color()
+        icon.set_valign(Gtk.Align.START)
+        row.pack_start(icon, False, False, 0)
+
+        column = Gtk.VBox()
+        who = _class(Gtk.Label(
+            label=_clean_text(str(comment.get('from') or ''))), 'pv-who')
+        who.set_xalign(0.0)
+        who.set_ellipsize(Pango.EllipsizeMode.END)
+        who.set_max_width_chars(40)
+        column.pack_start(who, False, False, 0)
+        said = _class(Gtk.Label(
+            label=_clean_text(str(comment.get('message') or ''))),
+            'pv-said')
+        said.set_xalign(0.0)
+        said.set_line_wrap(True)
+        said.set_max_width_chars(40)
+        column.pack_start(said, False, False, 0)
+        row.pack_start(column, True, True, 0)
+
+        card.add(row)
+        return card
+
+    def __build_ask(self, comments):
+        self._ask_column = Gtk.VBox()
+        self._ask_column.set_spacing(style.zoom(8))
+        self._ask_column.set_margin_start(style.zoom(15))
+        self._ask_column.set_margin_end(style.zoom(15))
+        self._ask_column.set_margin_top(style.zoom(14))
+        self._ask_column.set_margin_bottom(style.zoom(18))
+        self._ask_status = _class(Gtk.Label(), 'pv-status')
+        self._ask_status.set_xalign(0.0)
+        self._ask_status.set_no_show_all(True)
+
+        if peershare.has_asked(comments, profile.get_nick_name()):
+            self._asked = True
+            self._ask_status.set_label(_('You already asked here.'))
+            self._ask_column.pack_start(self._ask_status, False, False, 0)
+            self._ask_status.show()
+            return self._ask_column
+
+        self._ask_lead = _class(
+            Gtk.Label(label=_('Ask your friend one question')), 'pv-lead')
+        self._ask_lead.set_xalign(0.0)
+        self._ask_column.pack_start(self._ask_lead, False, False, 0)
+
+        self._ask_row = Gtk.HBox()
+        self._ask_row.set_spacing(style.zoom(10))
+        self._ask_entry = _class(Gtk.Entry(), 'pv-entry')
+        self._ask_entry.set_max_length(peershare.ASK_LIMIT)
+        self._ask_entry.set_has_frame(False)
+        self._ask_entry.set_width_chars(40)
+        self._ask_entry.connect('activate', self.__ask_cb)
+        self._ask_row.pack_start(self._ask_entry, True, True, 0)
+        # TRANS: button that sends the child's question to the friend
+        self._ask_button = _class(Gtk.Button(label=_('Ask')), 'pv-send')
+        self._ask_button.set_relief(Gtk.ReliefStyle.NONE)
+        self._ask_button.connect('clicked', self.__ask_cb)
+        self._ask_row.pack_start(self._ask_button, False, False, 0)
+        self._ask_column.pack_start(self._ask_row, False, False, 0)
+        self._ask_column.pack_start(self._ask_status, False, False, 0)
+        return self._ask_column
+
+    def __ask_cb(self, widget):
+        if self._asked or self._proxy is None:
+            return
+        text = self._ask_entry.get_text().strip()
+        if not text:
+            return
+        self._asked = True
+        self._ask_entry.set_sensitive(False)
+        self._ask_button.set_sensitive(False)
+        self._send({'peershare': peershare.PROTOCOL,
+                    'kind': peershare.KIND_ASK, 'uid': self._uid,
+                    'message': text},
+                   partial(self.__ask_error_cb, text),
+                   partial(self.__asked_cb, text))
+
+    def __asked_cb(self, text):
+        self._ask_column.remove(self._ask_lead)
+        self._ask_column.remove(self._ask_row)
+        self._ask_row = None
+        card = self._comment_card({'from': profile.get_nick_name(),
+                                   'message': text})
+        self._ask_column.pack_start(card, False, False, 0)
+        self._ask_column.reorder_child(card, 0)
+        self._ask_status.set_label(_('Your question is there now.'))
+        self._ask_status.show()
+        card.show_all()
+
+    def __ask_error_cb(self, text, error):
+        logging.error('peerview: could not send the question: %s', error)
+        self._asked = False
+        self._ask_entry.set_sensitive(True)
+        self._ask_button.set_sensitive(True)
+        self._ask_status.set_label(
+            _('Your question did not get through. Try again?'))
+        self._ask_status.show()
+
+    def __key_press_cb(self, window, event):
+        if Gdk.keyval_name(event.keyval) == 'Escape':
+            self.destroy()
+            return True
+        return False
+
+    def __destroy_cb(self, window):
+        self._closed = True
+        self._cancel_timeout()
+        if self._gone_id is not None:
+            neighborhood.get_model().disconnect(self._gone_id)
+            self._gone_id = None
+        if self._buddy_gone_id is not None:
+            neighborhood.get_model().disconnect(self._buddy_gone_id)
+            self._buddy_gone_id = None
+        if self._match is not None:
+            try:
+                self._match.remove()
+            except Exception:
+                logging.exception('peerview: could not drop the listener')
+            self._match = None
+        # The channel belongs to the contact. Chat and any other page
+        # opened on this friend are handed the same one, so drop the
+        # reference and leave it open.
+        self._proxy = None
+
+
+def open_entry(activity):
+    """Open the window for a friend's entry, or raise the open one."""
+    view = _open_views.get(activity.activity_id)
+    if view is not None:
+        view.present()
+        return view
+    view = PeerEntryView(activity)
+    _open_views[activity.activity_id] = view
+    view.connect('destroy',
+                 lambda window: _open_views.pop(activity.activity_id, None))
+    return view

--- a/src/jarabe/journal/reflection.py
+++ b/src/jarabe/journal/reflection.py
@@ -186,10 +186,13 @@ def kept_lines(raw, description, limit=2):
 
 
 def add_turn(session, role, text, peer=False, q=None, local=False,
-             typed=None):
+             offer=False, typed=None):
     """Append a turn to a session and return it. peer marks a Jo turn
     voicing another child's comment, and rides the stored turn so
-    later sessions still read it as a people question. q is the
+    later sessions still read it as a people question. offer marks
+    the shorter mention that only points at a comment - it has no
+    question of its own, so nothing should ever re-present it as one.
+    q is the
     scripted question's stable id, stamped from the text or passed in
     when a composed line stands in for a script slot. local marks a Jo
     turn whose text must never reach the wire, and latches the child's
@@ -203,6 +206,8 @@ def add_turn(session, role, text, peer=False, q=None, local=False,
     turn = {'role': role, 'text': text}
     if peer:
         turn['peer'] = True
+    if offer:
+        turn['offer'] = True
     if role == ROLE_JO:
         if q is None:
             q = _QUESTION_ID.get(text)
@@ -447,6 +452,16 @@ PEER_QUESTION_OPENER = _('%(who)s saw this and asks: “%(question)s”')
 # TRANS: the same line for a comment that carries no name.
 PEER_QUESTION_ANON = _('Someone saw this and asks: “%(question)s”')
 
+# Jo mentions that a comment is waiting but doesn't quote it. The
+# child decides whether to hear it, by pressing a chip. Jo shouldn't
+# butt into a conversation between kids.
+# TRANS: %(who)s is the commenter's name.
+PEER_OFFER_OPENER = _('%(who)s left you a question in the comments.')
+# TRANS: the same mention for a comment that carries no name.
+PEER_OFFER_ANON = _('Someone left you a question in the comments.')
+# TRANS: the chip a child presses to hear the peer's question.
+PEER_OFFER_CHIP = _('What did they ask?')
+
 # A name longer than any real name is not a name; the line it would
 # build could evict the child's whole saved talk.
 PEER_NAME_LIMIT = 40
@@ -587,6 +602,14 @@ def _plain_text(text):
                for ch in text)
 
 
+def _peer_name(comment):
+    who = comment.get('from')
+    who = who.strip() if isinstance(who, str) else ''
+    if len(who) > PEER_NAME_LIMIT or not _plain_text(who):
+        return ''
+    return who
+
+
 def compose_peer_question(comment):
     message = comment.get('message')
     if not isinstance(message, str):
@@ -594,21 +617,43 @@ def compose_peer_question(comment):
     message = message.strip()
     if not turn_acceptable(message) or not _plain_text(message):
         return None
-    who = comment.get('from')
-    who = who.strip() if isinstance(who, str) else ''
-    if len(who) > PEER_NAME_LIMIT or not _plain_text(who):
-        who = ''
+    message = quoted_child_text(message, TURN_TEXT_LIMIT)
+    who = _peer_name(comment)
     if who:
-        return PEER_QUESTION_OPENER % {'who': who, 'question': message}
+        return PEER_QUESTION_OPENER % {
+            'who': quoted_child_text(who, PEER_NAME_LIMIT),
+            'question': message}
     return PEER_QUESTION_ANON % {'question': message}
 
 
-def peer_question(comments_raw, spoken=()):
+def peer_offer(comments_raw, spoken=()):
+    """Find the first unheard comment and return its mention paired
+    with the question it stands for. Voicing the question is what
+    marks the comment spoken, not the mention - the mention only
+    names a person, so if it marked the comment spoken too, two
+    friends' comments (or two anonymous ones) could collide on that
+    one line and bury each other.
+    """
     for comment in parse_comments(comments_raw):
-        text = compose_peer_question(comment)
-        if text is not None and text not in spoken:
-            return text
+        question = compose_peer_question(comment)
+        if question is None or question in spoken:
+            continue
+        who = _peer_name(comment)
+        if who:
+            mention = PEER_OFFER_OPENER % {
+                'who': quoted_child_text(who, PEER_NAME_LIMIT)}
+        else:
+            mention = PEER_OFFER_ANON
+        return mention, question
     return None
+
+
+def peer_question_stands(comments_raw, question):
+    """Whether an offered question still has a comment behind it."""
+    if not question:
+        return False
+    return any(compose_peer_question(comment) == question
+               for comment in parse_comments(comments_raw))
 
 
 def jo_texts(conversation, turns=()):
@@ -1031,9 +1076,14 @@ def hanging_question(data):
     last = turns[-1]
     if last.get('role') != ROLE_JO:
         return None
+    if last.get('offer'):
+        # The mention doesn't carry a question, so don't treat it as
+        # one waiting for an answer.
+        return None
     text = (last.get('text') or '').strip()
-    # A voiced peer question ends on its closing quote.
-    if not text.rstrip('”').endswith(_QUESTION_ENDS):
+    # A voiced peer question ends on its closing quote. The isolating
+    # mark that fences the quoted words sits just inside that quote.
+    if not text.rstrip('”\u2069').endswith(_QUESTION_ENDS):
         return None
     return text
 
@@ -1051,10 +1101,13 @@ _QUESTION_ENDS = ('?', '？', '؟', '\u037e', '\u055e', '\u1367')
 _SENTENCE_MARKS = '.!?。！？؟\u0964\u06d4\u0589\u1362'
 
 
+TURN_TEXT_LIMIT = 140
+
+
 def turn_acceptable(text):
     """Whether a server turn is shaped like Jo: short, one question."""
     text = text.strip()
-    if not text or len(text) > 140 or '\n' in text:
+    if not text or len(text) > TURN_TEXT_LIMIT or '\n' in text:
         return False
     if not text.endswith(_QUESTION_ENDS):
         return False

--- a/src/jarabe/journal/reflectionview.py
+++ b/src/jarabe/journal/reflectionview.py
@@ -607,6 +607,7 @@ class ReflectionView(Gtk.EventBox):
         self._session_over = False
         self._opener_hint = None
         self._now_turn = None
+        self._peer_question = None
         self._turn_rows = []
         self._fold_revealer = None
         self._fold_open = False
@@ -667,12 +668,20 @@ class ReflectionView(Gtk.EventBox):
         self._chips_row.set_max_children_per_line(4)
         self._chips_row.set_column_spacing(style.zoom(10))
         self._chips_row.set_row_spacing(style.zoom(10))
+        self._starter_chips = []
         for chip_text in STARTER_CHIPS:
             chip = Gtk.Button(label=chip_text)
             chip.set_relief(Gtk.ReliefStyle.NONE)
             chip.get_style_context().add_class('reflection-chip')
             chip.connect('clicked', self.__chip_clicked_cb, chip_text)
             self._chips_row.add(chip)
+            self._starter_chips.append(chip.get_parent())
+        self._peer_chip = Gtk.Button(label=reflection.PEER_OFFER_CHIP)
+        self._peer_chip.set_relief(Gtk.ReliefStyle.NONE)
+        self._peer_chip.get_style_context().add_class('reflection-chip')
+        self._peer_chip.connect('clicked', self.__peer_chip_clicked_cb)
+        self._chips_row.add(self._peer_chip)
+        self._peer_chip.get_parent().set_no_show_all(True)
         for child in self._chips_row.get_children():
             child.set_can_focus(False)
         foot.pack_start(self._chips_row, False, False, 0)
@@ -752,6 +761,13 @@ class ReflectionView(Gtk.EventBox):
                 if turns and all(t.get('role') == reflection.ROLE_JO
                                  for t in turns):
                     pending = dict(turns[-1])
+        # The friend's question only lives in memory, behind its chip
+        # - it isn't saved anywhere. It stays good across a reload for
+        # as long as the comment it came from is still there.
+        pending_peer = None
+        if same_entry and reflection.peer_question_stands(
+                metadata.get('comments', ''), self._peer_question):
+            pending_peer = self._peer_question
 
         self._metadata = metadata
         self._known_raw = raw
@@ -762,6 +778,8 @@ class ReflectionView(Gtk.EventBox):
         self._session = None
         self._now_row = None
         self._now_turn = None
+        self._peer_question = None
+        self._set_peer_chip_visible(False)
         # New talk belongs only in the Journal's own store.
         self._editable = metadata.get('mountpoint', '/') == '/'
         self._data = reflection.loads(raw)
@@ -775,7 +793,12 @@ class ReflectionView(Gtk.EventBox):
         self._quiet_label.hide()
         if self._editable:
             self._input_row.show()
+            for wrapper in self._starter_chips:
+                wrapper.show()
             self._chips_row.show()
+            if pending_peer is not None:
+                self._peer_question = pending_peer
+                self._set_peer_chip_visible(True)
         else:
             # Read-only: no input, no chips, Jo asks nothing new. An
             # entry from another mount gets its own line instead -
@@ -826,11 +849,14 @@ class ReflectionView(Gtk.EventBox):
             self._set_input_active(True)
             self._scroll_to_newest()
             return
-        peer = reflection.peer_question(
+        pair = reflection.peer_offer(
             self._metadata.get('comments', ''),
             reflection.jo_texts(self._data))
-        if peer is not None:
-            self._speak(peer, peer=True)
+        if pair is not None:
+            offer, question = pair
+            self._peer_question = question
+            self._speak(offer, peer=True, offer=True)
+            self._set_peer_chip_visible(True)
             return
         used = reflection.used_floor_questions(self._data)
         together = reflection.together_question(self._metadata, used)
@@ -916,10 +942,10 @@ class ReflectionView(Gtk.EventBox):
                 self._session, next_steps)
         self.emit('reflections-changed', raw, next_steps)
 
-    def _speak(self, text, peer=False):
+    def _speak(self, text, peer=False, offer=False):
         self._ensure_session()
         reflection.add_turn(self._session, reflection.ROLE_JO, text,
-                            peer=peer)
+                            peer=peer, offer=offer)
         self._set_now(text)
         self._persist()
         self._set_input_active(True)
@@ -1162,7 +1188,7 @@ class ReflectionView(Gtk.EventBox):
         # The line never closes - words left now rest here for next time.
         self._session_over = True
         self._set_now(over=True)
-        self._chips_row.hide()
+        self._retire_starter_chips()
         self._set_input_active(True)
         self._quiet_label.set_text(SESSION_OVER_LINE)
         self._quiet_label.show()
@@ -1181,7 +1207,7 @@ class ReflectionView(Gtk.EventBox):
         # Nothing left to ask and no server to ask for more.
         self._session_over = True
         self._set_now(over=True)
-        self._chips_row.hide()
+        self._retire_starter_chips()
         self._set_input_active(True)
         self._quiet_label.set_text(QUIET_LINE)
         self._quiet_label.show()
@@ -1207,14 +1233,15 @@ class ReflectionView(Gtk.EventBox):
             reflection.add_turn(
                 self._session, reflection.ROLE_JO,
                 carried.get('text', ''), peer=bool(carried.get('peer')),
-                q=carried.get('q'), local=bool(carried.get('local')))
+                q=carried.get('q'), local=bool(carried.get('local')),
+                offer=bool(carried.get('offer')))
         self._now_turn = None
         reflection.add_turn(self._session, reflection.ROLE_CHILD, text)
         self._set_now()
         self._add_child_row(text)
         self._answers_this_session += 1
         if self._answers_this_session >= CHIPS_HIDE_AFTER:
-            self._chips_row.hide()
+            self._retire_starter_chips()
         self._persist()
         self._request_next_turn()
 
@@ -1229,6 +1256,43 @@ class ReflectionView(Gtk.EventBox):
         self._entry.set_text(text)
         self._entry.grab_focus()
         self._entry.set_position(-1)
+
+    def _set_peer_chip_visible(self, visible):
+        wrapper = self._peer_chip.get_parent()
+        if visible:
+            wrapper.set_no_show_all(False)
+            wrapper.show_all()
+            self._chips_row.show()
+        else:
+            wrapper.hide()
+            wrapper.set_no_show_all(True)
+
+    def _retire_starter_chips(self):
+        """Hide the starter chips. A friend's question waiting behind
+        its own chip isn't a starter, so it stays visible.
+        """
+        for wrapper in self._starter_chips:
+            wrapper.hide()
+        if self._peer_question is None:
+            self._chips_row.hide()
+
+    def __peer_chip_clicked_cb(self, button):
+        question = self._peer_question
+        self._peer_question = None
+        self._set_peer_chip_visible(False)
+        if not any(chip.get_visible() for chip in self._starter_chips):
+            self._chips_row.hide()
+        if question is None:
+            return
+        if self._session_over:
+            # Reopen the session for the friend's question. Left
+            # closed, it would swallow the question and the child's
+            # answer would have nowhere to go.
+            self._session = None
+            self._session_over = False
+            self._answers_this_session = 0
+            self._quiet_label.hide()
+        self._speak(question, peer=True)
 
     def __star_toggled_cb(self, button, text):
         self.emit('keep-toggled', text, button.get_active())

--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -71,6 +71,7 @@ from jarabe.view import gesturehandler
 from jarabe.view import cursortracker
 from jarabe.journal import journalactivity
 from jarabe.journal import reflectiontrigger
+from jarabe.journal import peershare
 from jarabe.model import notifications
 from jarabe.model import filetransfer
 from jarabe.view import launcher
@@ -121,6 +122,7 @@ def setup_journal_cb():
     logging.debug('STARTUP: setup_journal_cb')
     journalactivity.start()
     reflectiontrigger.start()
+    peershare.start()
 
 
 def setup_notification_service_cb():

--- a/tests/journal/test_expandedentry.py
+++ b/tests/journal/test_expandedentry.py
@@ -1,0 +1,93 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import types
+import unittest
+
+# gi is an apt-installed system package, not something `uvx pytest`'s
+# own managed interpreter has -- skip rather than error when it isn't
+# importable.
+try:
+    import gi
+    gi.require_version('Gtk', '3.0')
+    gi.require_version('Gdk', '3.0')
+    gi.require_version('GdkPixbuf', '2.0')
+except (ImportError, ValueError):
+    raise unittest.SkipTest('gi is not available')
+
+# jarabe isn't on sys.path outside a built/installed tree.
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
+
+# expandedentry reaches jarabe.config through the palettes import;
+# it's generated at build time and absent on a bare checkout.
+try:
+    import jarabe.config  # noqa: E402,F401
+except ImportError:
+    _config_stub = types.ModuleType('jarabe.config')
+    _config_stub.prefix = '/usr'
+    _config_stub.data_path = '/usr/share/sugar'
+    _config_stub.version = '0.999'
+    sys.modules['jarabe.config'] = _config_stub
+
+from gi.repository import GdkPixbuf  # noqa: E402
+
+from jarabe.journal.expandedentry import _trim_letterbox  # noqa: E402
+
+
+def _rgba(width, height, fill=0xffffffff):
+    pixbuf = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, True, 8,
+                                  width, height)
+    pixbuf.fill(fill)
+    return pixbuf
+
+
+class TestTrimLetterbox(unittest.TestCase):
+
+    def test_transparent_bars_are_cut_like_grey_ones(self):
+        pixbuf = _rgba(40, 30)
+        # subpixbufs share the parent's memory, so filling them paints
+        # the margins in place
+        pixbuf.new_subpixbuf(0, 0, 40, 6).fill(0x00000000)
+        pixbuf.new_subpixbuf(0, 24, 40, 6).fill(0x00000000)
+        trimmed = _trim_letterbox(pixbuf)
+        self.assertEqual((trimmed.get_width(), trimmed.get_height()),
+                         (40, 18))
+
+    def test_a_blank_too_small_to_frame_stays_whole(self):
+        # the trim never eats past the middle third, so only a
+        # one-pixel blank can collapse to nothing
+        pixbuf = _rgba(1, 1, fill=0x00000000)
+        self.assertIs(_trim_letterbox(pixbuf), pixbuf)
+
+    def test_a_large_blank_keeps_its_middle_third(self):
+        trimmed = _trim_letterbox(_rgba(30, 30, fill=0x00000000))
+        self.assertEqual((trimmed.get_width(), trimmed.get_height()),
+                         (10, 10))
+
+    def test_a_preview_without_bars_is_untouched(self):
+        pixbuf = _rgba(40, 30)
+        trimmed = _trim_letterbox(pixbuf)
+        self.assertEqual((trimmed.get_width(), trimmed.get_height()),
+                         (40, 30))
+
+    def test_none_passes_through(self):
+        self.assertIsNone(_trim_letterbox(None))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/journal/test_peerview.py
+++ b/tests/journal/test_peerview.py
@@ -1,0 +1,313 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import base64
+import logging
+import os
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+# gi is an apt-installed system package, not something `uvx pytest`'s
+# own managed interpreter has -- skip rather than error when it isn't
+# importable.
+try:
+    import gi
+    gi.require_version('Gtk', '3.0')
+    gi.require_version('Gdk', '3.0')
+except (ImportError, ValueError):
+    raise unittest.SkipTest('gi is not available')
+
+# jarabe isn't on sys.path outside a built/installed tree.
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
+
+# peerview.py reaches jarabe.journal.expandedentry -> jarabe.journal.
+# palettes -> jarabe.webservice.accountsmanager -> `from jarabe import
+# config`, which is generated at build time and absent on a bare
+# checkout. Stubbed only when the real thing is missing.
+try:
+    import jarabe.config  # noqa: E402,F401
+except ImportError:
+    _config_stub = types.ModuleType('jarabe.config')
+    _config_stub.prefix = '/usr'
+    _config_stub.data_path = '/usr/share/sugar'
+    _config_stub.version = '0.999'
+    sys.modules['jarabe.config'] = _config_stub
+
+from sugar3.graphics.xocolor import XoColor  # noqa: E402
+
+from jarabe.journal import peerview  # noqa: E402
+from jarabe.journal.peerview import _BorrowedPage  # noqa: E402
+from jarabe.journal.peerview import _clean_text  # noqa: E402
+from jarabe.journal.peerview import _preview_bytes  # noqa: E402
+from jarabe.journal.peerview import PeerEntryView  # noqa: E402
+from jarabe.model import neighborhood  # noqa: E402
+
+_PNG_MAGIC = b'\x89PNG\r\n\x1a\n'
+
+_TINY_PNG = base64.b64decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8A'
+    'AQUBAScY42YAAAAASUVORK5CYII=')
+
+
+class TestCleanText(unittest.TestCase):
+
+    def test_control_and_direction_characters_are_stripped(self):
+        self.assertEqual(_clean_text('a\rb\u202ec'), 'abc')
+        self.assertEqual(_clean_text('a\u2028b'), 'ab')
+
+    def test_newlines_are_dropped_by_default(self):
+        self.assertEqual(_clean_text('a\nb'), 'ab')
+
+    def test_newlines_survive_when_multiline_is_asked_for(self):
+        self.assertEqual(_clean_text('a\nb', multiline=True), 'a\nb')
+
+    def test_a_non_string_becomes_empty(self):
+        self.assertEqual(_clean_text(None), '')
+        self.assertEqual(_clean_text(5), '')
+
+    def test_ordinary_text_is_untouched(self):
+        self.assertEqual(_clean_text('hello there'), 'hello there')
+
+
+class TestPreviewBytes(unittest.TestCase):
+
+    def test_a_valid_image_decodes(self):
+        encoded = base64.b64encode(_TINY_PNG).decode()
+        self.assertEqual(_preview_bytes(encoded), _TINY_PNG)
+
+    def test_nothing_sent_is_nothing_to_show(self):
+        self.assertIsNone(_preview_bytes(None))
+        self.assertIsNone(_preview_bytes(''))
+
+    def test_a_non_string_is_refused(self):
+        self.assertIsNone(_preview_bytes(5))
+        self.assertIsNone(_preview_bytes([1, 2, 3]))
+
+    def test_an_oversized_payload_is_refused(self):
+        # this is valid base64; the size cap is what refuses it here,
+        # so a decode error would be the wrong failure mode
+        oversized = base64.b64encode(
+            b'x' * (peerview.peershare.PAYLOAD_LIMIT + 1)).decode()
+        self.assertIsNone(_preview_bytes(oversized))
+
+    def test_a_payload_at_the_limit_is_accepted(self):
+        limit = peerview.peershare.PAYLOAD_LIMIT
+        raw = _PNG_MAGIC + b'x' * (limit * 3 // 4 - len(_PNG_MAGIC))
+        at_limit = base64.b64encode(raw).decode()
+        self.assertEqual(len(at_limit), limit)
+        self.assertEqual(_preview_bytes(at_limit), raw)
+
+    def test_bytes_that_are_not_a_png_are_refused(self):
+        # the toolkit's loader would try to base64-decode these again
+        self.assertIsNone(_preview_bytes(base64.b64encode(b'AAAAA').decode()))
+
+    def test_text_that_is_not_base64_is_refused(self):
+        with self.assertLogs(level=logging.ERROR):
+            self.assertIsNone(_preview_bytes('not base64 at all!!'))
+
+
+class TestBorrowedPageSubtraction(unittest.TestCase):
+
+    def _page(self):
+        page = _BorrowedPage(XoColor('#FF2B34,#005FE4'))
+        self.addCleanup(page.destroy)
+        return page
+
+    def test_the_page_is_never_editable(self):
+        self.assertFalse(self._page()._entry_editable())
+
+    def test_writing_is_a_dead_end(self):
+        page = self._page()
+        page._write_entry()
+
+    def test_the_technical_line_is_an_empty_box(self):
+        box = self._page()._create_technical()
+        self.assertEqual(box.get_children(), [])
+
+    def test_set_metadata_hides_the_keep_icon_and_the_date(self):
+        page = self._page()
+        page.set_metadata({
+            'uid': 'abc', 'title': 'my rockit', 'description': '',
+            'tags': '', 'activity': '', 'mime_type': '',
+            'icon-color': '#FF2B34,#005FE4', 'comments': '[]'})
+        for widget in (page._keep_icon, page._date):
+            self.assertTrue(widget.get_no_show_all())
+            self.assertFalse(widget.get_visible())
+
+
+class _FakeNeighborhoodModel(object):
+    """A stand-in for neighborhood.get_model() that lets a test fire
+    'activity-removed'/'buddy-removed' by hand."""
+
+    def __init__(self):
+        self._callbacks = {}
+        self._next_id = 0
+        self.disconnected = []
+
+    def connect(self, signal, callback):
+        self._next_id += 1
+        self._callbacks[self._next_id] = (signal, callback)
+        return self._next_id
+
+    def disconnect(self, handler_id):
+        self.disconnected.append(handler_id)
+        self._callbacks.pop(handler_id, None)
+
+    def get_link_local_connection(self):
+        # PeerEntryView's own wire is not what these tests exercise;
+        # a missing connection sends _open_line straight to
+        # _give_up(), so no dbus is ever touched.
+        return None
+
+    def fire(self, signal, *args):
+        for handler_id, (sig, callback) in list(self._callbacks.items()):
+            if sig == signal:
+                callback(self, *args)
+
+
+class _PeerViewTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.model = _FakeNeighborhoodModel()
+        patcher = patch.object(peerview.neighborhood, 'get_model',
+                               lambda: self.model)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _owner(self, key='owner-1', nick='Ana'):
+        owner = Mock()
+        owner.props.key = key
+        owner.get_nick.return_value = nick
+        owner.is_owner.return_value = False
+        return owner
+
+    def _activity(self, activity_id='a1', uid='uid-1', owner=None):
+        activity = neighborhood.ActivityModel(activity_id, 7)
+        activity.entry_uid = uid
+        if owner is not None:
+            activity.add_buddy(owner)
+        return activity
+
+    def _view(self, activity):
+        view = PeerEntryView(activity)
+        self.addCleanup(view.destroy)
+        return view
+
+
+class TestActivityRemovedPutsAway(_PeerViewTestCase):
+
+    def test_a_different_activitys_removal_is_ignored(self):
+        activity = self._activity(owner=self._owner())
+        view = self._view(activity)
+        other = self._activity(activity_id='a2', uid='uid-2')
+
+        self.model.fire('activity-removed', other)
+
+        self.assertFalse(view._put_away_done)
+
+    def test_the_matching_activitys_removal_puts_it_away(self):
+        activity = self._activity(owner=self._owner())
+        view = self._view(activity)
+
+        self.model.fire('activity-removed', activity)
+
+        self.assertTrue(view._put_away_done)
+
+
+class TestBuddyRemovedPutsAway(_PeerViewTestCase):
+
+    def test_a_different_buddy_leaving_is_ignored(self):
+        activity = self._activity(owner=self._owner(key='owner-1'))
+        view = self._view(activity)
+        someone_else = Mock()
+        someone_else.props.key = 'someone-else'
+
+        self.model.fire('buddy-removed', someone_else)
+
+        self.assertFalse(view._put_away_done)
+
+    def test_the_owner_leaving_puts_it_away(self):
+        activity = self._activity(owner=self._owner(key='owner-1'))
+        view = self._view(activity)
+        the_owner = Mock()
+        the_owner.props.key = 'owner-1'
+
+        self.model.fire('buddy-removed', the_owner)
+
+        self.assertTrue(view._put_away_done)
+
+    def test_an_entry_with_no_owner_tolerates_any_buddy_leaving(self):
+        activity = self._activity(owner=None)
+        view = self._view(activity)
+        self.assertIsNone(view._owner_key)
+        somebody = Mock()
+        somebody.props.key = 'anybody'
+
+        self.model.fire('buddy-removed', somebody)
+
+        self.assertFalse(view._put_away_done)
+
+
+class TestPutAwayIsIdempotent(_PeerViewTestCase):
+
+    def test_without_a_page_the_status_update_happens_once(self):
+        activity = self._activity(owner=self._owner())
+        view = self._view(activity)
+        view._cancel_timeout = Mock()
+
+        view._put_away()
+        view._put_away()
+
+        self.assertEqual(view._cancel_timeout.call_count, 1)
+        self.assertTrue(view._put_away_done)
+
+    def test_with_a_page_the_page_is_put_away_only_once(self):
+        activity = self._activity(owner=self._owner())
+        view = self._view(activity)
+        view._page = Mock()
+        view._ask_row = Mock()
+        view._ask_column = Mock()
+        view._ask_lead = Mock()
+        view._ask_status = Mock()
+
+        view._put_away()
+        view._put_away()
+
+        self.assertEqual(view._page.put_away.call_count, 1)
+        # One _put_away call removes both the ask row and its lead;
+        # the guard means that only happens for the first call.
+        self.assertEqual(view._ask_column.remove.call_count, 2)
+        self.assertIsNone(view._ask_row)
+
+
+class TestDestroyDisconnectsBothWatches(_PeerViewTestCase):
+
+    def test_both_handlers_are_let_go_on_destroy(self):
+        activity = self._activity(owner=self._owner())
+        view = PeerEntryView(activity)
+        gone_id = view._gone_id
+        buddy_gone_id = view._buddy_gone_id
+
+        view.destroy()
+
+        self.assertIn(gone_id, self.model.disconnected)
+        self.assertIn(buddy_gone_id, self.model.disconnected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/journal/test_reflection.py
+++ b/tests/journal/test_reflection.py
@@ -1311,6 +1311,15 @@ def _comment(who, message):
             'icon': 'computer-xo', 'icon-color': '#FF2B34,#005FE4'}
 
 
+def _isolated(text):
+    return '⁨%s⁩' % text
+
+
+def _question(raw, spoken=()):
+    pair = reflection.peer_offer(raw, spoken=spoken)
+    return None if pair is None else pair[1]
+
+
 class TestPeerQuestions(unittest.TestCase):
 
     # --- peer questions: the comments box reaches the talk ---
@@ -1318,42 +1327,43 @@ class TestPeerQuestions(unittest.TestCase):
     def test_peer_question_voices_a_question_shaped_comment(self):
         raw = json.dumps(
             [_comment('Ana', 'How did you make the roof stay up?')])
-        text = reflection.peer_question(raw)
+        text = _question(raw)
         self.assertEqual(text, reflection.PEER_QUESTION_OPENER % {
-            'who': 'Ana', 'question': 'How did you make the roof stay up?'})
+            'who': _isolated('Ana'),
+            'question': _isolated('How did you make the roof stay up?')})
 
     def test_peer_question_skips_judgements_for_the_next_question(self):
         raw = json.dumps([_comment('Ana', 'this is bad'),
                           _comment('Ben', 'What does the red button do?')])
-        text = reflection.peer_question(raw)
+        text = _question(raw)
         self.assertIn('What does the red button do?', text)
         self.assertNotIn('bad', text)
 
     def test_peer_question_is_voiced_once(self):
         raw = json.dumps([_comment('Ana', 'What is it made of?')])
-        first = reflection.peer_question(raw)
+        first = _question(raw)
         self.assertIsNotNone(first)
-        self.assertIsNone(reflection.peer_question(raw, spoken={first}))
+        self.assertIsNone(_question(raw, spoken={first}))
 
     def test_peer_question_moves_to_the_next_unvoiced_comment(self):
         raw = json.dumps([_comment('Ana', 'What is it made of?'),
                           _comment('Ben', 'Why is it green?')])
-        first = reflection.peer_question(raw)
-        second = reflection.peer_question(raw, spoken={first})
+        first = _question(raw)
+        second = _question(raw, spoken={first})
         self.assertIn('Why is it green?', second)
 
     def test_peer_question_anonymous_without_from(self):
         raw = json.dumps([{'message': 'Why is it green?'}])
-        text = reflection.peer_question(raw)
+        text = _question(raw)
         self.assertEqual(text, reflection.PEER_QUESTION_ANON % {
-            'question': 'Why is it green?'})
+            'question': _isolated('Why is it green?')})
 
     def test_peer_question_tolerates_garbage(self):
-        self.assertIsNone(reflection.peer_question(''))
-        self.assertIsNone(reflection.peer_question('not json'))
-        self.assertIsNone(reflection.peer_question('{"a": 1}'))
-        self.assertIsNone(reflection.peer_question(json.dumps(['x', 3])))
-        self.assertIsNone(reflection.peer_question(
+        self.assertIsNone(_question(''))
+        self.assertIsNone(_question('not json'))
+        self.assertIsNone(_question('{"a": 1}'))
+        self.assertIsNone(_question(json.dumps(['x', 3])))
+        self.assertIsNone(_question(
             json.dumps([{'from': 'Ana'}])))
 
     def test_peer_turns_and_their_answers_stay_off_the_wire(self):
@@ -1392,35 +1402,118 @@ class TestPeerQuestions(unittest.TestCase):
         self.assertEqual(texts, {'old line', 'new line'})
 
     def test_peer_question_tolerates_wrong_typed_values(self):
-        self.assertIsNone(reflection.peer_question(
+        self.assertIsNone(_question(
             json.dumps([{'from': 'Ana', 'message': 5}])))
-        self.assertIsNone(reflection.peer_question(
+        self.assertIsNone(_question(
             json.dumps([{'from': 'Ana', 'message': {'x': 1}}])))
-        text = reflection.peer_question(
+        text = _question(
             json.dumps([{'from': 7, 'message': 'What is it?'}]))
         self.assertEqual(text, reflection.PEER_QUESTION_ANON % {
-            'question': 'What is it?'})
+            'question': _isolated('What is it?')})
+
+    def test_peer_offer_pairs_the_mention_with_the_question(self):
+        offer, question = reflection.peer_offer(
+            json.dumps([{'from': 'Ana', 'message': 'How does it fly?'}]))
+        self.assertEqual(offer, reflection.PEER_OFFER_OPENER % {
+            'who': _isolated('Ana')})
+        self.assertEqual(question, reflection.PEER_QUESTION_OPENER % {
+            'who': _isolated('Ana'),
+            'question': _isolated('How does it fly?')})
+        self.assertNotIn('How does it fly?', offer)
+
+    def test_peer_offer_mentions_anonymously_without_a_name(self):
+        offer, question = reflection.peer_offer(
+            json.dumps([{'from': 'A' * 200, 'message': 'What is it?'}]))
+        self.assertEqual(offer, reflection.PEER_OFFER_ANON)
+        self.assertNotIn('A' * 200, question)
+
+    def test_peer_offer_retires_on_the_voiced_question(self):
+        raw = json.dumps([{'from': 'Ana', 'message': 'What is it?'}])
+        _offer, question = reflection.peer_offer(raw)
+        self.assertIsNone(reflection.peer_offer(raw, spoken={question}))
+
+    def test_peer_offer_outlives_its_own_mention(self):
+        raw = json.dumps([{'from': 'Ana', 'message': 'What is it?'}])
+        offer, question = reflection.peer_offer(raw)
+        again = reflection.peer_offer(raw, spoken={offer})
+        self.assertEqual(again, (offer, question))
+
+    def test_peer_offer_reaches_a_second_comment_from_one_friend(self):
+        raw = json.dumps([_comment('Ana', 'What is it made of?'),
+                          _comment('Ana', 'Why is it green?')])
+        first, question = reflection.peer_offer(raw)
+        second = reflection.peer_offer(raw, spoken={first, question})
+        self.assertIsNotNone(second)
+        self.assertIn('Why is it green?', second[1])
+
+    def test_peer_offer_reaches_a_second_anonymous_comment(self):
+        raw = json.dumps([{'message': 'What is it made of?'},
+                          {'message': 'Why is it green?'}])
+        first, question = reflection.peer_offer(raw)
+        self.assertEqual(first, reflection.PEER_OFFER_ANON)
+        second = reflection.peer_offer(raw, spoken={first, question})
+        self.assertIsNotNone(second)
+        self.assertIn('Why is it green?', second[1])
+
+    def test_peer_offer_skips_junk_comments(self):
+        self.assertIsNone(reflection.peer_offer(
+            json.dumps([{'from': 'Ana', 'message': 'nice'}])))
+        self.assertIsNone(reflection.peer_offer('not json'))
+
+    def test_peer_offer_line_never_hangs(self):
+        offer, _question = reflection.peer_offer(
+            json.dumps([{'from': 'Ana', 'message': 'What is it?'}]))
+        data = reflection.empty_conversation()
+        session = reflection.new_session('creative')
+        reflection.add_turn(session, reflection.ROLE_JO, offer, peer=True,
+                            offer=True)
+        data['sessions'].append(session)
+        self.assertIsNone(reflection.hanging_question(data))
+
+    def test_peer_offer_never_hangs_when_it_reads_as_a_question(self):
+        data = reflection.empty_conversation()
+        session = reflection.new_session('creative')
+        reflection.add_turn(session, reflection.ROLE_JO,
+                            'Ana left you a question. Want to hear it?',
+                            peer=True, offer=True)
+        data['sessions'].append(session)
+        self.assertIsNone(reflection.hanging_question(data))
+
+    def test_peer_lines_isolate_the_name_and_the_words(self):
+        raw = json.dumps([_comment('שרה', 'How does it fly?')])
+        question = _question(raw)
+        self.assertIn('⁨שרה⁩', question)
+        self.assertIn('⁨How does it fly?⁩', question)
+        offer, _ = reflection.peer_offer(raw)
+        self.assertIn('⁨שרה⁩', offer)
+
+    def test_peer_question_stands_only_while_its_comment_does(self):
+        raw = json.dumps([_comment('Ana', 'What is it made of?')])
+        _offer, question = reflection.peer_offer(raw)
+        self.assertTrue(reflection.peer_question_stands(raw, question))
+        self.assertFalse(reflection.peer_question_stands('[]', question))
+        self.assertFalse(reflection.peer_question_stands(raw, None))
 
     def test_peer_question_drops_an_unwearable_name(self):
         long_name = 'A' * 200
-        text = reflection.peer_question(
+        text = _question(
             json.dumps([{'from': long_name, 'message': 'What is it?'}]))
         self.assertEqual(text, reflection.PEER_QUESTION_ANON % {
-            'question': 'What is it?'})
+            'question': _isolated('What is it?')})
         self.assertNotIn(long_name, text)
-        sneaky = reflection.peer_question(
+        sneaky = _question(
             json.dumps([{'from': 'Ana\nBen', 'message': 'What is it?'}]))
         self.assertEqual(sneaky, reflection.PEER_QUESTION_ANON % {
-            'question': 'What is it?'})
+            'question': _isolated('What is it?')})
 
     def test_peer_question_rejects_control_and_format_characters(self):
-        self.assertIsNone(reflection.peer_question(
+        self.assertIsNone(_question(
             json.dumps([{'from': 'Ana',
                          'message': 'line one\rline two?'}])))
-        self.assertIsNone(reflection.peer_question(
+        self.assertIsNone(_question(
             json.dumps([{'from': 'Ana',
                          'message': '‮evil?'}])))
-        self.assertIsNone(reflection.peer_question(
+        self.assertIsNone(_question(
             json.dumps([{'from': 'Ana',
                          'message': 'one two?'}])))
 
@@ -1453,8 +1546,10 @@ class TestConversationSync(unittest.TestCase):
         self.assertIsNone(reflection.hanging_question(data))
 
     def test_hanging_question_catches_a_voiced_peer_question(self):
-        voiced = reflection.PEER_QUESTION_OPENER % {
-            'who': 'Ana', 'question': 'How did you make the rockit fly?'}
+        # use the real producer so the text carries its isolating marks;
+        # a hand-built copy would not have them
+        voiced = _question(json.dumps(
+            [_comment('Ana', 'How did you make the rockit fly?')]))
         data = reflection.empty_conversation()
         session = reflection.new_session('creative')
         reflection.add_turn(session, reflection.ROLE_JO, voiced, peer=True)

--- a/tests/test_meshbox.py
+++ b/tests/test_meshbox.py
@@ -1,0 +1,445 @@
+# Copyright (C) 2026, Sugar Labs (Shubham Sharma)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import Mock
+
+# gi is an apt-installed system package, not something `uvx pytest`'s
+# own managed interpreter has -- skip rather than error when it isn't
+# importable.
+try:
+    import gi
+    gi.require_version('Gtk', '3.0')
+    gi.require_version('Gdk', '3.0')
+except (ImportError, ValueError):
+    raise unittest.SkipTest('gi is not available')
+
+# jarabe isn't on sys.path outside a built/installed tree.
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# jarabe.desktop.meshbox drags in three things this host does not
+# have: jarabe.config is generated at build time; xapian is not apt
+# installed here; jarabe.view.viewsource hard-pins GtkSource 3.0 and
+# the host only carries 4 on the girepository path. None of the three
+# is needed to exercise the widget logic under test, so each is
+# stubbed only when the real thing is missing.
+try:
+    import jarabe.config  # noqa: E402,F401
+except ImportError:
+    _config_stub = types.ModuleType('jarabe.config')
+    _config_stub.prefix = '/usr'
+    _config_stub.data_path = '/usr/share/sugar'
+    _config_stub.version = '0.999'
+    sys.modules['jarabe.config'] = _config_stub
+
+try:
+    import xapian  # noqa: E402,F401
+except ImportError:
+    sys.modules['xapian'] = types.ModuleType('xapian')
+
+try:
+    import jarabe.view.viewsource  # noqa: E402,F401
+except (ImportError, ValueError):
+    _viewsource_stub = types.ModuleType('jarabe.view.viewsource')
+    _viewsource_stub.setup_view_source = lambda activity: None
+    sys.modules['jarabe.view.viewsource'] = _viewsource_stub
+
+# meshbox <-> buddyicon <-> buddymenu <-> homewindow <-> meshbox is a
+# real circular import; homewindow imports MeshBox itself, so priming
+# sys.modules with it first lets meshbox finish initializing before
+# buddymenu asks for the (still loading) name a second time.
+import jarabe.desktop.homewindow  # noqa: E402,F401
+
+from gi.repository import Gdk  # noqa: E402
+from gi.repository import Gtk  # noqa: E402
+
+from jarabe.desktop.meshbox import MeshBox  # noqa: E402
+from jarabe.desktop.meshbox import _SharedEntriesGroup  # noqa: E402
+from jarabe.desktop.meshbox import _SharedEntryIcon  # noqa: E402
+from jarabe.model import neighborhood  # noqa: E402
+from jarabe.view.buddyicon import BuddyIcon  # noqa: E402
+
+
+class _Owner(object):
+    class props:
+        key = 'owner-1'
+
+
+class _FilterableBox(Gtk.EventBox):
+    """A center widget with the set_filter() method the group expects
+    on every child, including the center."""
+
+    def set_filter(self, query):
+        pass
+
+
+def _rect(width=50, height=50):
+    rect = Gdk.Rectangle()
+    rect.x = 0
+    rect.y = 0
+    rect.width = width
+    rect.height = height
+    return rect
+
+
+def _owner_buddy(key='owner-1', nick='Ana', handle=9):
+    return neighborhood.BuddyModel(nick=nick, key=key, account='/salut',
+                                   contact_id='%s@laptop' % nick.lower(),
+                                   handle=handle)
+
+
+class _SelfOwnedBuddyModel(neighborhood.BuddyModel):
+    """A BuddyModel whose is_owner() answers True, the way the real
+    OwnerBuddyModel does -- BuddyModel itself always answers False, so
+    exercising the is_owner() branch of _group_for needs this override.
+    """
+
+    def is_owner(self):
+        return True
+
+
+def _shared_activity(activity_id, uid, owner):
+    activity = neighborhood.ActivityModel(activity_id, 7)
+    activity.entry_uid = uid
+    activity.add_buddy(owner)
+    return activity
+
+
+class _FakeBox(object):
+    """Stands in for MeshBox itself when driving _group_for,
+    _dissolve_group and _adopt_entries.
+
+    MeshBox is a real Gtk.Container, but only _SharedEntriesGroup
+    got the 585c1a47 hardening -- MeshBox's own do_forall is still
+    unguarded. A bare MeshBox built for a test hits GTK's container
+    dispose path once its last Python reference drops, and runs into
+    the same unguarded `self._children` access the teardown-guard
+    tests below check for -- except on MeshBox nothing catches it.
+
+    Running the three grouping methods as unbound functions against
+    this plain double avoids that GTK lifecycle. That's fine here:
+    the methods are just dict bookkeeping over
+    _buddies/_activities/_entry_groups, and the widgets they build
+    (_SharedEntriesGroup, BuddyIcon, _SharedEntryIcon) are real and
+    guarded on their own.
+    """
+
+    # These are plain methods, no GTK vfunc dispatch involved, so the
+    # real unbound implementations work fine against this duck-typed
+    # self -- including _adopt_entries' call to the name-mangled
+    # self.__entry_owner_notify_cb, aliased under its mangled name.
+    _group_for = MeshBox._group_for
+    _dissolve_group = MeshBox._dissolve_group
+    _adopt_entries = MeshBox._adopt_entries
+    _MeshBox__entry_owner_notify_cb = MeshBox._MeshBox__entry_owner_notify_cb
+
+    def __init__(self):
+        self._buddies = {}
+        self._activities = {}
+        self._entry_groups = {}
+        self._query = ''
+        self._model = Mock()
+        self._children = []
+
+    def add(self, widget):
+        self._children.append(widget)
+
+    def remove(self, widget):
+        if widget in self._children:
+            self._children.remove(widget)
+
+
+class _WidgetTestCase(unittest.TestCase):
+    """Destroys every real GTK widget it builds before the test
+    method returns, instead of leaving it for the garbage collector.
+    GC timing isn't deterministic, and for the one container here
+    that isn't hardened (see _FakeBox) that can reproduce the exact
+    crash these tests are guarding against.
+    """
+
+    def _make_group(self):
+        group = _SharedEntriesGroup(_Owner(), _FilterableBox())
+        entry = Gtk.EventBox()
+        group.add_entry('activity-1', entry)
+        self.addCleanup(group.destroy)
+        return group, entry
+
+    def _offscreen_window(self):
+        window = Gtk.OffscreenWindow()
+        self.addCleanup(window.destroy)
+        return window
+
+
+# GTK walks a container's children once more while it is torn down,
+# after the Python wrapper has lost its own attributes; every vfunc
+# that reaches into self._children shares that risk (meshbox.py,
+# comment above do_forall). These regression-test the exact trigger:
+# a group with `_children` gone still answers every guarded vfunc.
+
+class TestSharedEntriesGroupTeardownGuard(_WidgetTestCase):
+
+    def test_do_forall_on_a_torn_down_group_visits_nothing(self):
+        group, _entry = self._make_group()
+        del group._children
+        seen = []
+        group.do_forall(True, seen.append)
+        self.assertEqual(seen, [])
+
+    def test_do_size_allocate_on_a_torn_down_group_does_not_crash(self):
+        group, _entry = self._make_group()
+        del group._children
+        group.do_size_allocate(_rect())
+
+    def test_get_radius_on_a_torn_down_group_is_zero(self):
+        group, _entry = self._make_group()
+        del group._children
+        self.assertEqual(group._get_radius(), 0)
+
+    def test_calculate_size_on_a_torn_down_group_is_zero(self):
+        group, _entry = self._make_group()
+        del group._children
+        self.assertEqual(group._calculate_size(), 0)
+
+    def test_do_realize_on_a_torn_down_group_does_not_crash(self):
+        # do_realize needs a real parent window before the guarded
+        # loop is even reached, so this parents the group for real
+        # first and only then removes _children underneath it.
+        window = self._offscreen_window()
+        group, _entry = self._make_group()
+        window.add(group)
+        window.show_all()
+        del group._children
+        group.do_realize()
+
+
+class TestSharedEntriesGroupNormalBehavior(_WidgetTestCase):
+
+    def test_do_forall_visits_the_center_and_every_entry(self):
+        group, entry = self._make_group()
+        seen = []
+        group.do_forall(True, seen.append)
+        self.assertEqual(set(seen), {group._center, entry})
+
+    def test_size_allocate_and_size_queries_do_not_crash(self):
+        window = self._offscreen_window()
+        group, _entry = self._make_group()
+        window.add(group)
+        window.show_all()
+        group.do_size_allocate(_rect())
+        self.assertGreater(group._get_radius(), 0)
+        self.assertGreater(group._calculate_size(), 0)
+
+    def test_has_entry_and_entry_ids_track_what_was_added(self):
+        group, _entry = self._make_group()
+        self.assertTrue(group.has_entry('activity-1'))
+        self.assertEqual(group.entry_ids(), ['activity-1'])
+        self.assertFalse(group.is_empty())
+
+    def test_remove_entry_leaves_the_group_empty(self):
+        group, _entry = self._make_group()
+        group.remove_entry('activity-1')
+        self.assertFalse(group.has_entry('activity-1'))
+        self.assertTrue(group.is_empty())
+
+    def test_positioning_data_is_keyed_on_the_owner(self):
+        group, _entry = self._make_group()
+        self.assertEqual(group.get_positioning_data(),
+                         'entries-of-owner-1')
+
+
+class TestGroupFor(unittest.TestCase):
+
+    def test_the_owners_standalone_icon_is_replaced_by_a_group(self):
+        box = _FakeBox()
+        owner = _owner_buddy()
+        standalone = BuddyIcon(owner)
+        box._buddies[owner.props.key] = standalone
+        box.add(standalone)
+        activity = _shared_activity('a1', 'uid-1', owner)
+
+        group = box._group_for(activity)
+
+        self.assertIsInstance(group, _SharedEntriesGroup)
+        self.assertIs(box._buddies[owner.props.key], group)
+        self.assertIs(box._entry_groups[owner.props.key], group)
+
+    def test_a_second_call_for_the_same_owner_reuses_the_group(self):
+        box = _FakeBox()
+        owner = _owner_buddy()
+        standalone = BuddyIcon(owner)
+        box._buddies[owner.props.key] = standalone
+        box.add(standalone)
+        activity = _shared_activity('a1', 'uid-1', owner)
+
+        first = box._group_for(activity)
+        second = box._group_for(activity)
+        self.assertIs(first, second)
+
+    def test_no_standalone_icon_means_no_group_yet(self):
+        box = _FakeBox()
+        owner = _owner_buddy()
+        activity = _shared_activity('a1', 'uid-1', owner)
+        self.assertIsNone(box._group_for(activity))
+
+    def test_the_owner_of_their_own_entry_never_groups(self):
+        box = _FakeBox()
+        # The owner already has a standalone icon in _buddies, same as
+        # any other buddy would -- so the only thing standing between
+        # this activity and a fresh group is the is_owner() check
+        # itself, not the `key not in self._buddies` guard below it.
+        owner = _SelfOwnedBuddyModel(nick='Ana', key='owner-self',
+                                     account='/salut',
+                                     contact_id='ana@laptop', handle=9)
+        standalone = BuddyIcon(owner)
+        box._buddies[owner.props.key] = standalone
+        box.add(standalone)
+        activity = _shared_activity('a1', 'uid-1', owner)
+
+        self.assertIsNone(box._group_for(activity))
+
+        self.assertIs(box._buddies[owner.props.key], standalone)
+        self.assertNotIn(owner.props.key, box._entry_groups)
+
+    def test_an_ownerless_entry_never_groups(self):
+        box = _FakeBox()
+        activity = neighborhood.ActivityModel('a1', 7)
+        activity.entry_uid = 'uid-1'
+        self.assertIsNone(box._group_for(activity))
+
+
+class TestDissolveGroup(unittest.TestCase):
+
+    def test_dissolving_keeps_the_buddy_as_a_plain_icon(self):
+        box = _FakeBox()
+        owner = _owner_buddy()
+        standalone = BuddyIcon(owner)
+        box._buddies[owner.props.key] = standalone
+        box.add(standalone)
+        activity = _shared_activity('a1', 'uid-1', owner)
+        group = box._group_for(activity)
+        entry_icon = _SharedEntryIcon(activity)
+        group.add_entry(activity.activity_id, entry_icon)
+        box._activities[activity.activity_id] = entry_icon
+
+        box._dissolve_group(owner.props.key, keep_buddy=True)
+
+        self.assertNotIn(owner.props.key, box._entry_groups)
+        self.assertIsInstance(box._buddies[owner.props.key], BuddyIcon)
+        self.assertIn(activity.activity_id, box._activities)
+        self.assertIsNot(box._activities[activity.activity_id], entry_icon)
+
+    def test_dissolving_without_keeping_drops_the_buddy_entirely(self):
+        box = _FakeBox()
+        owner = _owner_buddy()
+        standalone = BuddyIcon(owner)
+        box._buddies[owner.props.key] = standalone
+        box.add(standalone)
+        activity = _shared_activity('a1', 'uid-1', owner)
+        box._group_for(activity)
+
+        box._dissolve_group(owner.props.key, keep_buddy=False)
+
+        self.assertNotIn(owner.props.key, box._buddies)
+        self.assertNotIn(owner.props.key, box._entry_groups)
+
+    def test_entries_left_in_the_group_scatter_as_standalone_icons(self):
+        box = _FakeBox()
+        owner = _owner_buddy()
+        standalone = BuddyIcon(owner)
+        box._buddies[owner.props.key] = standalone
+        box.add(standalone)
+        activity = _shared_activity('a1', 'uid-1', owner)
+        group = box._group_for(activity)
+        entry_icon = _SharedEntryIcon(activity)
+        group.add_entry(activity.activity_id, entry_icon)
+        box._activities[activity.activity_id] = entry_icon
+
+        box._dissolve_group(owner.props.key, keep_buddy=False)
+
+        self.assertIsInstance(
+            box._activities[activity.activity_id], _SharedEntryIcon)
+
+
+class TestAdoptEntries(unittest.TestCase):
+
+    def test_a_standalone_entry_is_gathered_once_its_owner_gets_an_icon(
+            self):
+        box = _FakeBox()
+        owner = _owner_buddy()
+        standalone = BuddyIcon(owner)
+        box._buddies[owner.props.key] = standalone
+        box.add(standalone)
+        activity = _shared_activity('a3', 'uid-3', owner)
+        icon = _SharedEntryIcon(activity)
+        box.add(icon)
+        box._activities[activity.activity_id] = icon
+        box._model.get_activities.return_value = [activity]
+
+        box._adopt_entries(owner)
+
+        self.assertIn(owner.props.key, box._entry_groups)
+        self.assertIsInstance(
+            box._activities[activity.activity_id], _SharedEntryIcon)
+        self.assertIsNot(box._activities[activity.activity_id], icon)
+
+    def test_entries_owned_by_somebody_else_are_left_alone(self):
+        box = _FakeBox()
+        owner = _owner_buddy(key='owner-1')
+        other = _owner_buddy(key='owner-2', nick='Bo', handle=11)
+        standalone = BuddyIcon(owner)
+        box._buddies[owner.props.key] = standalone
+        box.add(standalone)
+        # `other` also has a standalone icon, so a group is just as
+        # reachable for their entry as for the owner's -- if the
+        # entry_uid/owner filter in _adopt_entries let it through,
+        # _group_for would happily gather it too.
+        other_standalone = BuddyIcon(other)
+        box._buddies[other.props.key] = other_standalone
+        box.add(other_standalone)
+        # A group for `owner` already exists, seeded by an unrelated
+        # entry, so `mine` below is adopted into an existing group
+        # rather than a freshly-created one.
+        seed = _shared_activity('a0', 'uid-0', owner)
+        group = box._group_for(seed)
+
+        mine = _shared_activity('a4', 'uid-4', owner)
+        icon_mine = _SharedEntryIcon(mine)
+        box.add(icon_mine)
+        box._activities[mine.activity_id] = icon_mine
+
+        theirs = _shared_activity('a5', 'uid-5', other)
+        icon_theirs = _SharedEntryIcon(theirs)
+        box.add(icon_theirs)
+        box._activities[theirs.activity_id] = icon_theirs
+
+        box._model.get_activities.return_value = [mine, theirs]
+
+        box._adopt_entries(owner)
+
+        self.assertTrue(group.has_entry(mine.activity_id))
+        self.assertIsNot(box._activities[mine.activity_id], icon_mine)
+
+        self.assertFalse(group.has_entry(theirs.activity_id))
+        self.assertIs(box._activities[theirs.activity_id], icon_theirs)
+        self.assertNotIn(other.props.key, box._entry_groups)
+        self.assertIs(box._buddies[other.props.key], other_standalone)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
UI half of peer sharing. 
Share toggle and a "Friends can look" badge on the entry page. A friend gets a read only copy of the page with one ask box. Jo tells the child a friend asked something and shows the words on tap. Shared entries sit around their owner's XO in the Neighborhood with the Journal badge.

Builds on #1124.

- Visitor page subclasses ExpandedEntry, writes are no-ops. Talk, moments and star don't travel so they aren't there.
- Preview must be a PNG under the size cap.
- Asker colors come from the owner's presence record, not the wire.
- Journal badge on every shared entry icon, also the ones already showing the Journal face (Walter's suggestion).
- First commit is a small preview trim fix, alpha padding was counting as content.
- Translators: 21 msgids in, none out. One more CssProvider.
- Uses the same hand font as the rail, falls back to system cursive if it's missing.

## Tests
- test_peerview.py (24)
- tests/test_meshbox.py (20)
- test_expandedentry.py (5)
- 11 new in test_reflection.py.

- VM Test: fetch with preview, ask lands on the owner, chip then question on tap, unshare and reshare.

New file in Makefile.am and POTFILES.in. Series notes in #1111.